### PR TITLE
RowValueJsonSerializer single value deserialization fix

### DIFF
--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/RowValueJsonSerializerTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/RowValueJsonSerializerTests.cs
@@ -178,15 +178,15 @@ public class RowValueJsonSerializerTests : TestBase
 
   private enum MyEnum
   {
-    None = 0
+    None = 0,
+    All = 1
   }
 
   [TestMethod]
-  [Ignore]
   public void Deserialize_Enum()
   {
     //Arrange
-    var value = (int)MyEnum.None;
+    var value = (int)MyEnum.All;
 
     string rawJson = $"[{value}]";
     var jsonSerializationOptions = KSqlDbJsonSerializerOptions.CreateInstance();
@@ -195,7 +195,7 @@ public class RowValueJsonSerializerTests : TestBase
     var rowValue = ClassUnderTest.Deserialize<MyEnum>(rawJson, jsonSerializationOptions);
 
     //Assert
-    rowValue.Value.Should().Be(MyEnum.None);
+    rowValue.Value.Should().Be(MyEnum.All);
   }
 
   [TestMethod]
@@ -220,6 +220,7 @@ public class RowValueJsonSerializerTests : TestBase
     //Assert
     rowValue.Value.Should().Be(guid);
   }
+
   class Foo : Dictionary<string, int>
   {
   }
@@ -243,5 +244,51 @@ public class RowValueJsonSerializerTests : TestBase
 
     //Assert
     rowValue.Value["A"].Should().Be(2);
+  }
+
+  [TestMethod]
+  public void Deserialize_RecordAsByteArray()
+  {
+    //Arrange
+    var queryStreamHeader = new QueryStreamHeader()
+    {
+      ColumnTypes = new[] { "BYTES" },
+      ColumnNames = new[] { "MESSAGE" },
+    };
+
+    ClassUnderTest = new RowValueJsonSerializer(queryStreamHeader);
+
+    string rawJson = "[\"e30=\"]";
+    var jsonSerializationOptions = KSqlDbJsonSerializerOptions.CreateInstance();
+
+    //Act
+    var rowValue = ClassUnderTest.Deserialize<byte[]>(rawJson, jsonSerializationOptions);
+
+    //Assert
+    rowValue.Value.Should().BeOfType<byte[]>();
+    rowValue.Value[0].Should().Be(0x7b);
+    rowValue.Value[1].Should().Be(0x7d);
+  }
+
+  [TestMethod]
+  public void Deserialize_RecordAsInt()
+  {
+    //Arrange
+    var queryStreamHeader = new QueryStreamHeader()
+    {
+      ColumnTypes = new[] { "INT" },
+      ColumnNames = new[] { "MESSAGE" },
+    };
+
+    ClassUnderTest = new RowValueJsonSerializer(queryStreamHeader);
+
+    string rawJson = "[1]";
+    var jsonSerializationOptions = KSqlDbJsonSerializerOptions.CreateInstance();
+
+    //Act
+    var rowValue = ClassUnderTest.Deserialize<int>(rawJson, jsonSerializationOptions);
+
+    //Assert
+    rowValue.Value.Should().Be(1);
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/RowValueJsonSerializer.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/RowValueJsonSerializer.cs
@@ -9,10 +9,18 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi;
 internal class RowValueJsonSerializer
 {
   private readonly QueryStreamHeader queryStreamHeader;
+  private readonly bool isSingleAnonymousColumn;
+  private readonly bool isMapColumn;
 
   internal RowValueJsonSerializer(QueryStreamHeader queryStreamHeader)
   {
     this.queryStreamHeader = queryStreamHeader ?? throw new ArgumentNullException(nameof(queryStreamHeader));
+
+    if (queryStreamHeader.ColumnTypes.Length == 1)
+    {
+      isSingleAnonymousColumn = Regex.Matches(queryStreamHeader.ColumnNames[0], anonymousColumnRegex).Count > 0;
+      isMapColumn = Regex.Matches(queryStreamHeader.ColumnTypes[0], structRegex).Count > 0;
+    }
   }
 
   private readonly string anonymousColumnRegex = "^KSQL_COL_\\d+";
@@ -24,10 +32,10 @@ internal class RowValueJsonSerializer
 
     if (queryStreamHeader.ColumnTypes.Length == 1 && !typeof(T).IsAnonymousType())
     {
-      bool isSingleColumn = Regex.Matches(queryStreamHeader.ColumnNames[0], anonymousColumnRegex).Count > 0;
-      bool isMapColumn = Regex.Matches(queryStreamHeader.ColumnTypes[0], structRegex).Count > 0;
+      var type = typeof(T);
+      var isAllowedType = type.IsPrimitive || type.IsArray || type.IsEnum;
 
-      if (isSingleColumn || isMapColumn)
+      if (isSingleAnonymousColumn || isMapColumn || isAllowedType)
         return new RowValue<T>(JsonSerializer.Deserialize<T>(result, jsonSerializerOptions));
     }
 

--- a/ksqlDb.RestApi.Client/KSql/RestApi/RowValueJsonSerializer.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/RowValueJsonSerializer.cs
@@ -16,6 +16,9 @@ internal class RowValueJsonSerializer
   {
     this.queryStreamHeader = queryStreamHeader ?? throw new ArgumentNullException(nameof(queryStreamHeader));
 
+    if (this.queryStreamHeader.ColumnNames.Length != queryStreamHeader.ColumnTypes.Length)
+      throw new InvalidOperationException("Length of the column names differs from column types");
+
     if (queryStreamHeader.ColumnTypes.Length == 1)
     {
       isSingleAnonymousColumn = Regex.Matches(queryStreamHeader.ColumnNames[0], anonymousColumnRegex).Count > 0;


### PR DESCRIPTION
`RowValueJsonSerializer` single value deserialization fix for arrays and primitive types. 
Fixes #35 

Possible usage:
```C#
var ksql =
  "SELECT ARRAY[1, 2] as MESSAGE FROM Movies EMIT CHANGES LIMIT 2;";

QueryStreamParameters queryParameters = new QueryStreamParameters
{
  Sql = ksql,
  [QueryParameters.AutoOffsetResetPropertyName] = "earliest",
};

await using var context2 = new KSqlDBContext(@"http:\\localhost:8088");

using var disposable = context.CreateQueryStream<int[]>(queryParameters)
  .ToObservable()
  .Subscribe(onNext: message =>
    {
      Console.WriteLine($"Message: {message}");
    }, onError: error => { Console.WriteLine($"Exception: {error.Message}"); },
    onCompleted: () => Console.WriteLine("Completed"));
```