### PR TITLE
[ksqlDB.RestApi.Client]: fix insert statement creation

### DIFF
--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -1,5 +1,8 @@
 # ksqlDB.RestApi.Client
 
+# 3.6.1
+- fix usage of `JsonPropertyName` when creating insert statements (since 3.6.0) (contributed by @mrt181)
+
 # 3.6.0
 - added escaping options using backticks for [Identifiers](https://docs.ksqldb.io/en/latest/reference/sql/syntax/lexical-structure/#identifiers) in statements #57 (contributed by @mrt181)
 - added `TypeProperties` class to configure type creation #58 (contributed by @mrt181)

--- a/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlVisitor.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlVisitor.cs
@@ -161,7 +161,7 @@ internal class KSqlVisitor : ExpressionVisitor
       else
         Append(ColumnsSeparator);
 
-      var memberName = IdentifierUtil.Format(memberBinding.Member, QueryMetadata.IdentifierEscaping);
+      var memberName = memberBinding.Member.Format(QueryMetadata.IdentifierEscaping);
 
       Append($"{memberName} := ");
 
@@ -353,13 +353,13 @@ internal class KSqlVisitor : ExpressionVisitor
     {
       Visit(expression);
 
-      Append(" " + IdentifierUtil.Format(memberInfo.Name, QueryMetadata.IdentifierEscaping));
+      Append(" " + memberInfo.Format(QueryMetadata.IdentifierEscaping));
       return;
     }
 
     if (expression is MemberExpression { Expression: MemberExpression me3 } && me3.Expression != null && me3.Expression.Type.IsKsqlGrouping())
     {
-      Append(IdentifierUtil.Format(memberInfo.Name, QueryMetadata.IdentifierEscaping));
+      Append(memberInfo.Format(QueryMetadata.IdentifierEscaping));
       return;
     }
 
@@ -374,7 +374,7 @@ internal class KSqlVisitor : ExpressionVisitor
     else if (expression is MemberExpression me2 && me2.Expression?.NodeType == ExpressionType.Constant)
       Visit(expression);
     else
-      Append(IdentifierUtil.Format(memberInfo.Name, QueryMetadata.IdentifierEscaping));
+      Append(memberInfo.Format(QueryMetadata.IdentifierEscaping));
   }
 
   protected override Expression VisitMember(MemberExpression memberExpression)
@@ -387,7 +387,7 @@ internal class KSqlVisitor : ExpressionVisitor
       {
         var foundFromItem = QueryMetadata.TrySetAlias(memberExpression, (_, alias) => string.IsNullOrEmpty(alias));
 
-        var memberName = IdentifierUtil.Format(memberExpression.Member, QueryMetadata.IdentifierEscaping);
+        var memberName = memberExpression.Member.Format(QueryMetadata.IdentifierEscaping);
 
         var alias = IdentifierUtil.Format(((ParameterExpression)memberExpression.Expression).Name, QueryMetadata.IdentifierEscaping);
 
@@ -410,7 +410,7 @@ internal class KSqlVisitor : ExpressionVisitor
 
         Append(".");
 
-        var memberName = IdentifierUtil.Format(memberExpression.Member, QueryMetadata.IdentifierEscaping);
+        var memberName = memberExpression.Member.Format(QueryMetadata.IdentifierEscaping);
         Append(memberName);
         return memberExpression;
       }
@@ -495,7 +495,7 @@ internal class KSqlVisitor : ExpressionVisitor
 
     if (type != fromItem?.Type)
     {
-        Append(IdentifierUtil.Format(memberExpression.Member, QueryMetadata.IdentifierEscaping));
+        Append(memberExpression.Member.Format(QueryMetadata.IdentifierEscaping));
     }
   }
 
@@ -522,7 +522,7 @@ internal class KSqlVisitor : ExpressionVisitor
     if (fromItem == null)
       Append("->");
 
-    var memberName = IdentifierUtil.Format(memberExpression.Member, QueryMetadata.IdentifierEscaping);
+    var memberName = memberExpression.Member.Format(QueryMetadata.IdentifierEscaping);
 
     Append(memberName);
   }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Extensions/MemberInfoExtensions.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Extensions/MemberInfoExtensions.cs
@@ -12,6 +12,6 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi.Extensions
     /// <param name="memberInfo"></param>
     /// <param name="escaping"></param>
     /// <returns>the <c>memberInfo.Name</c> modified based on the provided <c>format</c></returns>
