### PR TITLE
Feature/function translations

### DIFF
--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Visitors/KSqlCustomFunctionVisitorTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Visitors/KSqlCustomFunctionVisitorTests.cs
@@ -1,0 +1,95 @@
+using System.Linq.Expressions;
+using System.Text;
+using FluentAssertions;
+using ksqlDB.Api.Client.Tests.Models;
+using ksqlDB.RestApi.Client.KSql.Query.Context;
+using ksqlDB.RestApi.Client.KSql.Query.Visitors;
+using ksqlDb.RestApi.Client.KSql.RestApi.Statements.Annotations;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using UnitTests;
+
+namespace ksqlDB.Api.Client.Tests.KSql.Query.Visitors;
+
+[TestClass]
+public class KSqlCustomFunctionVisitorTests : TestBase
+{
+  private KSqlCustomFunctionVisitor ClassUnderTest { get; set; }
+
+  private StringBuilder StringBuilder { get; set; }
+
+  [TestInitialize]
+  public override void TestInitialize()
+  {
+    base.TestInitialize();
+
+    StringBuilder = new StringBuilder();
+    ClassUnderTest = new KSqlCustomFunctionVisitor(StringBuilder, new KSqlQueryMetadata());
+
+    KSqlDBContextOptions.NumberFormatInfo = new System.Globalization.NumberFormatInfo
+    {
+      NumberDecimalSeparator = "."
+    };
+  }
+
+  [KSqlFunction]
+  string Substring(string input, int position, int length) => throw new NotSupportedException();
+
+  [TestMethod]
+  public void InstanceFunction()
+  {
+    //Arrange
+    Expression<Func<Tweet, string>> expression = c => Substring(c.Message, 2, 3);
+
+    //Act
+    var query = ClassUnderTest.BuildKSql(expression);
+
+    //Assert
+    query.Should().BeEquivalentTo($"Substring({nameof(Tweet.Message)}, 2, 3)");
+  }
+
+  [TestMethod]
+  public void MissingAttribute_NothingIsRendered()
+  {
+    //Arrange
+    Expression<Func<Tweet, string>> expression = c => c.ToString();
+
+    //Act
+    var query = ClassUnderTest.BuildKSql(expression);
+
+    //Assert
+    query.Should().BeEquivalentTo(String.Empty);
+  }
+
+  private static class F
+  {
+    [KSqlFunction]
+    public static double Abs(double input) => throw new NotSupportedException();
+
+    [KSqlFunction(FunctionName = "Abs")]
+    public static double MyAbs(double input) => throw new NotSupportedException();
+  }
+
+  [TestMethod]
+  public void StaticFunction()
+  {
+    Expression<Func<Tweet, double>> expression = c => F.Abs(c.Amount);
+
+    //Act
+    var query = ClassUnderTest.BuildKSql(expression);
+
+    //Assert
+    query.Should().BeEquivalentTo($"ABS({nameof(Tweet.Amount)})");
+  }
+
+  [TestMethod]
+  public void StaticFunction_OverridenFunctionName()
+  {
+    Expression<Func<Tweet, double>> expression = c => F.Abs(c.Amount);
+
+    //Act
+    var query = ClassUnderTest.BuildKSql(expression);
+
+    //Assert
+    query.Should().BeEquivalentTo($"Abs({nameof(Tweet.Amount)})");
+  }
+}

--- a/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlCustomFunctionVisitor.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlCustomFunctionVisitor.cs
@@ -1,0 +1,43 @@
+using System.Linq.Expressions;
+using System.Text;
+using ksqlDb.RestApi.Client.KSql.RestApi.Statements.Annotations;
+using ksqlDB.RestApi.Client.Infrastructure.Extensions;
+
+namespace ksqlDB.RestApi.Client.KSql.Query.Visitors;
+
+internal class KSqlCustomFunctionVisitor : KSqlVisitor
+{
+  public KSqlCustomFunctionVisitor(StringBuilder stringBuilder, KSqlQueryMetadata queryMetadata)
+    : base(stringBuilder, queryMetadata)
+  {
+  }
+
+  protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+  {
+    var methodInfo = methodCallExpression.Method;
+
+    var functionAttribute = methodInfo.TryGetAttribute<KSqlFunctionAttribute>();
+
+    if (functionAttribute != null)
+    {
+      string functionName = string.IsNullOrEmpty(functionAttribute.FunctionName)
+        ? methodInfo.Name.ToKSqlFunctionName()
+        : functionAttribute.FunctionName;
+
+      Append($"{functionName}");
+
+      PrintFunctionArguments(methodCallExpression.Arguments);
+    }
+
+    return methodCallExpression;
+  }
+
+  protected void VisitParams(NewArrayExpression node)
+  {
+    Append("(");
+
+    PrintCommaSeparated(node.Expressions);
+
+    Append(")");
+  }
+}

--- a/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlFunctionVisitor.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlFunctionVisitor.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq.Expressions;
+using System.Linq.Expressions;
 using System.Text;
 using ksqlDB.RestApi.Client.Infrastructure.Extensions;
 using ksqlDB.RestApi.Client.KSql.Query.Functions;

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Annotations/KSqlFunctionAttribute.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Annotations/KSqlFunctionAttribute.cs
@@ -1,0 +1,7 @@
+namespace ksqlDb.RestApi.Client.KSql.RestApi.Statements.Annotations;
+
+[AttributeUsage(AttributeTargets.Method)]
+public class KSqlFunctionAttribute : Attribute
+{
+  public string FunctionName { get; set; }
+}

--- a/ksqlDb.RestApi.Client/ksqlDB.RestApi.Client.csproj
+++ b/ksqlDb.RestApi.Client/ksqlDB.RestApi.Client.csproj
@@ -16,8 +16,8 @@
 			Documentation for the library can be found at https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/README.md.
 		</Description>
 		<PackageTags>ksql ksqlDB LINQ .NET csharp push query</PackageTags>
-		<Version>2.6.0</Version>
-		<AssemblyVersion>2.6.0.0</AssemblyVersion>
+		<Version>2.7.0-rc.1</Version>
+		<AssemblyVersion>2.7.0.0</AssemblyVersion>
 		<LangVersion>10.0</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PackageReleaseNotes>https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/ksqlDb.RestApi.Client/ChangeLog.md</PackageReleaseNotes>


### PR DESCRIPTION
Added support for custom function translations (invocations):
```C#
  private static class F
  {
    [KSqlFunction]
    public static double Abs(double input) => throw new NotSupportedException();

    [KSqlFunction(FunctionName = "Abs")]
    public static double MyAbs(double input) => throw new NotSupportedException();
  }
```

```C#
Expression<Func<Tweet, double>> expression = c => F.Abs(c.Amount);
```