### PR TITLE
Feature/insert function values

### DIFF
--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/Inserts/InsertValuesTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/Inserts/InsertValuesTests.cs
@@ -1,0 +1,74 @@
+using System.Linq.Expressions;
+using FluentAssertions;
+using ksqlDb.RestApi.Client.KSql.RestApi.Statements.Annotations;
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Inserts;
+using NUnit.Framework;
+
+namespace ksqlDB.Api.Client.Tests.KSql.RestApi.Statements.Inserts;
+
+public class InsertValuesTests
+{
+  private record Movie
+  {
+    internal string Id { get; init; }
+    internal string Release_Year { get; set; }
+  }
+
+  [KSqlFunction]
+  public static string FormatTimestamp(long input, string format) => throw new NotSupportedException();
+
+  [KSqlFunction]
+  public static long FromUnixtime(long milliseconds) => throw new NotSupportedException();
+
+  [KSqlFunction]
+  public static long UNIX_TIMESTAMP() => throw new NotSupportedException();
+
+  [Test]
+  public void WithValue_RendersFromProvidedValue()
+  {
+    //Arrange
+    Expression<Func<string>> valueExpression = () => FormatTimestamp(FromUnixtime(UNIX_TIMESTAMP()), "yyyy");
+
+    var insertValues = new InsertValues<Movie>(new Movie { Id = "1" });
+
+    //Act
+    insertValues.WithValue(c => c.Release_Year, valueExpression)
+      .WithValue(c => c.Id, () => "2");
+
+    //Assert
+    string expectedFunction = "FORMAT_TIMESTAMP(FROM_UNIXTIME(UNIX_TIMESTAMP()), 'yyyy')";
+
+    insertValues.PropertyValues[nameof(Movie.Release_Year)].Should().Be(expectedFunction);
+    insertValues.PropertyValues[nameof(Movie.Id)].Should().Be("'2'");
+  }
+
+  [Test]
+  public void WithValue_IsCalledTwice_LastWins()
+  {
+    //Arrange
+    Expression<Func<string>> valueExpression = () => "2022";
+
+    var insertValues = new InsertValues<Movie>(new Movie { Id = "1" });
+
+    //Act
+    insertValues.WithValue(c => c.Release_Year, valueExpression)
+      .WithValue(c => c.Release_Year, () => "2023");
+
+    //Assert
+    string expectedFunction = "FORMAT_TIMESTAMP(FROM_UNIXTIME(UNIX_TIMESTAMP()), 'yyyy')";
+
+    insertValues.PropertyValues[nameof(Movie.Release_Year)].Should().Be("'2023'");
+  }
+
+  [Test]
+  public void WithValue_NotAPropertyGetter_ThrowsArgumentException()
+  {
+    //Arrange
+    Expression<Func<string>> valueExpression = () => "2022";
+
+    var insertValues = new InsertValues<Movie>(new Movie { Id = "1" });
+
+    //Act
+    Assert.Throws<ArgumentException>(() => insertValues.WithValue(c => c.ToString(), valueExpression));
+  }
+}

--- a/ksqlDb.RestApi.Client/Infrastructure/Extensions/StringExtensions.cs
+++ b/ksqlDb.RestApi.Client/Infrastructure/Extensions/StringExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 
 namespace ksqlDB.RestApi.Client.Infrastructure.Extensions;
 
@@ -15,6 +15,7 @@ internal static class StringExtensions
 
     return ksqlFunctionName.ToUpper();
   }
+
   public static bool IsNotNullOrEmpty(this string text)
   {
     return !string.IsNullOrEmpty(text);

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/IKSqlDBContext.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/IKSqlDBContext.cs
@@ -1,6 +1,7 @@
-﻿using ksqlDB.RestApi.Client.KSql.Linq;
+using ksqlDB.RestApi.Client.KSql.Linq;
 using ksqlDB.RestApi.Client.KSql.Linq.PullQueries;
 using ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Inserts;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
 
 namespace ksqlDB.RestApi.Client.KSql.Query.Context;
@@ -17,6 +18,14 @@ public interface IKSqlDBContext : IKSqlDBStatementsContext, IAsyncDisposable, ID
 
   IPullable<TEntity> CreatePullQuery<TEntity>(string tableName = null);
   ValueTask<TEntity> ExecutePullQuery<TEntity>(string ksql, CancellationToken cancellationToken = default);
+
+  /// <summary>
+  /// Add entity for insertion. In order to save them call SaveChangesAsync.
+  /// </summary>
+  /// <typeparam name="T">Type of entity to add.</typeparam>
+  /// <param name="insertValues">Configurable insert values.</param>
+  /// <param name="insertProperties">Optional insert properties.</param>
+  void Add<T>(InsertValues<T> insertValues, InsertProperties insertProperties = null);
 
   /// <summary>
   /// Add entity for insertion. In order to save them call SaveChangesAsync.

--- a/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlCustomFunctionVisitor.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlCustomFunctionVisitor.cs
@@ -24,7 +24,12 @@ internal class KSqlCustomFunctionVisitor : KSqlVisitor
         ? methodInfo.Name.ToKSqlFunctionName()
         : functionAttribute.FunctionName;
 
-      Append($"{functionName}");
+      if (string.IsNullOrEmpty(functionName))
+      {
+        functionName = methodInfo.Name;
+      }
+
+      Append($"{functionName.ToUpper()}");
 
       PrintFunctionArguments(methodCallExpression.Arguments);
     }

