### PR TITLE
Add support for IDisposable

### DIFF
--- a/ksqlDb.RestApi.Client/KSql/Query/Context/IKSqlDBContext.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/IKSqlDBContext.cs
@@ -10,7 +10,7 @@ using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
 
 namespace ksqlDB.RestApi.Client.KSql.Query.Context
 {
-  public interface IKSqlDBContext : IKSqlDBStatementsContext, IAsyncDisposable
+  public interface IKSqlDBContext : IKSqlDBStatementsContext, IAsyncDisposable, IDisposable
   {
 #if !NETSTANDARD
     IQbservable<TEntity> CreateQueryStream<TEntity>(string fromItemName = null);
@@ -19,7 +19,7 @@ namespace ksqlDB.RestApi.Client.KSql.Query.Context
 
     IQbservable<TEntity> CreateQuery<TEntity>(string fromItemName = null);
     IAsyncEnumerable<TEntity> CreateQuery<TEntity>(QueryParameters queryParameters, CancellationToken cancellationToken = default);
-    
+
     IPullable<TEntity> CreatePullQuery<TEntity>(string tableName = null);
     ValueTask<TEntity> ExecutePullQuery<TEntity>(string ksql, CancellationToken cancellationToken = default);
 

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContext.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContext.cs
@@ -234,7 +234,7 @@ public class KSqlDBContext : KSqlDBContextDependenciesProvider, IKSqlDBContext
       await base.OnDisposeAsync();
 #endif
     if (KSqlDBQueryContext != null)
-      await KSqlDBQueryContext.DisposeAsync();
+      await KSqlDBQueryContext.DisposeAsync().ConfigureAwait(false);
     Dispose(false);
   }
 

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContext.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContext.cs
@@ -46,9 +46,9 @@ public class KSqlDBContext : KSqlDBContextDependenciesProvider, IKSqlDBContext
     protected override void OnConfigureServices(IServiceCollection serviceCollection, KSqlDBContextOptions contextOptions)
     {
       base.OnConfigureServices(serviceCollection, contextOptions);
-          
+
       serviceCollection.TryAddScoped<IKSqlDbProvider, KSqlDbQueryStreamProvider>();
-          
+
       serviceCollection.TryAddSingleton<IKSqlDbParameters>(contextOptions.QueryStreamParameters);
     }
 
@@ -72,7 +72,7 @@ public class KSqlDBContext : KSqlDBContextDependenciesProvider, IKSqlDBContext
       {
         FromItemName = fromItemName
       };
-      
+
       return new KQueryStreamSet<TEntity>(serviceScopeFactory, queryStreamContext);
     }
 
@@ -235,5 +235,14 @@ public class KSqlDBContext : KSqlDBContextDependenciesProvider, IKSqlDBContext
 #endif
     if (KSqlDBQueryContext != null)
       await KSqlDBQueryContext.DisposeAsync();
+    Dispose(false);
+  }
+
+  protected override void Dispose(bool disposing)
+  {
+    if (!disposing) return;
+
+    (KSqlDBQueryContext as IDisposable)?.Dispose();
+    base.Dispose(true);
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContextDependenciesProvider.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContextDependenciesProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using ksqlDB.RestApi.Client.Infrastructure.Extensions;
 using ksqlDb.RestApi.Client.Infrastructure.Logging;
@@ -10,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace ksqlDB.RestApi.Client.KSql.Query.Context
 {
-  public abstract class KSqlDBContextDependenciesProvider : AsyncDisposableObject
+  public abstract class KSqlDBContextDependenciesProvider : AsyncDisposableObject, IDisposable
   {
     private readonly KSqlDBContextOptions kSqlDbContextOptions;
     private readonly ILoggerFactory loggerFactory;
@@ -24,7 +23,7 @@ namespace ksqlDB.RestApi.Client.KSql.Query.Context
     protected IServiceCollection ServiceCollection => kSqlDbContextOptions.ServiceCollection;
 
     protected ServiceProvider ServiceProvider { get; private set; }
-    
+
     private bool wasConfigured;
 
     internal IServiceScopeFactory Initialize(KSqlDBContextOptions contextOptions)
@@ -73,6 +72,21 @@ namespace ksqlDB.RestApi.Client.KSql.Query.Context
     {
       if(ServiceProvider != null)
         await ServiceProvider.DisposeAsync();
+      Dispose(false);
+    }
+
+    public void Dispose()
+    {
+      Dispose(true);
+      GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+      if (!disposing) return;
+
+      ServiceProvider?.Dispose();
+      ServiceProvider = null;
     }
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContextDependenciesProvider.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContextDependenciesProvider.cs
@@ -71,7 +71,7 @@ namespace ksqlDB.RestApi.Client.KSql.Query.Context
     protected override async ValueTask OnDisposeAsync()
     {
       if(ServiceProvider != null)
-        await ServiceProvider.DisposeAsync();
+        await ServiceProvider.DisposeAsync().ConfigureAwait(false);
       Dispose(false);
     }
 


### PR DESCRIPTION
Disposing of the `KSqlDBContext` throws an `InvalidOperationException` when the service provider is being disposed since the current context implementation is async only. Following the pattern established by [Microsoft](https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync#implement-both-dispose-and-async-dispose-patterns).