### PR TITLE
KSqlDbContext's create stream and create stream query influence each other

### DIFF
--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/QbservableExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/QbservableExtensionsTests.cs
@@ -640,4 +640,81 @@ WHERE MESSAGE = 'ET' EMIT CHANGES;");
     Assert.AreEqual(expectedItemsCount, actualValues.Count);
     actualValues[0].Year.Should().Be(year);
   }
+
+  [TestMethod]
+  public async Task SelectAsInt()
+  {
+    //Arrange
+    int expectedItemsCount = 1;
+
+    var ksql =
+      $"SELECT 42 FROM {StreamName} EMIT CHANGES LIMIT 1;";
+
+    QueryStreamParameters queryStreamParameters = new QueryStreamParameters
+    {
+      Sql = ksql,
+      [QueryParameters.AutoOffsetResetPropertyName] = "earliest",
+    };
+
+    var source = Context.CreateQueryStream<int>(queryStreamParameters);
+
+    //Act
+    var actualValues = await CollectActualValues(source, expectedItemsCount);
+
+    //Assert
+    actualValues[0].Should().Be(42);
+  }
+
+  [TestMethod]
+  public async Task SelectAsArray()
+  {
+    //Arrange
+    int expectedItemsCount = 1;
+
+    var ksql =
+      $"SELECT ARRAY[1, 2] FROM {StreamName} EMIT CHANGES LIMIT 1;";
+
+    QueryStreamParameters queryStreamParameters = new QueryStreamParameters
+    {
+      Sql = ksql,
+      [QueryParameters.AutoOffsetResetPropertyName] = "earliest",
+    };
+
+    var source = Context.CreateQueryStream<int[]>(queryStreamParameters);
+
+    //Act
+    var actualValues = await CollectActualValues(source, expectedItemsCount);
+
+    //Assert
+    CollectionAssert.AreEqual(new[]{1,2}, actualValues[0]);
+  }
+
+  private record MyStruct
+  {
+    public string Name { get; set; }
+  }
+
+  [TestMethod]
+  public async Task SelectAsStruct()
+  {
+    //Arrange
+    int expectedItemsCount = 1;
+
+    var ksql =
+      $"SELECT STRUCT(NAME := 'E.T.') FROM {StreamName} EMIT CHANGES LIMIT 1;";
+
+    QueryStreamParameters queryStreamParameters = new QueryStreamParameters
+    {
+      Sql = ksql,
+      [QueryParameters.AutoOffsetResetPropertyName] = "earliest",
+    };
+
+    var source = Context.CreateQueryStream<MyStruct>(queryStreamParameters);
+
+    //Act
+    var actualValues = await CollectActualValues(source, expectedItemsCount);
+
+    //Assert
+    actualValues[0].Name.Should().Be("E.T.");
+  }
 }

--- a/Tests/ksqlDB.RestApi.Client.Tests/DependencyInjection/KSqlDbServiceCollectionExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/DependencyInjection/KSqlDbServiceCollectionExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using ksqlDB.Api.Client.Tests.Helpers;
 using ksqlDb.RestApi.Client.DependencyInjection;
 using ksqlDB.RestApi.Client.Infrastructure.Extensions;
@@ -75,7 +75,7 @@ public class KSqlDbServiceCollectionExtensionsTests : TestBase
 
     //Assert
     context.Should().NotBeNull();
-    context.ContextOptions.QueryStreamParameters[KSqlDbConfigs.ProcessingGuarantee].ToProcessingGuarantee().Should().Be(ProcessingGuarantee.AtLeastOnce);
+    context?.ContextOptions.QueryStreamParameters[KSqlDbConfigs.ProcessingGuarantee].ToProcessingGuarantee().Should().Be(ProcessingGuarantee.AtLeastOnce);
   }
 
   [TestMethod]

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/RowValueJsonSerializerTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/RowValueJsonSerializerTests.cs
@@ -55,7 +55,7 @@ public class RowValueJsonSerializerTests : TestBase
   }
 
   [TestMethod]
-  public void Deserialize_String()
+  public void Deserialize_RecordAsString()
   {
     //Arrange
     var queryStreamHeader = new QueryStreamHeader()
@@ -77,7 +77,7 @@ public class RowValueJsonSerializerTests : TestBase
   }
 
   [TestMethod]
-  public void Deserialize_DateTimeOffsetStruct()
+  public void Deserialize_RecordAsDateTimeOffsetStruct()
   {
     //Arrange
     var queryStreamHeader = new QueryStreamHeader()
@@ -102,7 +102,7 @@ public class RowValueJsonSerializerTests : TestBase
   }
 
   [TestMethod]
-  public void Deserialize_Dictionary()
+  public void Deserialize_RecordAsDictionary()
   {
     //Arrange
     var queryStreamHeader = new QueryStreamHeader()
@@ -126,7 +126,7 @@ public class RowValueJsonSerializerTests : TestBase
   }
 
   [TestMethod]
-  public void Deserialize_PrimitiveInt()
+  public void Deserialize_RecordAsPrimitiveInt()
   {
     //Arrange
     var queryStreamHeader = new QueryStreamHeader()
@@ -155,7 +155,7 @@ public class RowValueJsonSerializerTests : TestBase
   }
 
   [TestMethod]