--- a/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlInvocationFunctionVisitor.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlInvocationFunctionVisitor.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq.Expressions;
+using System.Linq.Expressions;
 using System.Text;
 using ksqlDB.RestApi.Client.Infrastructure.Extensions;
 using ksqlDB.RestApi.Client.KSql.Query.Functions;
@@ -16,9 +16,7 @@ internal class KSqlInvocationFunctionVisitor : KSqlVisitor
     this.stringBuilder = stringBuilder ?? throw new ArgumentNullException(nameof(stringBuilder));
     this.queryMetadata = queryMetadata ?? throw new ArgumentNullException(nameof(queryMetadata));
   }
-
-  private static bool isNestedInvocationFunction;
-
+  
   protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
   {
     var methodInfo = methodCallExpression.Method;
@@ -39,12 +37,12 @@ internal class KSqlInvocationFunctionVisitor : KSqlVisitor
           if (arguments[0].Type == typeof(KSqlFunctions))
             arguments = arguments.Skip(1).ToList();
 
-          if (isNestedInvocationFunction)
+          if (queryMetadata.IsInsideNestedInvocationFunction)
             VisitArgument(arguments[0]);
           else
             base.Visit(arguments[0]);
 
-          isNestedInvocationFunction = true;
+          queryMetadata.IsInsideNestedInvocationFunction = true;
 
           Append(", ");
             
@@ -64,8 +62,8 @@ internal class KSqlInvocationFunctionVisitor : KSqlVisitor
       }
     }
     else base.VisitMethodCall(methodCallExpression);
-      
-    isNestedInvocationFunction = false;
+
+    queryMetadata.IsInsideNestedInvocationFunction = false;
 
     return methodCallExpression;
   }

--- a/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlQueryMetadata.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlQueryMetadata.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq.Expressions;
+using System.Linq.Expressions;
 using ksqlDb.RestApi.Client.KSql.Entities;
 
 namespace ksqlDB.RestApi.Client.KSql.Query.Visitors;
@@ -9,6 +9,8 @@ internal sealed record KSqlQueryMetadata
   public FromItem[] Joins { get; set; }
 
   internal LambdaExpression Select { get; set; }