-    public static string Format(this MemberInfo memberInfo, IdentifierEscaping escaping) => IdentifierUtil.Format(memberInfo.Name, escaping);
+    public static string Format(this MemberInfo memberInfo, IdentifierEscaping escaping) => IdentifierUtil.Format(memberInfo, escaping);
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
@@ -7,7 +7,7 @@ using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 
-internal sealed class CreateInsert : CreateEntityStatement 
+internal sealed class CreateInsert : CreateEntityStatement
 {
   internal string Generate<T>(T entity, InsertProperties insertProperties = null)
   {
@@ -19,7 +19,7 @@ internal sealed class CreateInsert : CreateEntityStatement
     if (insertValues == null) throw new ArgumentNullException(nameof(insertValues));
 
     insertProperties ??= new InsertProperties();
-		
+
     var entityName = GetEntityName<T>(insertProperties);
 
     bool isFirst = true;
@@ -46,7 +46,7 @@ internal sealed class CreateInsert : CreateEntityStatement
 
       var type = GetMemberType(memberInfo);
 
-      var value = GetValue(insertValues, insertProperties, memberInfo, type, str => IdentifierUtil.Format(str, insertProperties.IdentifierEscaping));
+      var value = GetValue(insertValues, insertProperties, memberInfo, type, memberInfo => IdentifierUtil.Format(memberInfo, insertProperties.IdentifierEscaping));
 
       valuesStringBuilder.Append(value);
     }
@@ -58,7 +58,7 @@ internal sealed class CreateInsert : CreateEntityStatement
   }
 
   private static object GetValue<T>(InsertValues<T> insertValues, InsertProperties insertProperties,
-    MemberInfo memberInfo, Type type, Func<string, string> formatter)
+    MemberInfo memberInfo, Type type, Func<MemberInfo, string> formatter)
   {
     var hasValue = insertValues.PropertyValues.ContainsKey(memberInfo.Format(insertProperties.IdentifierEscaping));
 

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateKSqlValue.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateKSqlValue.cs
@@ -11,7 +11,7 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 
 internal sealed class CreateKSqlValue : CreateEntityStatement
 {
-  public object ExtractValue<T>(T inputValue, IValueFormatters valueFormatters, MemberInfo memberInfo, Type type, Func<string, string> formatter)
+  public object ExtractValue<T>(T inputValue, IValueFormatters valueFormatters, MemberInfo memberInfo, Type type, Func<MemberInfo, string> formatter)
   {
     Type valueType = inputValue.GetType();
 
@@ -54,7 +54,7 @@ internal sealed class CreateKSqlValue : CreateEntityStatement
     else if (type == typeof(DateTimeOffset))
     {
       var dateTimeOffset = (DateTimeOffset)value;
-        
+
       value = dateTimeOffset.ToString(ValueFormats.DateTimeOffsetFormat, CultureInfo.InvariantCulture);
 
       value = $"'{value}'";
@@ -92,7 +92,7 @@ internal sealed class CreateKSqlValue : CreateEntityStatement
     return value;
   }
 
-  private void GenerateMap(IValueFormatters valueFormatters, Type type, Func<string, string> formatter,
+  private void GenerateMap(IValueFormatters valueFormatters, Type type, Func<MemberInfo, string> formatter,
     ref object value)
   {
     if (value is not IDictionary dict)
@@ -127,7 +127,7 @@ internal sealed class CreateKSqlValue : CreateEntityStatement
     value = sb.ToString();
   }
 
-  private void GenerateStruct<T>(IValueFormatters valueFormatters, Type type, Func<string, string> formatter,
+  private void GenerateStruct<T>(IValueFormatters valueFormatters, Type type, Func<MemberInfo, string> formatter,
     ref object value)
   {
     var sb = new StringBuilder();
@@ -146,7 +146,7 @@ internal sealed class CreateKSqlValue : CreateEntityStatement
       type = GetMemberType(memberInfo2);
 
       var innerValue = ExtractValue(value, valueFormatters, memberInfo2, type, formatter);
-      var name = formatter(memberInfo2.Name);
+      var name = formatter(memberInfo2);
       sb.Append($"{name} := {innerValue}");
     }
 
@@ -156,7 +156,7 @@ internal sealed class CreateKSqlValue : CreateEntityStatement
   }
 
   private object GenerateEnumerableValue(Type type, object value, IValueFormatters valueFormatters,
-    Func<string, string> formatter)
+    Func<MemberInfo, string> formatter)
   {
     if (value == null)
       return "NULL";


### PR DESCRIPTION
Inserts must use `JsonPropertyName' attributes when these are defined.

#59