-  public void Deserialize_MyStruct()
+  public void Deserialize_RecordAsRecord()
   {
     //Arrange
     var queryStreamHeader = new QueryStreamHeader()
@@ -185,7 +185,7 @@ public class RowValueJsonSerializerTests : TestBase
   }
 
   [TestMethod]
-  public void Deserialize_Class()
+  public void Deserialize_RecordAsClass()
   {
     //Arrange
     var queryStreamHeader = new QueryStreamHeader()
@@ -213,7 +213,7 @@ public class RowValueJsonSerializerTests : TestBase
   }
 
   [TestMethod]
-  public void Deserialize_Enum()
+  public void Deserialize_RecordAsEnum()
   {
     //Arrange
     var value = (int)MyEnum.All;
@@ -229,7 +229,7 @@ public class RowValueJsonSerializerTests : TestBase
   }
 
   [TestMethod]
-  public void Deserialize_Guid()
+  public void Deserialize_RecordAsGuid()
   {
     //Arrange
     var queryStreamHeader = new QueryStreamHeader()
@@ -256,7 +256,7 @@ public class RowValueJsonSerializerTests : TestBase
   }
 
   [TestMethod]
-  public void Deserialize_DictionaryBase()
+  public void Deserialize_RecordAsDictionaryBase()
   {
     //Arrange
     var queryStreamHeader = new QueryStreamHeader()

--- a/ksqlDb.RestApi.Client/DependencyInjection/KSqlDbServiceCollectionExtensions.cs
+++ b/ksqlDb.RestApi.Client/DependencyInjection/KSqlDbServiceCollectionExtensions.cs
@@ -103,7 +103,7 @@ public static class KSqlDbServiceCollectionExtensions
 
     contextOptions.ServiceCollection.Add(restApiServiceDescriptor);
 
-    contextOptions.Apply(services);
+    contextOptions.ServiceCollection.ApplyTo(services);
 
     return services;
   }

--- a/ksqlDb.RestApi.Client/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/ksqlDb.RestApi.Client/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using ksqlDB.RestApi.Client.KSql.Linq;
+using ksqlDB.RestApi.Client.KSql.Linq;
 using ksqlDB.RestApi.Client.KSql.Linq.Statements;
 using ksqlDB.RestApi.Client.KSql.Query;
 using ksqlDB.RestApi.Client.KSql.Query.Context;
@@ -80,5 +80,13 @@ internal static class ServiceCollectionExtensions
     serviceCollection.TryAddSingleton(contextOptions);
     serviceCollection.TryAddScoped<IKStreamSetDependencies, KStreamSetDependencies>();
     serviceCollection.TryAddScoped<IKSqlDbRestApiClient, KSqlDbRestApiClient>();
+  }
+
+  internal static void ApplyTo(this IServiceCollection externalServicesCollection, IServiceCollection servicesCollection)
+  {
+    foreach (var service in externalServicesCollection)
+    {
+      servicesCollection.Add(service);
+    }
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContextDependenciesProvider.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContextDependenciesProvider.cs
@@ -1,4 +1,4 @@
-﻿using ksqlDB.RestApi.Client.Infrastructure.Extensions;
+using ksqlDB.RestApi.Client.Infrastructure.Extensions;
 using ksqlDb.RestApi.Client.Infrastructure.Logging;
 using ksqlDB.RestApi.Client.KSql.Disposables;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,16 +9,18 @@ namespace ksqlDB.RestApi.Client.KSql.Query.Context;
 
 public abstract class KSqlDBContextDependenciesProvider : AsyncDisposableObject, IDisposable
 {
-  private readonly KSqlDBContextOptions kSqlDbContextOptions;
   private readonly ILoggerFactory loggerFactory;
 
   protected KSqlDBContextDependenciesProvider(KSqlDBContextOptions kSqlDbContextOptions, ILoggerFactory loggerFactory = null)
   {
-    this.kSqlDbContextOptions = kSqlDbContextOptions ?? throw new ArgumentNullException(nameof(kSqlDbContextOptions));
+    if (kSqlDbContextOptions == null) throw new ArgumentNullException(nameof(kSqlDbContextOptions));
     this.loggerFactory = loggerFactory;
+
+    ServiceCollection = new ServiceCollection();
+    ServiceCollection = kSqlDbContextOptions.ServiceCollection;
   }
 
-  protected IServiceCollection ServiceCollection => kSqlDbContextOptions.ServiceCollection;
+  internal IServiceCollection ServiceCollection { get; }
 
   protected ServiceProvider ServiceProvider { get; private set; }
 

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContextOptions.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContextOptions.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Text.Json;
 using ksqlDB.RestApi.Client.KSql.Config;
 using ksqlDb.RestApi.Client.KSql.Query.Context.Options;
@@ -97,13 +97,5 @@ public sealed class KSqlDBContextOptions : KSqlDbProviderOptions
   {
     this.userName = userName;
     this.password = password;
-  }
-
-  internal void Apply(IServiceCollection externalServicesCollection)
-  {
-    foreach (var service in ServiceCollection)
-    {
-      externalServicesCollection.Add(service);
-    }
   }
 }


### PR DESCRIPTION
Fixes: KSqlDbContext's CreateStream and CreateStreamQuery influence each others services collection during consecutive usages. #37