+
+  internal bool IsInsideNestedInvocationFunction { get; set; }
 
   internal FromItem TrySetAlias(MemberExpression memberExpression, Func<FromItem, string, bool> predicate)
   {

--- a/ksqlDb.RestApi.Client/KSql/RestApi/IKSqlDbRestApiClient.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/IKSqlDbRestApiClient.cs
@@ -1,10 +1,11 @@
-﻿using ksqlDB.RestApi.Client.KSql.RestApi.Http;
+using ksqlDB.RestApi.Client.KSql.RestApi.Http;
 using ksqlDB.RestApi.Client.KSql.RestApi.Responses.Connectors;
 using ksqlDB.RestApi.Client.KSql.RestApi.Responses.Queries;
 using ksqlDB.RestApi.Client.KSql.RestApi.Responses.Streams;
 using ksqlDB.RestApi.Client.KSql.RestApi.Responses.Tables;
 using ksqlDB.RestApi.Client.KSql.RestApi.Responses.Topics;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements;
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Inserts;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi;
@@ -95,14 +96,23 @@ public interface IKSqlDbRestApiClient : IKSqlDbAssertionsRestApiClient
   /// <param name="cancellationToken"></param>
   /// <returns>Http response object.</returns>
   Task<HttpResponseMessage> InsertIntoAsync<T>(T entity, InsertProperties insertProperties = null, CancellationToken cancellationToken = default);
+  
+  /// <summary>
+  /// Generates raw 'Insert Into' string, but does not execute it.
+  /// </summary>
+  /// <typeparam name="T">Type of entity</typeparam>
+  /// <param name="insertValues">Insert values</param>
+  /// <param name="insertProperties">Insert configuration</param>
+  /// <returns>A <see cref="KSqlDbStatement"/></returns>
+  KSqlDbStatement ToInsertStatement<T>(InsertValues<T> insertValues, InsertProperties insertProperties = null);
 
   /// <summary>
-  /// Generates raw string Insert Into, but does not execute it.
+  /// Generates raw 'Insert Into' string, but does not execute it.
   /// </summary>
-  /// <typeparam name="T"></typeparam>
+  /// <typeparam name="T">Type of entity</typeparam>
   /// <param name="entity">Entity for insertion.</param>
   /// <param name="insertProperties">Overrides conventions.</param>
-  /// <returns></returns>
+  /// <returns>A <see cref="KSqlDbStatement"/></returns>
   KSqlDbStatement ToInsertStatement<T>(T entity, InsertProperties insertProperties = null);
 
   /// <summary>

--- a/ksqlDb.RestApi.Client/KSql/RestApi/KSqlDbRestApiClient.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/KSqlDbRestApiClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Net.Http.Headers;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using ksqlDb.RestApi.Client.Infrastructure.Logging;
@@ -16,6 +16,7 @@ using ksqlDB.RestApi.Client.KSql.RestApi.Responses.Tables;
 using ksqlDB.RestApi.Client.KSql.RestApi.Responses.Topics;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Connectors;
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Inserts;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
 using Microsoft.Extensions.Logging;
 using IHttpClientFactory = ksqlDB.RestApi.Client.KSql.RestApi.Http.IHttpClientFactory;
@@ -344,17 +345,31 @@ public class KSqlDbRestApiClient : IKSqlDbRestApiClient
   }
 
   /// <summary>
-  /// Generates raw string Insert Into, but does not execute it.
+  /// Generates raw 'Insert Into' string, but does not execute it.
   /// </summary>
-  /// <typeparam name="T"></typeparam>
+  /// <typeparam name="T">Type of entity</typeparam>
+  /// <param name="insertValues">Insert values</param>
+  /// <param name="insertProperties">Insert configuration</param>
+  /// <returns>A <see cref="KSqlDbStatement"/></returns>
+  public KSqlDbStatement ToInsertStatement<T>(InsertValues<T> insertValues, InsertProperties insertProperties = null)
+  {
+    var insertStatement = new CreateInsert().Generate(insertValues, insertProperties);
+
+    return new KSqlDbStatement(insertStatement);
+  }
+
+  /// <summary>
+  /// Generates raw 'Insert Into' string, but does not execute it.
+  /// </summary>
+  /// <typeparam name="T">Type of entity</typeparam>
   /// <param name="entity">Entity for insertion.</param>
   /// <param name="insertProperties">Overrides conventions.</param>
