### PR TITLE
Feature/support for passing session variables

### DIFF
--- a/Samples/ksqlDB.RestApi.Client.Sample/Program.cs
+++ b/Samples/ksqlDB.RestApi.Client.Sample/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Concurrency;
@@ -926,6 +926,16 @@ Drop type Address;
     //Act
     httpResponseMessage = await restApiClient.CreateTypeAsync<Address>();
     httpResponseMessage = await restApiClient.CreateTypeAsync<Person>();
+  }
+
+  private static async Task CreateTypeWithSessionVariableAsync(IKSqlDbRestApiClient restApiClient)
+  {
+    var statement = new KSqlDbStatement("CREATE TYPE ${typeName} AS STRUCT<name VARCHAR, address ADDRESS>;")
+    {
+      SessionVariables = { { "typeName", "FromSessionValue" } }
+    };
+
+    var httpResponseMessage = await restApiClient.ExecuteStatementAsync(statement);
   }
 
   private static async Task SubscriptionToAComplexTypeAsync(IKSqlDbRestApiClient restApiClient, IKSqlDBContext ksqlDbContext)

--- a/Samples/ksqlDB.RestApi.Client.Sample/Program.cs
+++ b/Samples/ksqlDB.RestApi.Client.Sample/Program.cs
@@ -932,7 +932,8 @@ Drop type Address;
   {
     var statement = new KSqlDbStatement("CREATE TYPE ${typeName} AS STRUCT<name VARCHAR, address ADDRESS>;")
     {
-      SessionVariables = { { "typeName", "FromSessionValue" } }
+      //TODO: release package
+      //SessionVariables = { { "typeName", "FromSessionValue" } }
     };
 
     var httpResponseMessage = await restApiClient.ExecuteStatementAsync(statement);

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/RestApi/KSqlDbRestApiClientTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/RestApi/KSqlDbRestApiClientTests.cs
@@ -527,7 +527,7 @@ Drop type Address;
 
     var statement = new KSqlDbStatement("CREATE TYPE ${typeName} AS STRUCT<name VARCHAR, address ADDRESS>;")
     {
-      SessionVariables = { { "typeName", typeName } }
+      SessionVariables = new Dictionary<string, object> { { "typeName", typeName } }
     };
 
     //Act

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/RestApi/KSqlDbRestApiClientTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/RestApi/KSqlDbRestApiClientTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Reactive.Concurrency;
 using System.Text.Json;
 using FluentAssertions;
@@ -515,6 +515,28 @@ Drop type Address;
 
     //Assert
     httpResponseMessage.IsSuccessStatusCode.Should().BeTrue();
+    content[0].CommandStatus?.Status.Should().BeOneOf(default(string), SuccessStatus);
+  }
+
+  [TestMethod]
+  public async Task SessionVariables()
+  {
+    //Arrange
+    string typeName = "FromSessionVar";
+    var _ = await restApiClient.DropTypeAsync(typeName);
+
+    var statement = new KSqlDbStatement("CREATE TYPE ${typeName} AS STRUCT<name VARCHAR, address ADDRESS>;")
+    {
+      SessionVariables = { { "typeName", typeName } }
+    };
+
+    //Act
+    var httpResponseMessage = await restApiClient.ExecuteStatementAsync(statement);
+
+    //Assert
+    httpResponseMessage.IsSuccessStatusCode.Should().BeTrue();
+
+    var content = await httpResponseMessage.ToStatementResponsesAsync();
     content[0].CommandStatus?.Status.Should().BeOneOf(default(string), SuccessStatus);
   }
 }

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/KSqlDbStatementTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/KSqlDbStatementTests.cs
@@ -54,10 +54,13 @@ public class KSqlDbStatementTests : TestBase
   public void SessionVariables()
   {
     //Arrange
-    var ksqlDbStatement = new KSqlDbStatement(Statement);
-
-    ksqlDbStatement.SessionVariables.Add("key1", "value1");
-    ksqlDbStatement.SessionVariables.Add("key2", "value2");
+    var ksqlDbStatement = new KSqlDbStatement(Statement)
+    {
+      SessionVariables = new Dictionary<string, object> {
+        { "key1", "value1"},
+        { "key2", "value2"}
+      }
+    };
 
     //Act
     var json = JsonSerializer.Serialize(ksqlDbStatement);

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/KSqlDbStatementTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/KSqlDbStatementTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+using System.Text;
+using System.Text.Json;
 using FluentAssertions;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 using NUnit.Framework;
@@ -47,5 +48,21 @@ public class KSqlDbStatementTests : TestBase
 
     //Assert
     statementText.Should().Be(Statement);
+  }
+
+  [Test]
+  public void SessionVariables()
+  {
+    //Arrange
+    var ksqlDbStatement = new KSqlDbStatement(Statement);
+
+    ksqlDbStatement.SessionVariables.Add("key1", "value1");
+    ksqlDbStatement.SessionVariables.Add("key2", "value2");
+
+    //Act
+    var json = JsonSerializer.Serialize(ksqlDbStatement);
+
+    //Assert
+    json.Should().Contain(@"""sessionVariables"":{""key1"":""value1"",""key2"":""value2""}");
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/KSqlDbStatement.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/KSqlDbStatement.cs
@@ -17,7 +17,8 @@ public sealed class KSqlDbStatement : QueryParameters
   }
 
   [JsonPropertyName("sessionVariables")]
-  public Dictionary<string, object> SessionVariables { get; } = new();
+  [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+  public Dictionary<string, object> SessionVariables { get; set; }
 
   [JsonIgnore]
   public Encoding ContentEncoding { get; set; } = Encoding.UTF8;

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/KSqlDbStatement.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/KSqlDbStatement.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using System.Text.Json.Serialization;
 using ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
 
@@ -15,6 +15,9 @@ public sealed class KSqlDbStatement : QueryParameters
 
     EndpointType = EndpointType.KSql;
   }
+
+  [JsonPropertyName("sessionVariables")]
+  public Dictionary<string, object> SessionVariables { get; } = new();
 
   [JsonIgnore]
   public Encoding ContentEncoding { get; set; } = Encoding.UTF8;


### PR DESCRIPTION
The aim of this PR is to add support for [substitution variables](https://docs.ksqldb.io/en/latest/how-to-guides/substitute-variables/) requested in #39 in the following manner:

```C#
var statement = new KSqlDbStatement("CREATE TYPE ${typeName} AS STRUCT<name VARCHAR, address ADDRESS>;")
{
  SessionVariables = new Dictionary<string, object> { { "typeName", typeName } }
};

var httpResponseMessage = await restApiClient.ExecuteStatementAsync(statement);
```