-  /// <returns></returns>
+  /// <returns>A <see cref="KSqlDbStatement"/></returns>
   public KSqlDbStatement ToInsertStatement<T>(T entity, InsertProperties insertProperties = null)
   {
-    var insert = new CreateInsert().Generate(entity, insertProperties);
+    var insertStatement = new CreateInsert().Generate(entity, insertProperties);
 
-    return new KSqlDbStatement(insert);
+    return new KSqlDbStatement(insertStatement);
   }
 
   #region Get

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+using System.Reflection;
+using System.Text;
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Inserts;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
@@ -7,7 +9,12 @@ internal sealed class CreateInsert : CreateEntityStatement
 {
   internal string Generate<T>(T entity, InsertProperties insertProperties = null)
   {
-    if (entity == null) throw new ArgumentNullException(nameof(entity));
+    return Generate(new InsertValues<T>(entity), insertProperties);
+  }
+
+  internal string Generate<T>(InsertValues<T> insertValues, InsertProperties insertProperties = null)
+  {
+    if (insertValues == null) throw new ArgumentNullException(nameof(insertValues));
 
     insertProperties ??= new InsertProperties();
 		
@@ -19,7 +26,7 @@ internal sealed class CreateInsert : CreateEntityStatement
     var valuesStringBuilder = new StringBuilder();
 
     var useEntityType = insertProperties is {UseInstanceType: true};
-    var entityType = useEntityType ? entity.GetType() : typeof(T);
+    var entityType = useEntityType ? insertValues.Entity.GetType() : typeof(T);
 
     foreach (var memberInfo in Members(entityType, insertProperties?.IncludeReadOnlyProperties))
     {
@@ -37,7 +44,7 @@ internal sealed class CreateInsert : CreateEntityStatement
 
       var type = GetMemberType(memberInfo);
 
-      var value = new CreateKSqlValue().ExtractValue(entity, insertProperties, memberInfo, type);
+      var value = GetValue(insertValues, insertProperties, memberInfo, type);
 
       valuesStringBuilder.Append(value);
     }
@@ -46,5 +53,19 @@ internal sealed class CreateInsert : CreateEntityStatement
       $"INSERT INTO {entityName} ({columnsStringBuilder}) VALUES ({valuesStringBuilder});";
 			
     return insert;
+  }
+
+  private static object GetValue<T>(InsertValues<T> insertValues, InsertProperties insertProperties, MemberInfo memberInfo, Type type)
+  {
+    var hasValue = insertValues.PropertyValues.ContainsKey(memberInfo.Name);
+
+    object value;
+
+    if (hasValue)
+      value = insertValues.PropertyValues[memberInfo.Name];
+    else
+      value = new CreateKSqlValue().ExtractValue(insertValues.Entity, insertProperties, memberInfo, type);
+
+    return value;
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
@@ -28,7 +28,7 @@ internal sealed class CreateInsert : CreateEntityStatement
     var useEntityType = insertProperties is {UseInstanceType: true};
     var entityType = useEntityType ? insertValues.Entity.GetType() : typeof(T);
 
-    foreach (var memberInfo in Members(entityType, insertProperties?.IncludeReadOnlyProperties))
+    foreach (var memberInfo in Members(entityType, insertProperties.IncludeReadOnlyProperties))
     {
       if (isFirst)
       {

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Inserts/InsertValues.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Inserts/InsertValues.cs
@@ -1,0 +1,54 @@
+using System.Collections.ObjectModel;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using ksqlDB.RestApi.Client.KSql.Query.Visitors;
+
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements.Inserts;
+
+public class InsertValues<T>
+{
+  public T Entity { get; }
+
+  public InsertValues(T entity)
+  {
+    Entity = entity ?? throw new ArgumentNullException(nameof(entity));
+  }
+
+  private readonly Dictionary<string, string> propertyValues = new();
+
+  internal IDictionary<string, string> PropertyValues => new ReadOnlyDictionary<string, string>(propertyValues);
+
+  public InsertValues<T> WithValue<TColumn>(Expression<Func<T, TColumn>> getProperty, Expression<Func<TColumn>> provideValue)
+  {
+    if (getProperty == null) throw new ArgumentNullException(nameof(getProperty));
+    if (provideValue == null) throw new ArgumentNullException(nameof(provideValue));
+
+    var propertyName = ExtractPropertyName(getProperty);
+
+    var stringBuilder = new StringBuilder();
+
+    new KSqlCustomFunctionVisitor(stringBuilder, new KSqlQueryMetadata()).Visit(provideValue);
+
+    var propertyValue = stringBuilder.ToString();
+
+    propertyValues[propertyName] = propertyValue;
+
+    return this;
+  }
+
+  private static string ExtractPropertyName<TProp>(Expression<Func<T, TProp>> getProperty)
+  {
+    if (getProperty.Body is not MemberExpression memberExpression)
+      throw new ArgumentException($"Expression '{getProperty}' is not a property.");
+
+    PropertyInfo propInfo = memberExpression.Member as PropertyInfo;
+
+    if (propInfo == null)
+      throw new ArgumentException($"Expression '{getProperty}' is not a property.");
+
+    var propertyName = propInfo.Name;
+
+    return propertyName;
+  }
+}


### PR DESCRIPTION
This PR extends the library with enabling custom KSQL functions in the following manner:

```C#
var insertValues = new InsertValues<Article>(new Article())
  .WithValue(c => c.Release_Date, FormatTimestamp(FROM_UNIXTIME(UnixTimestamp()), "yyyy"));

var insertStatement = ClassUnderTest.ToInsertStatement(insertValues);
```

```C#
[KSqlFunction]
public static string FormatTimestamp(long input, string format) => throw new NotSupportedException();

[KSqlFunction]
public static long FROM_UNIXTIME(long milliseconds) => throw new NotSupportedException();

[KSqlFunction]
public static long UnixTimestamp() => throw new NotSupportedException();

private struct Article
{
  [IgnoreByInserts]
  public long RowTime { get; set; }
  public string Title { get; set; }
  [Key]
  public int Id { get; set; }
  public string Release_Date { get; set; }
}
```