### PR TITLE
Feature/add drop entity overloads to ksqldbrestapiclient

### DIFF
--- a/Samples/InsideOut/Consumer/KafkaConsumer.cs
+++ b/Samples/InsideOut/Consumer/KafkaConsumer.cs
@@ -152,8 +152,6 @@ public class KafkaConsumer<TKey, TValue> : IKafkaConsumer<TKey, TValue>
         yield return message;
       }
     }
-
-    Console.WriteLine("huhuuu");
   }
 
   private IEnumerable<ConsumeResult<TKey, TValue>> ConnectToTopic(TimeSpan? timeout, CancellationToken cancellationToken = default)

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Generators/TypeGeneratorTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Generators/TypeGeneratorTests.cs
@@ -15,7 +15,7 @@ public class TypeGeneratorTests
     //Arrange
 
     //Act
-    var statement = new TypeGenerator().Print(new TypeProperties<Address>());
+    var statement = new TypeGenerator().Print<Address>(new TypeProperties());
 
     //Assert
     statement.Should()
@@ -26,10 +26,10 @@ public class TypeGeneratorTests
   public void CreateType_WithTypeName()
   {
     //Arrange
-    var typeName = "MyType";
+    var typeName = "MYTYPE";
 
     //Act
-    var statement = new TypeGenerator().Print(new TypeProperties<Address> { EntityName = typeName });
+    var statement = new TypeGenerator().Print<Address>(new TypeProperties { EntityName = typeName });
 
     //Assert
     statement.Should().Be($"CREATE TYPE {typeName} AS STRUCT<Number INT, Street VARCHAR, City VARCHAR>;");
@@ -41,7 +41,7 @@ public class TypeGeneratorTests
     //Arrange
 
     //Act
-    var statement = new TypeGenerator().Print(new TypeProperties<Person>());
+    var statement = new TypeGenerator().Print<Person>(new TypeProperties());
 
     //Assert
     statement.Should().Be($"CREATE TYPE {nameof(Person).ToUpper()} AS STRUCT<Name VARCHAR, Address ADDRESS>;");
@@ -53,7 +53,7 @@ public class TypeGeneratorTests
     //Arrange
 
     //Act
-    var statement = new TypeGenerator().Print(new TypeProperties<Thumbnail>());
+    var statement = new TypeGenerator().Print<Thumbnail>(new TypeProperties());
 
     //Assert
     statement.Should().Be($"CREATE TYPE {nameof(Thumbnail).ToUpper()} AS STRUCT<Image BYTES>;");
@@ -65,7 +65,7 @@ public class TypeGeneratorTests
     //Arrange
 
     //Act
-    var statement = new TypeGenerator().Print(new TypeProperties<Container>());
+    var statement = new TypeGenerator().Print<Container>(new TypeProperties());
 
     //Assert
     statement.Should().Be($"CREATE TYPE {nameof(Container).ToUpper()} AS STRUCT<Values2 MAP<VARCHAR, INT>>;");
@@ -75,13 +75,13 @@ public class TypeGeneratorTests
   [TestCase(IdentifierEscaping.Keywords, ExpectedResult = "CREATE TYPE ROWTIME AS STRUCT<Value VARCHAR>;")]
   [TestCase(IdentifierEscaping.Always, ExpectedResult = "CREATE TYPE `ROWTIME` AS STRUCT<`Value` VARCHAR>;")]
   public string CreateType_WithSystemColumName(IdentifierEscaping escaping) =>
-    new TypeGenerator().Print(new TypeProperties<RowTime> { IdentifierEscaping = escaping });
+    new TypeGenerator().Print<RowTime>(new TypeProperties { IdentifierEscaping = escaping });
 
   [TestCase(IdentifierEscaping.Never, ExpectedResult = "CREATE TYPE VALUES AS STRUCT<Value VARCHAR>;")]
   [TestCase(IdentifierEscaping.Keywords, ExpectedResult = "CREATE TYPE `VALUES` AS STRUCT<Value VARCHAR>;")]
   [TestCase(IdentifierEscaping.Always, ExpectedResult = "CREATE TYPE `VALUES` AS STRUCT<`Value` VARCHAR>;")]
   public string CreateType_WithReservedWord(IdentifierEscaping escaping) =>
-    new TypeGenerator().Print(new TypeProperties<Values> { IdentifierEscaping = escaping });
+    new TypeGenerator().Print<Values>(new TypeProperties { IdentifierEscaping = escaping });
 
   [TestCase(IdentifierEscaping.Never,
     ExpectedResult =
@@ -93,7 +93,7 @@ public class TypeGeneratorTests
     ExpectedResult =
       "CREATE TYPE `SYSTEMCOLUMN` AS STRUCT<`RowTime` VARCHAR, `RowOffset` VARCHAR, `RowPartition` VARCHAR, `WindowStart` VARCHAR, `WindowEnd` VARCHAR>;")]
   public string CreateType_WithSystemColumnNameField(IdentifierEscaping escaping) =>
-    new TypeGenerator().Print(new TypeProperties<SystemColumn> { IdentifierEscaping = escaping });
+    new TypeGenerator().Print<SystemColumn>(new TypeProperties { IdentifierEscaping = escaping });
 
   public record Address
   {
@@ -176,7 +176,7 @@ public class TypeGeneratorTests
 
     //Act
     var statement =
-      new TypeGenerator().Print(new TypeProperties<DatabaseChangeObject<IoTSensor>>());
+      new TypeGenerator().Print<DatabaseChangeObject<IoTSensor>>(new TypeProperties());
 
     //Assert
     statement.Should()

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Generators/TypeGeneratorTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Generators/TypeGeneratorTests.cs
@@ -19,7 +19,7 @@ public class TypeGeneratorTests
 
     //Assert
     statement.Should()
-      .Be($"CREATE TYPE {nameof(Address).ToUpper()} AS STRUCT<Number INT, Street VARCHAR, City VARCHAR>;");
+      .Be($"CREATE TYPE {nameof(Address)} AS STRUCT<Number INT, Street VARCHAR, City VARCHAR>;");
   }
 
   [Test]
@@ -44,7 +44,7 @@ public class TypeGeneratorTests
     var statement = new TypeGenerator().Print<Person>(new TypeProperties());
 
     //Assert
-    statement.Should().Be($"CREATE TYPE {nameof(Person).ToUpper()} AS STRUCT<Name VARCHAR, Address ADDRESS>;");
+    statement.Should().Be($"CREATE TYPE {nameof(Person)} AS STRUCT<Name VARCHAR, Address ADDRESS>;");
   }
 
   [Test]
@@ -56,7 +56,7 @@ public class TypeGeneratorTests
     var statement = new TypeGenerator().Print<Thumbnail>(new TypeProperties());
 
     //Assert
-    statement.Should().Be($"CREATE TYPE {nameof(Thumbnail).ToUpper()} AS STRUCT<Image BYTES>;");
+    statement.Should().Be($"CREATE TYPE {nameof(Thumbnail)} AS STRUCT<Image BYTES>;");
   }
 
   [Test]
@@ -68,30 +68,30 @@ public class TypeGeneratorTests
     var statement = new TypeGenerator().Print<Container>(new TypeProperties());
 
     //Assert
-    statement.Should().Be($"CREATE TYPE {nameof(Container).ToUpper()} AS STRUCT<Values2 MAP<VARCHAR, INT>>;");
+    statement.Should().Be($"CREATE TYPE {nameof(Container)} AS STRUCT<Values2 MAP<VARCHAR, INT>>;");
   }
 
-  [TestCase(IdentifierEscaping.Never, ExpectedResult = "CREATE TYPE ROWTIME AS STRUCT<Value VARCHAR>;")]
-  [TestCase(IdentifierEscaping.Keywords, ExpectedResult = "CREATE TYPE ROWTIME AS STRUCT<Value VARCHAR>;")]
-  [TestCase(IdentifierEscaping.Always, ExpectedResult = "CREATE TYPE `ROWTIME` AS STRUCT<`Value` VARCHAR>;")]
+  [TestCase(IdentifierEscaping.Never, ExpectedResult = "CREATE TYPE RowTime AS STRUCT<Value VARCHAR>;")]
+  [TestCase(IdentifierEscaping.Keywords, ExpectedResult = "CREATE TYPE RowTime AS STRUCT<Value VARCHAR>;")]
+  [TestCase(IdentifierEscaping.Always, ExpectedResult = "CREATE TYPE `RowTime` AS STRUCT<`Value` VARCHAR>;")]
   public string CreateType_WithSystemColumName(IdentifierEscaping escaping) =>
     new TypeGenerator().Print<RowTime>(new TypeProperties { IdentifierEscaping = escaping });
 
-  [TestCase(IdentifierEscaping.Never, ExpectedResult = "CREATE TYPE VALUES AS STRUCT<Value VARCHAR>;")]
-  [TestCase(IdentifierEscaping.Keywords, ExpectedResult = "CREATE TYPE `VALUES` AS STRUCT<Value VARCHAR>;")]
-  [TestCase(IdentifierEscaping.Always, ExpectedResult = "CREATE TYPE `VALUES` AS STRUCT<`Value` VARCHAR>;")]
+  [TestCase(IdentifierEscaping.Never, ExpectedResult = "CREATE TYPE Values AS STRUCT<Value VARCHAR>;")]
+  [TestCase(IdentifierEscaping.Keywords, ExpectedResult = "CREATE TYPE `Values` AS STRUCT<Value VARCHAR>;")]
+  [TestCase(IdentifierEscaping.Always, ExpectedResult = "CREATE TYPE `Values` AS STRUCT<`Value` VARCHAR>;")]
   public string CreateType_WithReservedWord(IdentifierEscaping escaping) =>
     new TypeGenerator().Print<Values>(new TypeProperties { IdentifierEscaping = escaping });
 
   [TestCase(IdentifierEscaping.Never,
     ExpectedResult =
-      "CREATE TYPE SYSTEMCOLUMN AS STRUCT<RowTime VARCHAR, RowOffset VARCHAR, RowPartition VARCHAR, WindowStart VARCHAR, WindowEnd VARCHAR>;")]
+      "CREATE TYPE SystemColumn AS STRUCT<RowTime VARCHAR, RowOffset VARCHAR, RowPartition VARCHAR, WindowStart VARCHAR, WindowEnd VARCHAR>;")]
   [TestCase(IdentifierEscaping.Keywords,
     ExpectedResult =
-      "CREATE TYPE SYSTEMCOLUMN AS STRUCT<RowTime VARCHAR, RowOffset VARCHAR, RowPartition VARCHAR, WindowStart VARCHAR, WindowEnd VARCHAR>;")]
+      "CREATE TYPE SystemColumn AS STRUCT<RowTime VARCHAR, RowOffset VARCHAR, RowPartition VARCHAR, WindowStart VARCHAR, WindowEnd VARCHAR>;")]
   [TestCase(IdentifierEscaping.Always,
     ExpectedResult =
-      "CREATE TYPE `SYSTEMCOLUMN` AS STRUCT<`RowTime` VARCHAR, `RowOffset` VARCHAR, `RowPartition` VARCHAR, `WindowStart` VARCHAR, `WindowEnd` VARCHAR>;")]
+      "CREATE TYPE `SystemColumn` AS STRUCT<`RowTime` VARCHAR, `RowOffset` VARCHAR, `RowPartition` VARCHAR, `WindowStart` VARCHAR, `WindowEnd` VARCHAR>;")]
   public string CreateType_WithSystemColumnNameField(IdentifierEscaping escaping) =>
     new TypeGenerator().Print<SystemColumn>(new TypeProperties { IdentifierEscaping = escaping });
 
@@ -180,7 +180,7 @@ public class TypeGeneratorTests
 
     //Assert
     statement.Should()
-      .Be("CREATE TYPE DATABASECHANGEOBJECT AS STRUCT<Before IOTSENSOR, After IOTSENSOR, Source SOURCE, Op VARCHAR, TsMs BIGINT>;"); //, Transaction OBJECT
+      .Be($"CREATE TYPE {nameof(DatabaseChangeObject)} AS STRUCT<Before IOTSENSOR, After IOTSENSOR, Source SOURCE, Op VARCHAR, TsMs BIGINT>;"); //, Transaction OBJECT
   }
 
   #endregion

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Parsers/SystemColumnsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Parsers/SystemColumnsTests.cs
@@ -1,4 +1,3 @@
-using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
 using ksqlDb.RestApi.Client.KSql.RestApi.Parsers;
 using NUnit.Framework;
 

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/CreateEntityTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/CreateEntityTests.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Text.Json.Serialization;
 using FluentAssertions;
 using Joker.Extensions;
@@ -70,207 +69,7 @@ public class CreateEntityTests
     };
   }
 
-  #region KSqlTypeTranslator
-
-  [Test]
-  public void KSqlTypeTranslator_StringType()
-  {
-    //Arrange
-    var type = typeof(string);
-
-    //Act
-    string ksqlType = CreateEntity.KSqlTypeTranslator(type);
-
-    //Assert
-    ksqlType.Should().Be("VARCHAR");
-  }
-
-  [Test]
-  public void KSqlTypeTranslator_IntType()
-  {
-    //Arrange
-    var type = typeof(int);
-
-    //Act
-    string ksqlType = CreateEntity.KSqlTypeTranslator(type);
-
-    //Assert
-    ksqlType.Should().Be("INT");
-  }
-
-  [Test]
-  public void KSqlTypeTranslator_LongType()
-  {
-    //Arrange
-    var type = typeof(long);
-
-    //Act
-    string ksqlType = CreateEntity.KSqlTypeTranslator(type);
-
-    //Assert
-    ksqlType.Should().Be("BIGINT");
-  }
-
-  [Test]
-  public void KSqlTypeTranslator_DoubleType()
-  {
-    //Arrange
-    var type = typeof(double);
-
-    //Act
-    string ksqlType = CreateEntity.KSqlTypeTranslator(type);
-
-    //Assert
-    ksqlType.Should().Be("DOUBLE");
-  }
-
-  [Test]
-  public void KSqlTypeTranslator_DecimalType()
-  {
-    //Arrange
-    var type = typeof(decimal);
-
-    //Act
-    string ksqlType = CreateEntity.KSqlTypeTranslator(type);
-
-    //Assert
-    ksqlType.Should().Be("DECIMAL");
-  }
-
-  [Test]
-  public void KSqlTypeTranslator_BoolType()
-  {
-    //Arrange
-    var type = typeof(bool);
-
-    //Act
-    string ksqlType = CreateEntity.KSqlTypeTranslator(type);
-
-    //Assert
-    ksqlType.Should().Be("BOOLEAN");
-  }
-
-  [Test]
-  public void KSqlTypeTranslator_DictionaryType()
-  {
-    //Arrange
-    var type = typeof(Dictionary<string, int>);
-
-    //Act
-    string ksqlType = CreateEntity.KSqlTypeTranslator(type);
-
-    //Assert
-    ksqlType.Should().Be("MAP<VARCHAR, INT>");
-  }
-
-  [Test]
-  public void KSqlTypeTranslator_DictionaryInterface()
-  {
-    //Arrange
-    var type = typeof(IDictionary<string, long>);
-
-    //Act
-    string ksqlType = CreateEntity.KSqlTypeTranslator(type);
-
-    //Assert
-    ksqlType.Should().Be("MAP<VARCHAR, BIGINT>");
-  }
-
-  [Test]
-  public void KSqlTypeTranslator_ArrayType()
-  {
-    //Arrange
-    var type = typeof(double[]);
-
-    //Act
-    string ksqlType = CreateEntity.KSqlTypeTranslator(type);
-
-    //Assert
-    ksqlType.Should().Be("ARRAY<DOUBLE>");
-  }
-
-  [Test]
-  public void KSqlTypeTranslator_ListType()
-  {
-    //Arrange
-    var type = typeof(List<string>);
-
-    //Act
-    string ksqlType = CreateEntity.KSqlTypeTranslator(type);
-
-    //Assert
-    ksqlType.Should().Be("ARRAY<VARCHAR>");
-  }
-
-  [Test]
-  public void KSqlTypeTranslator_IListInterface()
-  {
-    //Arrange
-    var type = typeof(IList<string>);
-
-    //Act
-    string ksqlType = CreateEntity.KSqlTypeTranslator(type);
-
-    //Assert
-    ksqlType.Should().Be("ARRAY<VARCHAR>");
-  }
-
-  [Test]
-  public void KSqlTypeTranslator_IEnumerable()
-  {
-    //Arrange
-    var type = typeof(IEnumerable<string>);
-
-    //Act
-    string ksqlType = CreateEntity.KSqlTypeTranslator(type);
-
-    //Assert
-    ksqlType.Should().Be("ARRAY<VARCHAR>");
-  }
-
-  [Test]
-  public void KSqlTypeTranslator_NestedMapInArray()
-  {
-    //Arrange
-    var type = typeof(IDictionary<string, int>[]);
-
-    //Act
-    string ksqlType = CreateEntity.KSqlTypeTranslator(type);
-
-    //Assert
-    ksqlType.Should().Be("ARRAY<MAP<VARCHAR, INT>>");
-  }
-
-  [Test]
-  public void KSqlTypeTranslator_NestedArrayInMap()
-  {
-    //Arrange
-    var type = typeof(IDictionary<string, int[]>);
-
-    //Act
-    string ksqlType = CreateEntity.KSqlTypeTranslator(type);
-
-    //Assert
-    ksqlType.Should().Be("MAP<VARCHAR, ARRAY<INT>>");
-  }
-
-  [Test]
-  public void KSqlTypeTranslator_BytesType()
-  {
-    //Arrange
-    var type = typeof(byte[]);
-
-    //Act
-    string ksqlType = CreateEntity.KSqlTypeTranslator(type);
-
-    //Assert
-    ksqlType.Should().Be("BYTES");
-  }
-
-  #endregion
-
-
-  public static IEnumerable<(IdentifierEscaping, string)> PrintCreateStreamTestCases()
+  internal static IEnumerable<(IdentifierEscaping, string)> PrintCreateStreamTestCases()
   {
     yield return (Never, CreateExpectedStatement("CREATE STREAM", hasPrimaryKey: false, escaping: Never));
     yield return (Keywords, CreateExpectedStatement("CREATE STREAM", hasPrimaryKey: false, escaping: Keywords));
@@ -301,7 +100,7 @@ public class CreateEntityTests
     public decimal Amount { get; set; }
   }
 
-  public static IEnumerable<(IdentifierEscaping, string)> DecimalWithPrecisionTestCases()
+  internal static IEnumerable<(IdentifierEscaping, string)> DecimalWithPrecisionTestCases()
   {
     yield return (Never, $@"CREATE STREAM Transactions (
 {"\t"}Amount DECIMAL(3,2)
@@ -333,7 +132,7 @@ public class CreateEntityTests
     statement.Should().Be(expected);
   }
 
-  public static IEnumerable<(IdentifierEscaping, string)> PrintCreatStreamOverrideEntityNameTestCases()
+  internal static IEnumerable<(IdentifierEscaping, string)> PrintCreatStreamOverrideEntityNameTestCases()
   {
     yield return (Never,
       CreateExpectedStatement("CREATE STREAM", hasPrimaryKey: false,
@@ -367,7 +166,7 @@ public class CreateEntityTests
     statement.Should().Be(expected);
   }
 
-  public static IEnumerable<(IdentifierEscaping, string)> PrintCreateStreamOverrideEntityNameDoNotPluralizeTestCases()
+  internal static IEnumerable<(IdentifierEscaping, string)> PrintCreateStreamOverrideEntityNameDoNotPluralizeTestCases()
   {
     yield return (Never, CreateExpectedStatement("CREATE STREAM", hasPrimaryKey: false, entityName: "TestName"));
     yield return (Keywords,
@@ -500,7 +299,7 @@ public class CreateEntityTests
     statement.Should().Be(CreateExpectedStatement("CREATE OR REPLACE TABLE", hasPrimaryKey: true));
   }
 
-  public static IEnumerable<(IdentifierEscaping, string)> PrintCreateOrReplaceTableIncludeReadOnlyPropertiesTestCases()
+  internal static IEnumerable<(IdentifierEscaping, string)> PrintCreateOrReplaceTableIncludeReadOnlyPropertiesTestCases()
   {
     yield return (Never, $@"CREATE OR REPLACE TABLE MyItems (
 {"\t"}Id INT PRIMARY KEY,
@@ -767,7 +566,7 @@ public class CreateEntityTests
 
     //Assert
     statement.Should().Be(@$"CREATE STREAM {nameof(GuidKey)} (
-	DataId VARCHAR
+	{nameof(GuidKey.DataId)} VARCHAR
 ) WITH ( KAFKA_TOPIC='{streamCreationMetadata.KafkaTopic}', VALUE_FORMAT='Json', PARTITIONS='1' );".ReplaceLineEndings());
   }
 }

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/KSqlTypeTranslatorTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/KSqlTypeTranslatorTests.cs
@@ -1,0 +1,371 @@
+using System.Drawing;
+using System.Text;
+using FluentAssertions;
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements;
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Annotations;
+using NUnit.Framework;
+
+namespace ksqlDb.RestApi.Client.Tests.KSql.RestApi.Statements
+{
+  public class KSqlTypeTranslatorTests
+  {
+    [Test]
+    public void Translate_StringType()
+    {
+      //Arrange
+      var type = typeof(string);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be(KSqlTypes.Varchar);
+    }
+
+    [Test]
+    public void Translate_IntType()
+    {
+      //Arrange
+      var type = typeof(int);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be(KSqlTypes.Int);
+    }
+
+    [Test]
+    public void Translate_LongType()
+    {
+      //Arrange
+      var type = typeof(long);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be(KSqlTypes.BigInt);
+    }
+
+    [Test]
+    public void Translate_DoubleType()
+    {
+      //Arrange
+      var type = typeof(double);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be(KSqlTypes.Double);
+    }
+
+    [Test]
+    public void Translate_DecimalType()
+    {
+      //Arrange
+      var type = typeof(decimal);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be(KSqlTypes.Decimal);
+    }
+
+    [Test]
+    public void Translate_BoolType()
+    {
+      //Arrange
+      var type = typeof(bool);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be(KSqlTypes.Boolean);
+    }
+
+    [Test]
+    public void Translate_DictionaryType()
+    {
+      //Arrange
+      var type = typeof(Dictionary<string, int>);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be($"{KSqlTypes.Map}<{KSqlTypes.Varchar}, {KSqlTypes.Int}>");
+    }
+
+    [Test]
+    public void Translate_DictionaryInterface()
+    {
+      //Arrange
+      var type = typeof(IDictionary<string, long>);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be($"{KSqlTypes.Map}<{KSqlTypes.Varchar}, {KSqlTypes.BigInt}>");
+    }
+
+    [Test]
+    public void Translate_ArrayType()
+    {
+      //Arrange
+      var type = typeof(double[]);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be($"{KSqlTypes.Array}<{KSqlTypes.Double}>");
+    }
+
+    [Test]
+    public void Translate_EnumerableType()
+    {
+      //Arrange
+      var type = typeof(IEnumerable<string>);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be($"{KSqlTypes.Array}<{KSqlTypes.Varchar}>");
+    }
+
+    [Test]
+    public void Translate_ListType()
+    {
+      //Arrange
+      var type = typeof(List<string>);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be($"{KSqlTypes.Array}<{KSqlTypes.Varchar}>");
+    }
+
+    [Test]
+    public void Translate_IListInterface()
+    {
+      //Arrange
+      var type = typeof(IList<string>);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be($"{KSqlTypes.Array}<{KSqlTypes.Varchar}>");
+    }
+
+    [Test]
+    public void Translate_IEnumerable()
+    {
+      //Arrange
+      var type = typeof(IEnumerable<string>);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be($"{KSqlTypes.Array}<{KSqlTypes.Varchar}>");
+    }
+
+    [Test]
+    public void Translate_NestedMapInArray()
+    {
+      //Arrange
+      var type = typeof(IDictionary<string, int>[]);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be($"{KSqlTypes.Array}<{KSqlTypes.Map}<{KSqlTypes.Varchar}, {KSqlTypes.Int}>>");
+    }
+
+    [Test]
+    public void Translate_NestedArrayInMap()
+    {
+      //Arrange
+      var type = typeof(IDictionary<string, int[]>);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be($"{KSqlTypes.Map}<{KSqlTypes.Varchar}, {KSqlTypes.Array}<{KSqlTypes.Int}>>");
+    }
+
+    [Test]
+    public void Translate_BytesType()
+    {
+      //Arrange
+      var type = typeof(byte[]);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be(KSqlTypes.Bytes);
+    }
+
+    [Test]
+    public void Translate_GuidType()
+    {
+      //Arrange
+      var type = typeof(Guid);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be(KSqlTypes.Varchar);
+    }
+
+    [Test]
+    public void Translate_DateTimeType()
+    {
+      //Arrange
+      var type = typeof(DateTime);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be(KSqlTypes.Date);
+    }
+
+    [Test]
+    public void Translate_TimeSpanType()
+    {
+      //Arrange
+      var type = typeof(TimeSpan);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be(KSqlTypes.Time);
+    }
+
+    [Test]
+    public void Translate_DateTimeOffsetType()
+    {
+      //Arrange
+      var type = typeof(DateTimeOffset);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be(KSqlTypes.Timestamp);
+    }
+
+    [Test]
+    public void Translate_EnumType()
+    {
+      //Arrange
+      var type = typeof(ConsoleColor);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be(KSqlTypes.Varchar);
+    }
+
+    [Test]
+    public void Translate_ClassType()
+    {
+      //Arrange
+      var type = typeof(StringBuilder);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be(nameof(StringBuilder).ToUpper());
+    }
+
+    [Test]
+    public void Translate_StructType()
+    {
+      //Arrange
+      var type = typeof(Point);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be(nameof(Point).ToUpper());
+    }
+
+    [Struct]
+    private class Decorated
+    {
+      public required int Foo { get; set; }
+      public required string Bzr { get; set; }
+    }
+
+    [Test]
+    public void Translate_StructAttributeType()
+    {
+      //Arrange
+      var type = typeof(Decorated);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be($"{KSqlTypes.Struct}<{nameof(Decorated.Foo)} {KSqlTypes.Int}, {nameof(Decorated.Bzr)} {KSqlTypes.Varchar}>");
+    }
+
+    [Struct]
+    private record IoTSensor
+    {
+      [Headers("abc")]
+      public byte[] Header { get; set; } = null!;
+    }
+
+    [Test]
+    public void Translate_HeadersAttributeType()
+    {
+      //Arrange
+      var type = typeof(IoTSensor);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be($"{KSqlTypes.Struct}<{nameof(IoTSensor.Header)} {KSqlTypes.Bytes} HEADER('abc')>");
+    }
+
+    [Struct]
+    private record Account
+    {
+      [Decimal(1,1)]
+      public decimal Amount { get; set; }
+    }
+
+    [Test]
+    public void Translate_DecimalAttributeType()
+    {
+      //Arrange
+      var type = typeof(Account);
+
+      //Act
+      string ksqlType = KSqlTypeTranslator.Translate(type);
+
+      //Assert
+      ksqlType.Should().Be($"{KSqlTypes.Struct}<{nameof(Account.Amount)} {KSqlTypes.Decimal}(1,1)>");
+    }
+  }
+}

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/Providers/EntityProviderTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/Providers/EntityProviderTests.cs
@@ -1,0 +1,91 @@
+using FluentAssertions;
+using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
+using ksqlDb.RestApi.Client.KSql.RestApi.Statements.Providers;
+using NUnit.Framework;
+using static ksqlDB.RestApi.Client.KSql.RestApi.Enums.IdentifierEscaping;
+
+namespace ksqlDb.RestApi.Client.Tests.KSql.RestApi.Statements.Providers
+{
+  public class EntityProviderTests
+  {
+    private readonly EntityProvider entityProvider = new();
+
+    private record TestType;
+
+    internal static IEnumerable<(IdentifierEscaping, string)> GetEntityNameTestCases()
+    {
+      yield return (Never, nameof(TestType));
+      yield return (Keywords, nameof(TestType));
+      yield return (Always, $"`{nameof(TestType)}`");
+    }
+
+    [TestCaseSource(nameof(GetEntityNameTestCases))]
+    public void GetName_ShouldNotPluralizeEntityName((IdentifierEscaping escaping, string expected) testCase)
+    {
+      //Arrange
+      var (escaping, expected) = testCase;
+      var properties = new EntityProperties
+      {
+        ShouldPluralizeEntityName = false,
+        IdentifierEscaping = escaping
+      };
+
+      //Act
+      var entityName = entityProvider.GetName<TestType>(properties);
+
+      //Assert
+      entityName.Should().Be(expected);
+    }
+
+    internal static IEnumerable<(IdentifierEscaping, string)> GetPluralizedEntityNameTestCases()
+    {
+      yield return (Never, $"{nameof(TestType)}s");
+      yield return (Keywords, $"{nameof(TestType)}s");
+      yield return (Always, $"`{nameof(TestType)}s`");
+    }
+
+    [TestCaseSource(nameof(GetPluralizedEntityNameTestCases))]
+    public void GetName_ShouldPluralizeEntityName((IdentifierEscaping escaping, string expected) testCase)
+    {
+      //Arrange
+      var (escaping, expected) = testCase;
+      var properties = new EntityProperties
+      {
+        ShouldPluralizeEntityName = true,
+        IdentifierEscaping = escaping
+      };
+
+      //Act
+      var entityName = entityProvider.GetName<TestType>(properties);
+
+      //Assert
+      entityName.Should().Be(expected);
+    }
+
+    internal static IEnumerable<(IdentifierEscaping, string)> GetOverridenEntityNameTestCases()
+    {
+      yield return (Never, "Values");
+      yield return (Keywords, "`Values`");
+      yield return (Always, "`Values`");
+    }
+
+    [TestCaseSource(nameof(GetOverridenEntityNameTestCases))]
+    public void GetName_GetOverridenEntityName((IdentifierEscaping escaping, string expected) testCase)
+    {
+      //Arrange
+      var (escaping, expected) = testCase;
+      var properties = new EntityProperties
+      {
+        EntityName = "Values",
+        IdentifierEscaping = escaping
+      };
+
+      //Act
+      var entityName = entityProvider.GetName<TestType>(properties);
+
+      //Assert
+      entityName.Should().Be(expected);
+    }
+  }
+}

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/Providers/EntityProviderTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/Providers/EntityProviderTests.cs
@@ -21,7 +21,7 @@ namespace ksqlDb.RestApi.Client.Tests.KSql.RestApi.Statements.Providers
     }
 
     [TestCaseSource(nameof(GetEntityNameTestCases))]
-    public void GetName_ShouldNotPluralizeEntityName((IdentifierEscaping escaping, string expected) testCase)
+    public void GetFormattedName_ShouldNotPluralizeEntityName((IdentifierEscaping escaping, string expected) testCase)
     {
       //Arrange
       var (escaping, expected) = testCase;
@@ -32,7 +32,7 @@ namespace ksqlDb.RestApi.Client.Tests.KSql.RestApi.Statements.Providers
       };
 
       //Act
-      var entityName = entityProvider.GetName<TestType>(properties);
+      var entityName = entityProvider.GetFormattedName<TestType>(properties);
 
       //Assert
       entityName.Should().Be(expected);
@@ -46,7 +46,7 @@ namespace ksqlDb.RestApi.Client.Tests.KSql.RestApi.Statements.Providers
     }
 
     [TestCaseSource(nameof(GetPluralizedEntityNameTestCases))]
-    public void GetName_ShouldPluralizeEntityName((IdentifierEscaping escaping, string expected) testCase)
+    public void GetFormattedName_ShouldPluralizeEntityName((IdentifierEscaping escaping, string expected) testCase)
     {
       //Arrange
       var (escaping, expected) = testCase;
@@ -57,7 +57,7 @@ namespace ksqlDb.RestApi.Client.Tests.KSql.RestApi.Statements.Providers
       };
 
       //Act
-      var entityName = entityProvider.GetName<TestType>(properties);
+      var entityName = entityProvider.GetFormattedName<TestType>(properties);
 
       //Assert
       entityName.Should().Be(expected);
@@ -71,7 +71,7 @@ namespace ksqlDb.RestApi.Client.Tests.KSql.RestApi.Statements.Providers
     }
 
     [TestCaseSource(nameof(GetOverridenEntityNameTestCases))]
-    public void GetName_GetOverridenEntityName((IdentifierEscaping escaping, string expected) testCase)
+    public void GetFormattedName_GetOverridenEntityName((IdentifierEscaping escaping, string expected) testCase)
     {
       //Arrange
       var (escaping, expected) = testCase;
@@ -82,10 +82,50 @@ namespace ksqlDb.RestApi.Client.Tests.KSql.RestApi.Statements.Providers
       };
 
       //Act
-      var entityName = entityProvider.GetName<TestType>(properties);
+      var entityName = entityProvider.GetFormattedName<TestType>(properties);
 
       //Assert
       entityName.Should().Be(expected);
+    }
+
+    internal record TestType<T>
+    {
+      internal T Foo { get; init; } = default!;
+    }
+
+    [TestCaseSource(nameof(GetEntityNameTestCases))]
+    public void GetFormattedName_FromGenericType((IdentifierEscaping escaping, string expected) testCase)
+    {
+      //Arrange
+      var (escaping, expected) = testCase;
+      var properties = new EntityProperties
+      {
+        ShouldPluralizeEntityName = false,
+        IdentifierEscaping = escaping
+      };
+
+      //Act
+      var entityName = entityProvider.GetFormattedName<TestType<string>>(properties);
+
+      //Assert
+      entityName.Should().Be(expected);
+    }
+
+    [Test]
+    public void GetFormattedName_WithFormatter()
+    {
+      //Arrange
+      var properties = new EntityProperties
+      {
+        ShouldPluralizeEntityName = false,
+        IdentifierEscaping = Always
+      };
+
+      //Act
+      var entityName = entityProvider.GetFormattedName<TestType<string>>(properties, (_, identifierEscaping) => "formatted");
+
+      //Assert
+      entityName.Should().Be("formatted");
     }
   }
 }

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/StatementTemplatesTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/StatementTemplatesTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 using NUnit.Framework;
 
@@ -113,6 +113,19 @@ public class StatementTemplatesTests
 
     //Assert
     statement.Should().Be($"DROP CONNECTOR {connectorName};");
+  }
+
+  [Test]
+  public void DropConnectorIfExists()
+  {
+    //Arrange
+    string connectorName = "CONNECTOR_NAME";
+
+    //Act
+    var statement = StatementTemplates.DropConnectorIfExists(connectorName);
+
+    //Assert
+    statement.Should().Be($"DROP CONNECTOR IF EXISTS {connectorName};");
   }
 
   [Test]

--- a/docs/breaking_changes.md
+++ b/docs/breaking_changes.md
@@ -4,6 +4,7 @@
 - `TypeProperties` - removed generic type argument and added a base type `EntityProperties`. Additionally, changed from a class to a record type.
 - the above change affected the argument for the `IKSqlDbRestApiClient.CreateTypeAsync<T>(TypeProperties typeProperties)`
 - `IEntityCreationProperties` was replaced with `IEntityProperties`
+- ksqlDB types are no longer **automatically capitalized**
 
 Updated package references:
 ```xml

--- a/docs/breaking_changes.md
+++ b/docs/breaking_changes.md
@@ -1,5 +1,18 @@
 # Breaking changes
 
+# v4.0.0
+- `TypeProperties` - removed generic type argument and added a base type `EntityProperties`. Additionally, changed from a class to a record type.
+- the above change affected the argument for the `IKSqlDbRestApiClient.CreateTypeAsync<T>(TypeProperties typeProperties)`
+- `IEntityCreationProperties` was replaced with `IEntityProperties`
+
+Updated package references:
+```xml
+<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+<PackageReference Include="System.Text.Json" Version="8.0.2" />
+```
+
 # v3.0.0
 - The **accessibility modifier** of the `IsDisposed` property in `AsyncDisposableObject` was modified from public to internal.
 

--- a/docs/statements.md
+++ b/docs/statements.md
@@ -674,6 +674,24 @@ DROP TYPE EventCategory;
 DROP TYPE IF EXISTS EventCategory;
 ```
 
+With the `DropTypeAsync` overload, the type name can be automatically inferred from the generic type argument.
+
+```C#
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
+
+var properties = new DropTypeProperties
+{
+  ShouldPluralizeEntityName = false,
+  IdentifierEscaping = IdentifierEscaping.Always
+};
+
+var response = await restApiClient.DropTypeAsync<EventCategory>(properties);
+```
+
+```SQL
+DROP TYPE `EventCategory`;
+```
+
 ### Drop a stream
 **v1.0.0**
 
@@ -710,6 +728,38 @@ Parameters:
 `useIfExistsClause` - If the IF EXISTS clause is present, the statement doesn't fail if the stream doesn't exist.
 
 `deleteTopic` - If the DELETE TOPIC clause is present, the stream's source topic is marked for deletion.
+
+#### DropEntityProperties
+
+The `DropFromItemProperties` class is used to configure dropping entitities, such as streams or tables in ksqlDB.
+In the provided example, it's instantiated with specific properties: using "IF EXISTS" clause, deleting the associated topic,
+not pluralizing the entity name, and always escaping identifiers. The `from-item` name is inferred from the generic type argument.
+This configuration is then used to drop a table named `TestTable` and a stream named `TestStream` via the ksqlDB REST API client.
+
+```C#
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
+
+class TestTable;
+class TestStream;
+
+var properties = new DropFromItemProperties
+{
+  UseIfExistsClause = true,
+  DeleteTopic = true,
+  ShouldPluralizeEntityName = false,
+  IdentifierEscaping = IdentifierEscaping.Always
+};
+
+//Act
+var response1 = await ksqlDbRestApiClient.DropTableAsync<TestTable>(properties);
+var response2 = await ksqlDbRestApiClient.DropStreamAsync<TestStream>(properties);
+```
+
+The resulting KSQL commands executed are: 
+```SQL
+DROP TABLE IF EXISTS `TestTable` DELETE TOPIC;
+DROP STREAM IF EXISTS `TestStream` DELETE TOPIC;
+```
 
 ### PartitionBy
 **v1.0.0**

--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -2,7 +2,7 @@
 
 # 3.7.0
 - introduced new overloads for dropping entities: `DropTableAsync`, `DropTypeAsync`, and `DropStreamAsync` in `KSqlDbRestApiClient`. These overloads now accept an argument `DropFromItemProperties`, providing more flexibility in configuring the drop operations.
-- extracted `IKSqlDbDropRestApiClient` interface from `IKSqlDbRestApiClient`
+- extracted `IKSqlDbDropRestApiClient` and `IKSqlDbCreateRestApiClient` interfaces from `IKSqlDbRestApiClient`
 - see also [breakingchanges.md](https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/docs/breaking_changes.md#v400)
 
 # 3.6.2

--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -1,5 +1,9 @@
 # ksqlDB.RestApi.Client
 
+# 3.7.0
+- introduced new overloads for dropping entities: `DropTableAsync`, `DropTypeAsync`, and `DropStreamAsync` in `KSqlDbRestApiClient`. These overloads now accept an argument `DropFromItemProperties`, providing more flexibility in configuring the drop operations.
+- extracted `IKSqlDbDropRestApiClient` interface from `IKSqlDbRestApiClient`
+
 # 3.6.1
 - fix usage of `JsonPropertyName` when creating insert statements (since 3.6.0) #59 (contributed by @mrt181)
 

--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -4,9 +4,9 @@
 - introduced new overloads for dropping entities: `DropTableAsync`, `DropTypeAsync`, and `DropStreamAsync` in `KSqlDbRestApiClient`. These overloads now accept an argument `DropFromItemProperties`, providing more flexibility in configuring the drop operations.
 - extracted `IKSqlDbDropRestApiClient` interface from `IKSqlDbRestApiClient`
 - see also [breakingchanges.md](https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/docs/breaking_changes.md#v400)
-- 
+
 # 3.6.2
-- JsonPropertyName and PseudoColumn attributes are taken into account when setting column names in LINQ column selection syntax #61 (contributed by @mrt181)
+- `JsonPropertyName` and `PseudoColumn` attributes are taken into account when setting column names in LINQ column selection syntax #61 (contributed by @mrt181)
 
 # 3.6.1
 - fix usage of `JsonPropertyName` when creating insert statements (since 3.6.0) #59 (contributed by @mrt181)

--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -3,7 +3,8 @@
 # 3.7.0
 - introduced new overloads for dropping entities: `DropTableAsync`, `DropTypeAsync`, and `DropStreamAsync` in `KSqlDbRestApiClient`. These overloads now accept an argument `DropFromItemProperties`, providing more flexibility in configuring the drop operations.
 - extracted `IKSqlDbDropRestApiClient` interface from `IKSqlDbRestApiClient`
-
+- see also [breakingchanges.md](https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/docs/breaking_changes.md#v400)
+- 
 # 3.6.2
 - JsonPropertyName and PseudoColumn attributes are taken into account when setting column names in LINQ column selection syntax #61 (contributed by @mrt181)
 

--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -1,6 +1,6 @@
 # ksqlDB.RestApi.Client
 
-# 3.7.0
+# 4.0.0-rc.2
 - introduced new overloads for dropping entities: `DropTableAsync`, `DropTypeAsync`, and `DropStreamAsync` in `KSqlDbRestApiClient`. These overloads now accept an argument `DropFromItemProperties`, providing more flexibility in configuring the drop operations.
 - extracted `IKSqlDbDropRestApiClient` and `IKSqlDbCreateRestApiClient` interfaces from `IKSqlDbRestApiClient`
 - see also [breakingchanges.md](https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/docs/breaking_changes.md#v400)

--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -4,6 +4,9 @@
 - introduced new overloads for dropping entities: `DropTableAsync`, `DropTypeAsync`, and `DropStreamAsync` in `KSqlDbRestApiClient`. These overloads now accept an argument `DropFromItemProperties`, providing more flexibility in configuring the drop operations.
 - extracted `IKSqlDbDropRestApiClient` interface from `IKSqlDbRestApiClient`
 
+# 3.6.2
+- JsonPropertyName and PseudoColumn attributes are taken into account when setting column names in LINQ column selection syntax #61 (contributed by @mrt181)
+
 # 3.6.1
 - fix usage of `JsonPropertyName` when creating insert statements (since 3.6.0) #59 (contributed by @mrt181)
 

--- a/ksqlDb.RestApi.Client/KSql/Query/KSqlQueryGenerator.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/KSqlQueryGenerator.cs
@@ -43,11 +43,11 @@ internal class KSqlQueryGenerator(KSqlDBContextOptions options) : ExpressionVisi
       ShouldPluralizeEntityName = options.ShouldPluralizeFromItemName,
       IdentifierEscaping = queryMetadata.IdentifierEscaping
     };
-    var fromItemName = entityProvider.GetFormattedName(fromTableType, entityProperties);
+    var fromItemName = entityProvider.GetFormattedName(fromItemType, entityProperties);
 
     queryContext.AutoOffsetReset = autoOffsetReset;
 
-    queryMetadata.FromItemType = fromTableType;
+    queryMetadata.FromItemType = fromItemType;
 
     if (joins.Count > 0)
     {
@@ -169,7 +169,7 @@ internal class KSqlQueryGenerator(KSqlDBContextOptions options) : ExpressionVisi
     return expression;
   }
 
-  private Type fromTableType;
+  private Type fromItemType;
 
   protected override Expression VisitConstant(ConstantExpression constantExpression)
   {
@@ -181,7 +181,7 @@ internal class KSqlQueryGenerator(KSqlDBContextOptions options) : ExpressionVisi
 
     if (kStreamSetType != null)
     {
-      fromTableType = ((KSet)constantExpression.Value)?.ElementType;
+      fromItemType = ((KSet)constantExpression.Value)?.ElementType;
     }
 
     return constantExpression;

--- a/ksqlDb.RestApi.Client/KSql/Query/KSqlQueryGenerator.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/KSqlQueryGenerator.cs
@@ -12,24 +12,20 @@ using ksqlDB.RestApi.Client.KSql.Query.Visitors;
 using ksqlDB.RestApi.Client.KSql.Query.Windows;
 using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
 using ksqlDb.RestApi.Client.KSql.RestApi.Parsers;
-using Pluralize.NET;
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
+using ksqlDb.RestApi.Client.KSql.RestApi.Statements.Providers;
 
 namespace ksqlDB.RestApi.Client.KSql.Query;
 
-internal class KSqlQueryGenerator : ExpressionVisitor, IKSqlQueryGenerator
+internal class KSqlQueryGenerator(KSqlDBContextOptions options) : ExpressionVisitor, IKSqlQueryGenerator
 {
-  private readonly KSqlDBContextOptions options;
-  private static readonly Pluralizer EnglishPluralizationService = new();
+  private readonly KSqlDBContextOptions options = options ?? throw new ArgumentNullException(nameof(options));
+  private readonly EntityProvider entityProvider = new();
 
   private KSqlVisitor kSqlVisitor;
   private KSqlQueryMetadata queryMetadata;
 
   public bool ShouldEmitChanges { get; set; } = true;
-
-  public KSqlQueryGenerator(KSqlDBContextOptions options)
-  {
-    this.options = options ?? throw new ArgumentNullException(nameof(options));
-  }
 
   public string BuildKSql(Expression expression, QueryContext queryContext)
   {
@@ -41,7 +37,13 @@ internal class KSqlQueryGenerator : ExpressionVisitor, IKSqlQueryGenerator
 
     Visit(expression);
 
-    var finalFromItemName = IdentifierUtil.Format(InterceptFromItemName(queryContext.FromItemName ?? fromItemName), queryMetadata.IdentifierEscaping);
+    var entityProperties = new EntityProperties
+    {
+      EntityName = queryContext.FromItemName,
+      ShouldPluralizeEntityName = options.ShouldPluralizeFromItemName,
+      IdentifierEscaping = queryMetadata.IdentifierEscaping
+    };
+    var fromItemName = entityProvider.GetFormattedName(fromTableType, entityProperties);
 
     queryContext.AutoOffsetReset = autoOffsetReset;
 
@@ -51,7 +53,7 @@ internal class KSqlQueryGenerator : ExpressionVisitor, IKSqlQueryGenerator
     {
       var fromItem = joins.Last();
 
-      var lambdaExpression = StripQuotes(fromItem.Item2.ToArray()[1]) as LambdaExpression;
+      var lambdaExpression = (LambdaExpression)StripQuotes(fromItem.Item2.ToArray()[1]);
       var alias = lambdaExpression.Parameters[0].Name;
 
       var fromTable = new FromItem
@@ -62,7 +64,7 @@ internal class KSqlQueryGenerator : ExpressionVisitor, IKSqlQueryGenerator
 
       queryMetadata.Joins = GetFromItems(joins, fromTable, queryMetadata.IdentifierEscaping);
 
-      var joinsVisitor = new KSqlJoinsVisitor(kSqlVisitor.StringBuilder, options, new QueryContext { FromItemName = finalFromItemName }, queryMetadata);
+      var joinsVisitor = new KSqlJoinsVisitor(kSqlVisitor.StringBuilder, options, new QueryContext { FromItemName = fromItemName }, queryMetadata);
 
       joinsVisitor.VisitJoinTable(joins);
     }
@@ -75,7 +77,7 @@ internal class KSqlQueryGenerator : ExpressionVisitor, IKSqlQueryGenerator
       else
         kSqlVisitor.Append("*");
 
-      kSqlVisitor.Append($" FROM {finalFromItemName}");
+      kSqlVisitor.Append($" FROM {fromItemName}");
     }
 
     bool isFirst = true;
@@ -149,14 +151,6 @@ internal class KSqlQueryGenerator : ExpressionVisitor, IKSqlQueryGenerator
     return (TimeWindows)constantExpression.Value;
   }
 
-  protected virtual string InterceptFromItemName(string value)
-  {
-    if (options.ShouldPluralizeFromItemName)
-      return EnglishPluralizationService.Pluralize(value);
-
-    return value;
-  }
-
   public override Expression Visit(Expression expression)
   {
     if (expression == null)
@@ -175,8 +169,6 @@ internal class KSqlQueryGenerator : ExpressionVisitor, IKSqlQueryGenerator
     return expression;
   }
 
-  private string fromItemName;
-
   private Type fromTableType;
 
   protected override Expression VisitConstant(ConstantExpression constantExpression)
@@ -190,8 +182,6 @@ internal class KSqlQueryGenerator : ExpressionVisitor, IKSqlQueryGenerator
     if (kStreamSetType != null)
     {
       fromTableType = ((KSet)constantExpression.Value)?.ElementType;
-
-      fromItemName = fromTableType.ExtractTypeName();
     }
 
     return constantExpression;
@@ -336,7 +326,7 @@ internal class KSqlQueryGenerator : ExpressionVisitor, IKSqlQueryGenerator
     return joins.Select(c =>
       {
         var items = c.Item2.ToArray();
-        var lambdaExpression = StripQuotes(items[2]) as LambdaExpression;
+        var lambdaExpression = (LambdaExpression)StripQuotes(items[2]);
         var alias = lambdaExpression.Parameters[0].Name;
 
         var type = items[0].Type.GenericTypeArguments[0];

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Generators/TypeGenerator.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Generators/TypeGenerator.cs
@@ -3,15 +3,12 @@ using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
 using ksqlDb.RestApi.Client.KSql.RestApi.Parsers;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
-using ksqlDb.RestApi.Client.KSql.RestApi.Statements.Providers;
 using static ksqlDB.RestApi.Client.KSql.RestApi.Enums.IdentifierEscaping;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Generators;
 
 internal class TypeGenerator : CreateEntityStatement
 {
-  private static readonly EntityProvider EntityProvider = new();
-
   internal string Print<T>(TypeProperties properties)
   {
     StringBuilder stringBuilder = new();

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Generators/TypeGenerator.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Generators/TypeGenerator.cs
@@ -7,12 +7,12 @@ using static ksqlDB.RestApi.Client.KSql.RestApi.Enums.IdentifierEscaping;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Generators;
 
-internal class TypeGenerator : CreateEntityStatement
+internal sealed class TypeGenerator : EntityInfo
 {
   internal string Print<T>(TypeProperties properties)
   {
     StringBuilder stringBuilder = new();
-    var typeName = EntityProvider.GetFormattedName<T>(properties, EscapeName).ToUpper();
+    var typeName = EntityProvider.GetFormattedName<T>(properties, EscapeName);
     stringBuilder.Append($"CREATE TYPE {typeName} AS STRUCT<");
 
     PrintProperties<T>(stringBuilder, properties.IdentifierEscaping);
@@ -30,9 +30,9 @@ internal class TypeGenerator : CreateEntityStatement
     {
       var type = GetMemberType(memberInfo);
 
-      var ksqlType = CreateEntity.KSqlTypeTranslator(type, escaping);
+      var ksqlType = KSqlTypeTranslator.Translate(type, escaping);
 
-      var columnDefinition = $"{EscapeName(memberInfo.Name, escaping)} {ksqlType}{CreateEntity.ExploreAttributes(memberInfo, type)}";
+      var columnDefinition = $"{EscapeName(memberInfo.Name, escaping)} {ksqlType}{KSqlTypeTranslator.ExploreAttributes(memberInfo, type)}";
       ksqlProperties.Add(columnDefinition);
     }
 

--- a/ksqlDb.RestApi.Client/KSql/RestApi/IKSqlDbCreateRestApiClient.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/IKSqlDbCreateRestApiClient.cs
@@ -1,0 +1,119 @@
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements;
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
+
+namespace ksqlDB.RestApi.Client.KSql.RestApi
+{
+  public interface IKSqlDbCreateRestApiClient
+  {
+    /// <summary>
+    /// Create a new stream with the specified columns and properties.
+    /// </summary>
+    /// <typeparam name="T">The type that represents the stream.</typeparam>
+    /// <param name="creationMetadata">Stream properties, specify details about your stream by using the WITH clause.</param>
+    /// <param name="ifNotExists">If the IF NOT EXISTS clause is present, the statement won't fail if a stream with the same name already exists.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>Http response object.</returns>
+    Task<HttpResponseMessage> CreateStreamAsync<T>(EntityCreationMetadata creationMetadata, bool ifNotExists = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create a new stream or replace an existing one with the specified columns and properties.
+    /// </summary>
+    /// <typeparam name="T">The type that represents the stream.</typeparam>
+    /// <param name="creationMetadata">Stream properties, specify details about your stream by using the WITH clause.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>Http response object.</returns>
+    ///
+    Task<HttpResponseMessage> CreateOrReplaceStreamAsync<T>(EntityCreationMetadata creationMetadata, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create a new read-only source stream with the specified columns and properties.
+    /// </summary>
+    /// <typeparam name="T">The type that represents the stream.</typeparam>
+    /// <param name="creationMetadata">Stream properties, specify details about your stream by using the WITH clause.</param>
+    /// <param name="ifNotExists">If the IF NOT EXISTS clause is present, the statement won't fail if a stream with the same name already exists.</param>
+    /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+    /// <returns>Http response object.</returns>
+    Task<HttpResponseMessage> CreateSourceStreamAsync<T>(EntityCreationMetadata creationMetadata, bool ifNotExists = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create a new table with the specified columns and properties.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="creationMetadata">Table properties, specify details about your table by using the WITH clause.</param>
+    /// <param name="ifNotExists">If the IF NOT EXISTS clause is present, the statement won't fail if a table with the same name already exists.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>Http response object.</returns>
+    Task<HttpResponseMessage> CreateTableAsync<T>(EntityCreationMetadata creationMetadata, bool ifNotExists = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create a new read-only table with the specified columns and properties.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="creationMetadata">Table properties, specify details about your table by using the WITH clause.</param>
+    /// <param name="ifNotExists">If the IF NOT EXISTS clause is present, the statement won't fail if a table with the same name already exists.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>Http response object.</returns>
+    Task<HttpResponseMessage> CreateSourceTableAsync<T>(EntityCreationMetadata creationMetadata, bool ifNotExists = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create a new table or replace an existing one with the specified columns and properties.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="creationMetadata">Table properties, specify details about your table by using the WITH clause.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>Http response object.</returns>
+    Task<HttpResponseMessage> CreateOrReplaceTableAsync<T>(EntityCreationMetadata creationMetadata, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create a new source connector in the Kafka Connect cluster with the configuration passed in the config parameter.
+    /// </summary>
+    /// <param name="config">Configuration passed into the WITH clause.</param>
+    /// <param name="connectorName">Name of the connector to create.</param>
+    /// <param name="ifNotExists">If the IF NOT EXISTS clause is present, the statement does not fail if a connector with the supplied name already exists.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<HttpResponseMessage> CreateSourceConnectorAsync(IDictionary<string, string> config, string connectorName, bool ifNotExists = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create a new sink connector in the Kafka Connect cluster with the configuration passed in the config parameter.
+    /// </summary>
+    /// <param name="config">Configuration passed into the WITH clause.</param>
+    /// <param name="connectorName">Name of the connector to create.</param>
+    /// <param name="ifNotExists">If the IF NOT EXISTS clause is present, the statement does not fail if a connector with the supplied name already exists.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<HttpResponseMessage> CreateSinkConnectorAsync(IDictionary<string, string> config, string connectorName, bool ifNotExists = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create an alias for a complex type declaration.
+    /// The CREATE TYPE statement registers a type alias directly in KSQL. Any types registered by using this command can be leveraged in future statements. The CREATE TYPE statement works in interactive and headless modes.
+    /// Any attempt to register the same type twice, without a corresponding DROP TYPE statement, will fail.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+    /// <returns>Http response object.</returns>
+    Task<HttpResponseMessage> CreateTypeAsync<T>(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create an alias for a complex type declaration.
+    /// The CREATE TYPE statement registers a type alias directly in KSQL. Any types registered by using this command can be leveraged in future statements. The CREATE TYPE statement works in interactive and headless modes.
+    /// Any attempt to register the same type twice, without a corresponding DROP TYPE statement, will fail.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="typeName">Optional name of the type. Otherwise, the type name is inferred from the generic type name.</param>
+    /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+    /// <returns>Http response object.</returns>
+    Task<HttpResponseMessage> CreateTypeAsync<T>(string typeName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create an alias for a complex type declaration.
+    /// The CREATE TYPE statement registers a type alias directly in KSQL. Any types registered by using this command can be leveraged in future statements. The CREATE TYPE statement works in interactive and headless modes.
+    /// Any attempt to register the same type twice, without a corresponding DROP TYPE statement, will fail.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="properties">Type configuration</param>
+    /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+    /// <returns>Http response object.</returns>
+    Task<HttpResponseMessage> CreateTypeAsync<T>(TypeProperties properties, CancellationToken cancellationToken = default);
+  }
+}

--- a/ksqlDb.RestApi.Client/KSql/RestApi/IKSqlDbDropRestApiClient.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/IKSqlDbDropRestApiClient.cs
@@ -1,0 +1,106 @@
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
+
+namespace ksqlDB.RestApi.Client.KSql.RestApi
+{
+  public interface IKSqlDbDropRestApiClient
+  {
+    /// <summary>
+    /// Drop a connector and delete it from the Connect cluster. The topics associated with this cluster are not deleted by this command. The statement doesn't fail if the connector doesn't exist.
+    /// </summary>
+    /// <param name="connectorName">Name of the connector to drop.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<HttpResponseMessage> DropConnectorIfExistsAsync(string connectorName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Drop a connector and delete it from the Connect cluster. The topics associated with this cluster are not deleted by this command. The statement fails if the connector doesn't exist.
+    /// </summary>
+    /// <param name="connectorName">Name of the connector to drop.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<HttpResponseMessage> DropConnectorAsync(string connectorName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Drops an existing table.
+    /// DROP TABLE [IF EXISTS] table_name [DELETE TOPIC];
+    /// </summary>
+    /// <param name="tableName">Name of the table to delete.</param>
+    /// <param name="useIfExistsClause">If the IF EXISTS clause is present, the statement doesn't fail if the table doesn't exist.</param>
+    /// <param name="deleteTopic">If the DELETE TOPIC clause is present, the table's source topic is marked for deletion.</param>
+    /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+    /// <returns></returns>
+    Task<HttpResponseMessage> DropTableAsync(string tableName, bool useIfExistsClause, bool deleteTopic, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Drops an existing table.
+    /// DROP TABLE table_name;
+    /// </summary>
+    /// <param name="tableName">Name of the table to delete.</param>
+    /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+    /// <returns></returns>
+    Task<HttpResponseMessage> DropTableAsync(string tableName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Drops an existing table.
+    /// DROP TABLE [IF EXISTS] table_name [DELETE TOPIC];
+    /// </summary>
+    /// <typeparam name="T">The type that represents the table.</typeparam>
+    /// <param name="dropFromItemProperties">Configuration for dropping the table.</param>
+    /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+    /// <returns></returns>
+    Task<HttpResponseMessage> DropTableAsync<T>(DropFromItemProperties dropFromItemProperties, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a type alias from ksqlDB. This statement doesn't fail if the type is in use in active queries or user-defined functions.
+    /// </summary>
+    /// <param name="typeName">Name of the type to remove.</param>
+    /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+    /// <returns>Http response object.</returns>
+    Task<HttpResponseMessage> DropTypeAsync(string typeName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a type alias from ksqlDB. This statement doesn't fail if the type is in use in active queries or user-defined functions. The statement doesn't fail if the type doesn't exist.
+    /// </summary>
+    /// <param name="typeName">Name of the type to remove.</param>
+    /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+    /// <returns>Http response object.</returns>
+    Task<HttpResponseMessage> DropTypeIfExistsAsync(string typeName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a type alias from ksqlDB. This statement doesn't fail if the type is in use in active queries or user-defined functions.
+    /// </summary>
+    /// <param name="dropTypeProperties">Configuration for dropping the type.</param>
+    /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+    /// <returns>Http response object.</returns>
+    Task<HttpResponseMessage> DropTypeAsync<T>(DropTypeProperties dropTypeProperties, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Drops an existing stream.
+    /// DROP STREAM [IF EXISTS] stream_name [DELETE TOPIC];
+    /// </summary>
+    /// <param name="dropFromItemProperties">Configuration for dropping the stream.</param>
+    /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+    /// <returns></returns>
+    Task<HttpResponseMessage> DropStreamAsync<T>(DropFromItemProperties dropFromItemProperties, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Drops an existing stream.
+    /// DROP STREAM [IF EXISTS] stream_name [DELETE TOPIC];
+    /// </summary>
+    /// <param name="streamName">Name of the stream to delete.</param>
+    /// <param name="useIfExistsClause">If the IF EXISTS clause is present, the statement doesn't fail if the stream doesn't exist.</param>
+    /// <param name="deleteTopic">If the DELETE TOPIC clause is present, the stream's source topic is marked for deletion.</param>
+    /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+    /// <returns></returns>
+    Task<HttpResponseMessage> DropStreamAsync(string streamName, bool useIfExistsClause, bool deleteTopic, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Drops an existing stream.
+    /// DROP STREAM stream_name;
+    /// </summary>
+    /// <param name="streamName">Name of the stream to delete.</param>
+    /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+    /// <returns></returns>
+    Task<HttpResponseMessage> DropStreamAsync(string streamName, CancellationToken cancellationToken = default);
+  }
+}

--- a/ksqlDb.RestApi.Client/KSql/RestApi/IKSqlDbRestApiClient.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/IKSqlDbRestApiClient.cs
@@ -10,7 +10,7 @@ using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi;
 
-public interface IKSqlDbRestApiClient : IKSqlDbAssertionsRestApiClient, IKSqlDbDropRestApiClient
+public interface IKSqlDbRestApiClient : IKSqlDbCreateRestApiClient, IKSqlDbAssertionsRestApiClient, IKSqlDbDropRestApiClient
 {
   /// <summary>
   /// Sets Basic HTTP authentication mechanism.
@@ -26,66 +26,6 @@ public interface IKSqlDbRestApiClient : IKSqlDbAssertionsRestApiClient, IKSqlDbD
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
   Task<HttpResponseMessage> ExecuteStatementAsync(KSqlDbStatement ksqlDbStatement, CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Create a new stream with the specified columns and properties.
-  /// </summary>
-  /// <typeparam name="T">The type that represents the stream.</typeparam>
-  /// <param name="creationMetadata">Stream properties, specify details about your stream by using the WITH clause.</param>
-  /// <param name="ifNotExists">If the IF NOT EXISTS clause is present, the statement won't fail if a stream with the same name already exists.</param>
-  /// <param name="cancellationToken"></param>
-  /// <returns>Http response object.</returns>
-  Task<HttpResponseMessage> CreateStreamAsync<T>(EntityCreationMetadata creationMetadata, bool ifNotExists = false, CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Create a new stream or replace an existing one with the specified columns and properties.
-  /// </summary>
-  /// <typeparam name="T">The type that represents the stream.</typeparam>
-  /// <param name="creationMetadata">Stream properties, specify details about your stream by using the WITH clause.</param>
-  /// <param name="cancellationToken"></param>
-  /// <returns>Http response object.</returns>
-  ///
-  Task<HttpResponseMessage> CreateOrReplaceStreamAsync<T>(EntityCreationMetadata creationMetadata, CancellationToken cancellationToken = default);
-
-
-  /// <summary>
-  /// Create a new read-only source stream with the specified columns and properties.
-  /// </summary>
-  /// <typeparam name="T">The type that represents the stream.</typeparam>
-  /// <param name="creationMetadata">Stream properties, specify details about your stream by using the WITH clause.</param>
-  /// <param name="ifNotExists">If the IF NOT EXISTS clause is present, the statement won't fail if a stream with the same name already exists.</param>
-  /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
-  /// <returns>Http response object.</returns>
-  Task<HttpResponseMessage> CreateSourceStreamAsync<T>(EntityCreationMetadata creationMetadata, bool ifNotExists = false, CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Create a new table with the specified columns and properties.
-  /// </summary>
-  /// <typeparam name="T"></typeparam>
-  /// <param name="creationMetadata">Table properties, specify details about your table by using the WITH clause.</param>
-  /// <param name="ifNotExists">If the IF NOT EXISTS clause is present, the statement won't fail if a table with the same name already exists.</param>
-  /// <param name="cancellationToken"></param>
-  /// <returns>Http response object.</returns>
-  Task<HttpResponseMessage> CreateTableAsync<T>(EntityCreationMetadata creationMetadata, bool ifNotExists = false, CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Create a new read-only table with the specified columns and properties.
-  /// </summary>
-  /// <typeparam name="T"></typeparam>
-  /// <param name="creationMetadata">Table properties, specify details about your table by using the WITH clause.</param>
-  /// <param name="ifNotExists">If the IF NOT EXISTS clause is present, the statement won't fail if a table with the same name already exists.</param>
-  /// <param name="cancellationToken"></param>
-  /// <returns>Http response object.</returns>
-  Task<HttpResponseMessage> CreateSourceTableAsync<T>(EntityCreationMetadata creationMetadata, bool ifNotExists = false, CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Create a new table or replace an existing one with the specified columns and properties.
-  /// </summary>
-  /// <typeparam name="T"></typeparam>
-  /// <param name="creationMetadata">Table properties, specify details about your table by using the WITH clause.</param>
-  /// <param name="cancellationToken"></param>
-  /// <returns>Http response object.</returns>
-  Task<HttpResponseMessage> CreateOrReplaceTableAsync<T>(EntityCreationMetadata creationMetadata, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Produce a row into an existing stream or table and its underlying topic based on explicitly specified entity properties.
@@ -172,26 +112,6 @@ public interface IKSqlDbRestApiClient : IKSqlDbAssertionsRestApiClient, IKSqlDbD
   Task<ConnectorsResponse[]> GetConnectorsAsync(CancellationToken cancellationToken = default);
 
   /// <summary>
-  /// Create a new source connector in the Kafka Connect cluster with the configuration passed in the config parameter.
-  /// </summary>
-  /// <param name="config">Configuration passed into the WITH clause.</param>
-  /// <param name="connectorName">Name of the connector to create.</param>
-  /// <param name="ifNotExists">If the IF NOT EXISTS clause is present, the statement does not fail if a connector with the supplied name already exists.</param>
-  /// <param name="cancellationToken"></param>
-  /// <returns></returns>
-  Task<HttpResponseMessage> CreateSourceConnectorAsync(IDictionary<string, string> config, string connectorName, bool ifNotExists = false, CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Create a new sink connector in the Kafka Connect cluster with the configuration passed in the config parameter.
-  /// </summary>
-  /// <param name="config">Configuration passed into the WITH clause.</param>
-  /// <param name="connectorName">Name of the connector to create.</param>
-  /// <param name="ifNotExists">If the IF NOT EXISTS clause is present, the statement does not fail if a connector with the supplied name already exists.</param>
-  /// <param name="cancellationToken"></param>
-  /// <returns></returns>
-  Task<HttpResponseMessage> CreateSinkConnectorAsync(IDictionary<string, string> config, string connectorName, bool ifNotExists = false, CancellationToken cancellationToken = default);
-
-  /// <summary>
   /// Pause a persistent query.
   /// </summary>
   /// <param name="queryId">ID of the query to pause.</param>
@@ -222,36 +142,4 @@ public interface IKSqlDbRestApiClient : IKSqlDbAssertionsRestApiClient, IKSqlDbD
   /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
   /// <returns>Statement response</returns>
   Task<HttpResponseMessage> TerminatePushQueryAsync(string queryId, CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Create an alias for a complex type declaration.
-  /// The CREATE TYPE statement registers a type alias directly in KSQL. Any types registered by using this command can be leveraged in future statements. The CREATE TYPE statement works in interactive and headless modes.
-  /// Any attempt to register the same type twice, without a corresponding DROP TYPE statement, will fail.
-  /// </summary>
-  /// <typeparam name="T"></typeparam>
-  /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
-  /// <returns>Http response object.</returns>
-  Task<HttpResponseMessage> CreateTypeAsync<T>(CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Create an alias for a complex type declaration.
-  /// The CREATE TYPE statement registers a type alias directly in KSQL. Any types registered by using this command can be leveraged in future statements. The CREATE TYPE statement works in interactive and headless modes.
-  /// Any attempt to register the same type twice, without a corresponding DROP TYPE statement, will fail.
-  /// </summary>
-  /// <typeparam name="T"></typeparam>
-  /// <param name="typeName">Optional name of the type. Otherwise, the type name is inferred from the generic type name.</param>
-  /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
-  /// <returns>Http response object.</returns>
-  Task<HttpResponseMessage> CreateTypeAsync<T>(string typeName, CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Create an alias for a complex type declaration.
-  /// The CREATE TYPE statement registers a type alias directly in KSQL. Any types registered by using this command can be leveraged in future statements. The CREATE TYPE statement works in interactive and headless modes.
-  /// Any attempt to register the same type twice, without a corresponding DROP TYPE statement, will fail.
-  /// </summary>
-  /// <typeparam name="T"></typeparam>
-  /// <param name="properties">Type configuration</param>
-  /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
-  /// <returns>Http response object.</returns>
-  Task<HttpResponseMessage> CreateTypeAsync<T>(TypeProperties properties, CancellationToken cancellationToken = default);
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/IKSqlDbRestApiClient.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/IKSqlDbRestApiClient.cs
@@ -253,5 +253,5 @@ public interface IKSqlDbRestApiClient : IKSqlDbAssertionsRestApiClient, IKSqlDbD
   /// <param name="properties">Type configuration</param>
   /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
   /// <returns>Http response object.</returns>
-  Task<HttpResponseMessage> CreateTypeAsync<T>(TypeProperties<T> properties, CancellationToken cancellationToken = default);
+  Task<HttpResponseMessage> CreateTypeAsync<T>(TypeProperties properties, CancellationToken cancellationToken = default);
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/IKSqlDbRestApiClient.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/IKSqlDbRestApiClient.cs
@@ -10,7 +10,7 @@ using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi;
 
-public interface IKSqlDbRestApiClient : IKSqlDbAssertionsRestApiClient
+public interface IKSqlDbRestApiClient : IKSqlDbAssertionsRestApiClient, IKSqlDbDropRestApiClient
 {
   /// <summary>
   /// Sets Basic HTTP authentication mechanism.
@@ -192,22 +192,6 @@ public interface IKSqlDbRestApiClient : IKSqlDbAssertionsRestApiClient
   Task<HttpResponseMessage> CreateSinkConnectorAsync(IDictionary<string, string> config, string connectorName, bool ifNotExists = false, CancellationToken cancellationToken = default);
 
   /// <summary>
-  /// Drop a connector and delete it from the Connect cluster. The topics associated with this cluster are not deleted by this command. The statement doesn't fail if the connector doesn't exist.
-  /// </summary>
-  /// <param name="connectorName">Name of the connector to drop.</param>
-  /// <param name="cancellationToken"></param>
-  /// <returns></returns>
-  Task<HttpResponseMessage> DropConnectorIfExistsAsync(string connectorName, CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Drop a connector and delete it from the Connect cluster. The topics associated with this cluster are not deleted by this command. The statement fails if the connector doesn't exist.
-  /// </summary>
-  /// <param name="connectorName">Name of the connector to drop.</param>
-  /// <param name="cancellationToken"></param>
-  /// <returns></returns>
-  Task<HttpResponseMessage> DropConnectorAsync(string connectorName, CancellationToken cancellationToken = default);
-
-  /// <summary>
   /// Pause a persistent query.
   /// </summary>
   /// <param name="queryId">ID of the query to pause.</param>
@@ -240,46 +224,6 @@ public interface IKSqlDbRestApiClient : IKSqlDbAssertionsRestApiClient
   Task<HttpResponseMessage> TerminatePushQueryAsync(string queryId, CancellationToken cancellationToken = default);
 
   /// <summary>
-  /// Drops an existing stream.
-  /// DROP STREAM [IF EXISTS] stream_name [DELETE TOPIC];
-  /// </summary>
-  /// <param name="streamName">Name of the stream to delete.</param>
-  /// <param name="useIfExistsClause">If the IF EXISTS clause is present, the statement doesn't fail if the stream doesn't exist.</param>
-  /// <param name="deleteTopic">If the DELETE TOPIC clause is present, the stream's source topic is marked for deletion.</param>
-  /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
-  /// <returns></returns>
-  Task<HttpResponseMessage> DropStreamAsync(string streamName, bool useIfExistsClause, bool deleteTopic, CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Drops an existing stream.
-  /// DROP STREAM stream_name;
-  /// </summary>
-  /// <param name="streamName">Name of the stream to delete.</param>
-  /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
-  /// <returns></returns>
-  Task<HttpResponseMessage> DropStreamAsync(string streamName, CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Drops an existing table.
-  /// DROP TABLE [IF EXISTS] table_name [DELETE TOPIC];
-  /// </summary>
-  /// <param name="tableName">Name of the table to delete.</param>
-  /// <param name="useIfExistsClause">If the IF EXISTS clause is present, the statement doesn't fail if the table doesn't exist.</param>
-  /// <param name="deleteTopic">If the DELETE TOPIC clause is present, the table's source topic is marked for deletion.</param>
-  /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
-  /// <returns></returns>
-  Task<HttpResponseMessage> DropTableAsync(string tableName, bool useIfExistsClause, bool deleteTopic, CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Drops an existing table.
-  /// DROP TABLE table_name;
-  /// </summary>
-  /// <param name="tableName">Name of the table to delete.</param>
-  /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
-  /// <returns></returns>
-  Task<HttpResponseMessage> DropTableAsync(string tableName, CancellationToken cancellationToken = default);
-
-  /// <summary>
   /// Create an alias for a complex type declaration.
   /// The CREATE TYPE statement registers a type alias directly in KSQL. Any types registered by using this command can be leveraged in future statements. The CREATE TYPE statement works in interactive and headless modes.
   /// Any attempt to register the same type twice, without a corresponding DROP TYPE statement, will fail.
@@ -310,20 +254,4 @@ public interface IKSqlDbRestApiClient : IKSqlDbAssertionsRestApiClient
   /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
   /// <returns>Http response object.</returns>
   Task<HttpResponseMessage> CreateTypeAsync<T>(TypeProperties<T> properties, CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Removes a type alias from ksqlDB. This statement doesn't fail if the type is in use in active queries or user-defined functions.
-  /// </summary>
-  /// <param name="typeName">Name of the type to remove.</param>
-  /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
-  /// <returns>Http response object.</returns>
-  Task<HttpResponseMessage> DropTypeAsync(string typeName, CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Removes a type alias from ksqlDB. This statement doesn't fail if the type is in use in active queries or user-defined functions. The statement doesn't fail if the type doesn't exist.
-  /// </summary>
-  /// <param name="typeName">Name of the type to remove.</param>
-  /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
-  /// <returns>Http response object.</returns>
-  Task<HttpResponseMessage> DropTypeIfExistsAsync(string typeName, CancellationToken cancellationToken = default);
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/KSqlDbRestApiClient.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/KSqlDbRestApiClient.cs
@@ -305,7 +305,7 @@ public class KSqlDbRestApiClient : IKSqlDbRestApiClient
   /// <returns>Http response object.</returns>
   public Task<HttpResponseMessage> CreateTypeAsync<T>(CancellationToken cancellationToken = default)
   {
-    var properties = new TypeProperties<T>();
+    var properties = new TypeProperties();
     return CreateTypeAsync<T>(properties, cancellationToken);
   }
 
@@ -320,7 +320,7 @@ public class KSqlDbRestApiClient : IKSqlDbRestApiClient
   /// <returns>Http response object.</returns>
   public Task<HttpResponseMessage> CreateTypeAsync<T>(string typeName, CancellationToken cancellationToken = default)
   {
-    var properties = new TypeProperties<T> { EntityName = typeName };
+    var properties = new TypeProperties { EntityName = typeName };
     return CreateTypeAsync<T>(properties, cancellationToken);
   }
 
@@ -333,7 +333,7 @@ public class KSqlDbRestApiClient : IKSqlDbRestApiClient
   /// <param name="properties">Type configuration</param>
   /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
   /// <returns>Http response object.</returns>
-  public Task<HttpResponseMessage> CreateTypeAsync<T>(TypeProperties<T> properties, CancellationToken cancellationToken = default)
+  public Task<HttpResponseMessage> CreateTypeAsync<T>(TypeProperties properties, CancellationToken cancellationToken = default)
   {
     var ksql = new TypeGenerator().Print<T>(properties);
 
@@ -348,7 +348,7 @@ public class KSqlDbRestApiClient : IKSqlDbRestApiClient
   /// <returns>Http response object.</returns>
   public Task<HttpResponseMessage> DropTypeAsync<T>(DropTypeProperties dropTypeProperties, CancellationToken cancellationToken = default)
   {
-    var typeName = entityProvider.GetName<T>(dropTypeProperties);
+    var typeName = entityProvider.GetFormattedName<T>(dropTypeProperties);
     string dropStatement = StatementTemplates.DropType(typeName);
 
     KSqlDbStatement ksqlDbStatement = new(dropStatement);
@@ -679,7 +679,7 @@ public class KSqlDbRestApiClient : IKSqlDbRestApiClient
   /// <returns></returns>
   public Task<HttpResponseMessage> DropStreamAsync<T>(DropFromItemProperties dropFromItemProperties, CancellationToken cancellationToken = default)
   {
-    var streamName = entityProvider.GetName<T>(dropFromItemProperties);
+    var streamName = entityProvider.GetFormattedName<T>(dropFromItemProperties);
     string dropStatement = StatementTemplates.DropStream(streamName, dropFromItemProperties.UseIfExistsClause, dropFromItemProperties.DeleteTopic);
 
     KSqlDbStatement ksqlDbStatement = new(dropStatement);
@@ -732,7 +732,7 @@ public class KSqlDbRestApiClient : IKSqlDbRestApiClient
   /// <returns></returns>
   public Task<HttpResponseMessage> DropTableAsync<T>(DropFromItemProperties dropFromItemProperties, CancellationToken cancellationToken = default)
   {
-    var tableName = entityProvider.GetName<T>(dropFromItemProperties);
+    var tableName = entityProvider.GetFormattedName<T>(dropFromItemProperties);
     string dropStatement = StatementTemplates.DropTable(tableName, dropFromItemProperties.UseIfExistsClause, dropFromItemProperties.DeleteTopic);
 
     KSqlDbStatement ksqlDbStatement = new(dropStatement);

--- a/ksqlDb.RestApi.Client/KSql/RestApi/KSqlDbRestApiClient.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/KSqlDbRestApiClient.cs
@@ -20,11 +20,13 @@ using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Inserts;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
 using Microsoft.Extensions.Logging;
 using IHttpClientFactory = ksqlDB.RestApi.Client.KSql.RestApi.Http.IHttpClientFactory;
+using ksqlDb.RestApi.Client.KSql.RestApi.Statements.Providers;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi;
 
 public class KSqlDbRestApiClient : IKSqlDbRestApiClient
 {
+  private readonly EntityProvider entityProvider = new();
   private readonly IHttpClientFactory httpClientFactory;
   private readonly ILogger logger;
 
@@ -341,6 +343,22 @@ public class KSqlDbRestApiClient : IKSqlDbRestApiClient
   /// <summary>
   /// Removes a type alias from ksqlDB. This statement doesn't fail if the type is in use in active queries or user-defined functions.
   /// </summary>
+  /// <param name="dropTypeProperties">Configuration for dropping the type.</param>
+  /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+  /// <returns>Http response object.</returns>
+  public Task<HttpResponseMessage> DropTypeAsync<T>(DropTypeProperties dropTypeProperties, CancellationToken cancellationToken = default)
+  {
+    var typeName = entityProvider.GetName<T>(dropTypeProperties);
+    string dropStatement = StatementTemplates.DropType(typeName);
+
+    KSqlDbStatement ksqlDbStatement = new(dropStatement);
+
+    return ExecuteStatementAsync(ksqlDbStatement, cancellationToken);
+  }
+
+  /// <summary>
+  /// Removes a type alias from ksqlDB. This statement doesn't fail if the type is in use in active queries or user-defined functions.
+  /// </summary>
   /// <param name="typeName">Name of the type to remove.</param>
   /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
   /// <returns>Http response object.</returns>
@@ -628,7 +646,7 @@ public class KSqlDbRestApiClient : IKSqlDbRestApiClient
   /// <returns></returns>
   public Task<HttpResponseMessage> DropConnectorIfExistsAsync(string connectorName, CancellationToken cancellationToken = default)
   {
-    string dropIfExistsStatement = $"DROP CONNECTOR IF EXISTS {connectorName};";
+    string dropIfExistsStatement = StatementTemplates.DropConnectorIfExists(connectorName);
 
     KSqlDbStatement ksqlDbStatement = new(dropIfExistsStatement);
 
@@ -656,6 +674,24 @@ public class KSqlDbRestApiClient : IKSqlDbRestApiClient
   /// Drops an existing stream.
   /// DROP STREAM [IF EXISTS] stream_name [DELETE TOPIC];
   /// </summary>
+  /// <param name="dropFromItemProperties">Configuration for dropping the stream.</param>
+  /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+  /// <returns></returns>
+  public Task<HttpResponseMessage> DropStreamAsync<T>(DropFromItemProperties dropFromItemProperties, CancellationToken cancellationToken = default)
+  {
+    var streamName = entityProvider.GetName<T>(dropFromItemProperties);
+    string dropStatement = StatementTemplates.DropStream(streamName, dropFromItemProperties.UseIfExistsClause, dropFromItemProperties.DeleteTopic);
+
+    KSqlDbStatement ksqlDbStatement = new(dropStatement);
+
+    return ExecuteStatementAsync(ksqlDbStatement, cancellationToken);
+  }
+
+  /// <summary>
+  /// Drops an existing stream.
+  /// DROP STREAM [IF EXISTS] stream_name [DELETE TOPIC];
+  /// </summary>
+  /// <typeparam name="T">The type that represents the stream.</typeparam>
   /// <param name="streamName">Name of the stream to delete.</param>
   /// <param name="useIfExistsClause">If the IF EXISTS clause is present, the statement doesn't fail if the stream doesn't exist.</param>
   /// <param name="deleteTopic">If the DELETE TOPIC clause is present, the stream's source topic is marked for deletion.</param>
@@ -680,6 +716,24 @@ public class KSqlDbRestApiClient : IKSqlDbRestApiClient
   public Task<HttpResponseMessage> DropStreamAsync(string streamName, CancellationToken cancellationToken = default)
   {
     string dropStatement = StatementTemplates.DropStream(streamName, useIfExists: false, deleteTopic: false);
+
+    KSqlDbStatement ksqlDbStatement = new(dropStatement);
+
+    return ExecuteStatementAsync(ksqlDbStatement, cancellationToken);
+  }
+
+  /// <summary>
+  /// Drops an existing table.
+  /// DROP TABLE [IF EXISTS] table_name [DELETE TOPIC];
+  /// </summary>
+  /// <typeparam name="T">The type that represents the table.</typeparam>
+  /// <param name="dropFromItemProperties">Configuration for dropping the table.</param>
+  /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+  /// <returns></returns>
+  public Task<HttpResponseMessage> DropTableAsync<T>(DropFromItemProperties dropFromItemProperties, CancellationToken cancellationToken = default)
+  {
+    var tableName = entityProvider.GetName<T>(dropFromItemProperties);
+    string dropStatement = StatementTemplates.DropTable(tableName, dropFromItemProperties.UseIfExistsClause, dropFromItemProperties.DeleteTopic);
 
     KSqlDbStatement ksqlDbStatement = new(dropStatement);
 

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parsers/IdentifierUtil.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parsers/IdentifierUtil.cs
@@ -13,7 +13,7 @@ namespace ksqlDb.RestApi.Client.KSql.RestApi.Parsers
     /// Check if a string is a reserved word.
     /// </summary>
     /// <param name="identifier">the identifier</param>
-    /// <returns>whether or not <c>identifier</c> is a valid identifier without quotes</returns>
+    /// <returns>whether <c>identifier</c> is a valid identifier without quotes</returns>
     public static bool IsValid(string identifier)
     {
       var sqlBaseLexer = new SqlBaseLexer(

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntity.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntity.cs
@@ -6,6 +6,7 @@ using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
 using ksqlDB.RestApi.Client.KSql.RestApi.Extensions;
 using ksqlDb.RestApi.Client.KSql.RestApi.Parsers;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Annotations;
+using static System.String;
 using DateTime = System.DateTime;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
@@ -14,7 +15,7 @@ internal sealed class CreateEntity : CreateEntityStatement
 {
   internal static string KSqlTypeTranslator(Type type, IdentifierEscaping escaping = IdentifierEscaping.Never)
   {
-    var ksqlType = string.Empty;
+    var ksqlType = Empty;
 
     if (type == typeof(byte[]))
       ksqlType = KSqlTypes.Bytes;
@@ -57,7 +58,7 @@ internal sealed class CreateEntity : CreateEntityStatement
     {
       var ksqlProperties = GetProperties(type, escaping);
 
-      ksqlType = $"STRUCT<{string.Join(", ", ksqlProperties)}>";
+      ksqlType = $"STRUCT<{Join(", ", ksqlProperties)}>";
     }
     else if (!type.IsGenericType && (type.IsClass || type.IsStruct()))
     {
@@ -136,14 +137,14 @@ internal sealed class CreateEntity : CreateEntityStatement
       {
         const string header = " HEADER";
 
-        if (string.IsNullOrEmpty(headersAttribute.Key))
+        if (IsNullOrEmpty(headersAttribute.Key))
           return $"{header}S";
 
         return $"{header}('{headersAttribute.Key}')";
       }
     }
 
-    return string.Empty;
+    return Empty;
   }
 
   private void PrintProperties<T>(StatementContext statementContext, EntityCreationMetadata metadata)
@@ -164,7 +165,7 @@ internal sealed class CreateEntity : CreateEntityStatement
       ksqlProperties.Add(columnDefinition);
     }
 
-    stringBuilder.AppendLine(string.Join($",{Environment.NewLine}", ksqlProperties));
+    stringBuilder.AppendLine(Join($",{Environment.NewLine}", ksqlProperties));
   }
 
   internal static IEnumerable<string> GetProperties(Type type, IdentifierEscaping escaping)
@@ -201,9 +202,9 @@ internal sealed class CreateEntity : CreateEntityStatement
       _ => throw new ArgumentOutOfRangeException(nameof(statementContext), $"Unknown '{nameof(KSqlEntityType)}' value {statementContext.KSqlEntityType}.")
     };
 
-    statementContext.EntityName = GetEntityName<T>(metadata);
+    statementContext.EntityName = EntityProvider.GetFormattedName<T>(metadata);
 
-    string source = metadata.IsReadOnly ? " SOURCE" : String.Empty;
+    string source = metadata.IsReadOnly ? " SOURCE" : Empty;
 
     stringBuilder.Append($"{creationTypeText}{source} {entityTypeText}");
   }
@@ -211,7 +212,7 @@ internal sealed class CreateEntity : CreateEntityStatement
   private static string TryAttachKey(KSqlEntityType entityType, MemberInfo memberInfo)
   {
     if (!memberInfo.HasKey())
-      return string.Empty;
+      return Empty;
 
     string key = entityType switch
     {

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntityStatement.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntityStatement.cs
@@ -1,15 +1,13 @@
 using System.Reflection;
-using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
-using ksqlDb.RestApi.Client.KSql.RestApi.Parsers;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Annotations;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
-using Pluralize.NET;
+using ksqlDb.RestApi.Client.KSql.RestApi.Statements.Providers;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 
 internal class CreateEntityStatement
 {
-  protected static readonly IPluralize EnglishPluralizationService = new Pluralizer();
+  private static readonly EntityProvider EntityProvider = new();
 
   protected static IEnumerable<MemberInfo> Members<T>(bool? includeReadOnly = null)
   {
@@ -31,15 +29,7 @@ internal class CreateEntityStatement
 
   protected static string GetEntityName<T>(IEntityCreationProperties metadata)
   {
-    string entityName = metadata?.EntityName;
-
-    if (string.IsNullOrEmpty(entityName))
-      entityName = typeof(T).Name;
-
-    if (metadata is { ShouldPluralizeEntityName: true })
-      entityName = EnglishPluralizationService.Pluralize(entityName);
-
-    return IdentifierUtil.Format(entityName, metadata?.IdentifierEscaping ?? IdentifierEscaping.Never);
+    return EntityProvider.GetName<T>(metadata);
   }
 
   protected static Type GetMemberType(MemberInfo memberInfo)

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntityStatement.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntityStatement.cs
@@ -27,9 +27,9 @@ internal class CreateEntityStatement
     return properties.Where(c => !c.GetCustomAttributes().OfType<IgnoreByInsertsAttribute>().Any());
   }
 
-  protected static string GetEntityName<T>(IEntityCreationProperties metadata)
+  protected static string GetEntityName<T>(IEntityProperties metadata)
   {
-    return EntityProvider.GetName<T>(metadata);
+    return EntityProvider.GetFormattedName<T>(metadata);
   }
 
   protected static Type GetMemberType(MemberInfo memberInfo)

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntityStatement.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntityStatement.cs
@@ -1,13 +1,12 @@
 using System.Reflection;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Annotations;
-using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
 using ksqlDb.RestApi.Client.KSql.RestApi.Statements.Providers;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 
 internal class CreateEntityStatement
 {
-  private static readonly EntityProvider EntityProvider = new();
+  protected static readonly EntityProvider EntityProvider = new();
 
   protected static IEnumerable<MemberInfo> Members<T>(bool? includeReadOnly = null)
   {
@@ -25,11 +24,6 @@ internal class CreateEntityStatement
       .Concat(fields);
       
     return properties.Where(c => !c.GetCustomAttributes().OfType<IgnoreByInsertsAttribute>().Any());
-  }
-
-  protected static string GetEntityName<T>(IEntityProperties metadata)
-  {
-    return EntityProvider.GetFormattedName<T>(metadata);
   }
 
   protected static Type GetMemberType(MemberInfo memberInfo)

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
@@ -63,7 +63,7 @@ internal sealed class CreateInsert : CreateEntityStatement
     var hasValue = insertValues.PropertyValues.ContainsKey(memberInfo.Format(insertProperties.IdentifierEscaping));
 
     object value;
-
+    
     if (hasValue)
       value = insertValues.PropertyValues[memberInfo.Format(insertProperties.IdentifierEscaping)];
     else

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
@@ -7,7 +7,7 @@ using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 
-internal sealed class CreateInsert : CreateEntityStatement
+internal sealed class CreateInsert : EntityInfo
 {
   internal string Generate<T>(T entity, InsertProperties insertProperties = null)
   {
@@ -22,13 +22,13 @@ internal sealed class CreateInsert : CreateEntityStatement
 
     var entityName = EntityProvider.GetFormattedName<T>(insertProperties);
 
-    bool isFirst = true;
-
     var columnsStringBuilder = new StringBuilder();
     var valuesStringBuilder = new StringBuilder();
 
-    var useEntityType = insertProperties is {UseInstanceType: true};
-    var entityType = useEntityType ? insertValues.Entity.GetType() : typeof(T);
+    var useInstanceType = insertProperties is {UseInstanceType: true};
+    var entityType = useInstanceType ? insertValues.Entity.GetType() : typeof(T);
+
+    bool isFirst = true;
 
     foreach (var memberInfo in Members(entityType, insertProperties.IncludeReadOnlyProperties))
     {

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
@@ -20,7 +20,7 @@ internal sealed class CreateInsert : CreateEntityStatement
 
     insertProperties ??= new InsertProperties();
 
-    var entityName = GetEntityName<T>(insertProperties);
+    var entityName = EntityProvider.GetFormattedName<T>(insertProperties);
 
     bool isFirst = true;
 
@@ -46,7 +46,7 @@ internal sealed class CreateInsert : CreateEntityStatement
 
       var type = GetMemberType(memberInfo);
 
-      var value = GetValue(insertValues, insertProperties, memberInfo, type, memberInfo => IdentifierUtil.Format(memberInfo, insertProperties.IdentifierEscaping));
+      var value = GetValue(insertValues, insertProperties, memberInfo, type, mi => IdentifierUtil.Format(mi, insertProperties.IdentifierEscaping));
 
       valuesStringBuilder.Append(value);
     }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateKSqlValue.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateKSqlValue.cs
@@ -9,7 +9,7 @@ using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 
-internal sealed class CreateKSqlValue : CreateEntityStatement
+internal sealed class CreateKSqlValue : EntityInfo
 {
   public object ExtractValue<T>(T inputValue, IValueFormatters valueFormatters, MemberInfo memberInfo, Type type, Func<MemberInfo, string> formatter)
   {
@@ -82,7 +82,7 @@ internal sealed class CreateKSqlValue : CreateEntityStatement
     }
     else if (!type.IsGenericType && (type.IsClass || type.IsStruct()))
     {
-      GenerateStruct<T>(valueFormatters, type, formatter, ref value);
+      GenerateStruct(valueFormatters, type, formatter, ref value);
     }
     else
     {
@@ -100,7 +100,7 @@ internal sealed class CreateKSqlValue : CreateEntityStatement
 
     var sb = new StringBuilder();
 
-    sb.Append("MAP(");
+    sb.Append($"{KSqlTypes.Map}(");
 
     bool isFirst = true;
 
@@ -127,12 +127,12 @@ internal sealed class CreateKSqlValue : CreateEntityStatement
     value = sb.ToString();
   }
 
-  private void GenerateStruct<T>(IValueFormatters valueFormatters, Type type, Func<MemberInfo, string> formatter,
+  private void GenerateStruct(IValueFormatters valueFormatters, Type type, Func<MemberInfo, string> formatter,
     ref object value)
   {
     var sb = new StringBuilder();
 
-    sb.Append("STRUCT(");
+    sb.Append($"{KSqlTypes.Struct}(");
 
     bool isFirst = true;
 
@@ -181,9 +181,9 @@ internal sealed class CreateKSqlValue : CreateEntityStatement
   private static string PrintArray(object[] array)
   {
     var sb = new StringBuilder();
-    sb.Append("ARRAY[");
+    sb.Append($"{KSqlTypes.Array}[");
 #if NETSTANDARD
-      var value = string.Join(", ", array);
+    var value = string.Join(", ", array);
 #else
     var value = string.Join(", ", array);
 #endif

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/EntityCreationMetadata.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/EntityCreationMetadata.cs
@@ -8,7 +8,7 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 /// <summary>
 /// Configuration for creating entities e.g. streams and tables.
 /// </summary>
-public record EntityCreationMetadata : CreationMetadata, IEntityCreationProperties
+public record EntityCreationMetadata : CreationMetadata, IEntityProperties
 {
   /// <summary>
   /// Initializes a new instance of the <see cref="T:EntityCreationMetadata"></see> class, specifying the backing Kafka topic for the entity.

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/EntityInfo.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/EntityInfo.cs
@@ -4,7 +4,7 @@ using ksqlDb.RestApi.Client.KSql.RestApi.Statements.Providers;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 
-internal class CreateEntityStatement
+internal class EntityInfo
 {
   protected static readonly EntityProvider EntityProvider = new();
 

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/KSqlTypeTranslator.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/KSqlTypeTranslator.cs
@@ -1,0 +1,137 @@
+using System.Reflection;
+using ksqlDB.RestApi.Client.Infrastructure.Extensions;
+using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
+using ksqlDB.RestApi.Client.KSql.RestApi.Extensions;
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Annotations;
+
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements
+{
+  internal sealed class KSqlTypeTranslator : EntityInfo
+  {
+    internal static string Translate(Type type, IdentifierEscaping escaping = IdentifierEscaping.Never)
+    {
+      var ksqlType = string.Empty;
+
+      if (type == typeof(byte[]))
+        ksqlType = KSqlTypes.Bytes;
+      else if (type.IsArray)
+      {
+        var elementType = Translate(type.GetElementType(), escaping);
+
+        ksqlType = $"{KSqlTypes.Array}<{elementType}>";
+      }
+      else if (type.IsDictionary())
+      {
+        Type[] typeParameters = type.GetGenericArguments();
+
+        var keyType = Translate(typeParameters[0], escaping);
+        var valueType = Translate(typeParameters[1], escaping);
+
+        ksqlType = $"{KSqlTypes.Map}<{keyType}, {valueType}>";
+      }
+      else if (type == typeof(string))
+        ksqlType = KSqlTypes.Varchar;
+      else if (type == typeof(Guid))
+        ksqlType = KSqlTypes.Varchar;
+      else if (type.IsOneOfFollowing(typeof(int), typeof(int?), typeof(short), typeof(short?)))
+        ksqlType = KSqlTypes.Int;
+      else if (type.IsOneOfFollowing(typeof(long), typeof(long?)))
+        ksqlType = KSqlTypes.BigInt;
+      else if (type.IsOneOfFollowing(typeof(double), typeof(double?)))
+        ksqlType = KSqlTypes.Double;
+      else if (type.IsOneOfFollowing(typeof(bool), typeof(bool?)))
+        ksqlType = KSqlTypes.Boolean;
+      else if (type == typeof(decimal))
+        ksqlType = KSqlTypes.Decimal;
+      else if (type == typeof(DateTime))
+        ksqlType = KSqlTypes.Date;
+      else if (type == typeof(TimeSpan))
+        ksqlType = KSqlTypes.Time;
+      else if (type == typeof(DateTimeOffset))
+        ksqlType = KSqlTypes.Timestamp;
+      else if (!type.IsGenericType && type.TryGetAttribute<StructAttribute>() != null)
+      {
+        var ksqlProperties = GetProperties(type, escaping);
+
+        ksqlType = $"{KSqlTypes.Struct}<{string.Join(", ", ksqlProperties)}>";
+      }
+      else if (!type.IsGenericType && (type.IsClass || type.IsStruct()))
+      {
+        ksqlType = type.Name.ToUpper();
+      }
+      else if (type.IsEnum)
+        ksqlType = KSqlTypes.Varchar;
+      else
+      {
+        Type elementType = null;
+
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+          elementType = type.GetGenericArguments()[0];
+        else
+        {
+          var enumerableInterfaces = type.GetEnumerableTypeDefinition().ToArray();
+
+          if (enumerableInterfaces.Length > 0)
+          {
+            elementType = enumerableInterfaces[0].GetGenericArguments()[0];
+          }
+        }
+
+        if (elementType != null)
+        {
+          string ksqlElementType = Translate(elementType, escaping);
+
+          ksqlType = $"ARRAY<{ksqlElementType}>";
+        }
+      }
+
+      return ksqlType;
+    }
+
+    internal static IEnumerable<string> GetProperties(Type type, IdentifierEscaping escaping)
+    {
+      var ksqlProperties = new List<string>();
+
+      foreach (var memberInfo in Members(type, false))
+      {
+        var memberType = GetMemberType(memberInfo);
+
+        var ksqlType = Translate(memberType, escaping);
+
+        string columnDefinition = $"{memberInfo.Format(escaping)} {ksqlType}{ExploreAttributes(memberInfo, memberType)}";
+
+        ksqlProperties.Add(columnDefinition);
+      }
+
+      return ksqlProperties;
+    }
+
+    internal static string ExploreAttributes(MemberInfo memberInfo, Type type)
+    {
+      if (type == typeof(decimal))
+      {
+        var decimalMember = memberInfo.TryGetAttribute<DecimalAttribute>();
+
+        if (decimalMember != null)
+          return $"({decimalMember.Precision},{decimalMember.Scale})";
+      }
+
+      if (type.IsArray)
+      {
+        var headersAttribute = memberInfo.TryGetAttribute<HeadersAttribute>();
+
+        if (headersAttribute != null)
+        {
+          const string header = " HEADER";
+
+          if (string.IsNullOrEmpty(headersAttribute.Key))
+            return $"{header}S";
+
+          return $"{header}('{headersAttribute.Key}')";
+        }
+      }
+
+      return string.Empty;
+    }
+  }
+}

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/KSqlTypes.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/KSqlTypes.cs
@@ -1,4 +1,4 @@
-﻿namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements
 {
   internal static class KSqlTypes
   {
@@ -12,5 +12,8 @@
     internal static string Date => "DATE";
     internal static string Time => "TIME";
     internal static string Timestamp => "TIMESTAMP";
+    internal static string Array => "ARRAY";
+    internal static string Struct => "STRUCT";
+    internal static string Map => "MAP";
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Properties/DropFromItemProperties.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Properties/DropFromItemProperties.cs
@@ -1,0 +1,18 @@
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties
+{
+  /// <summary>
+  /// Represents a configuration for dropping a ksqlDB stream or table.
+  /// </summary>
+  public record DropFromItemProperties : EntityProperties
+  {
+    /// <summary>
+    /// Gets or sets a value indicating whether to use the "IF EXISTS" clause when dropping the entity.
+    /// </summary>
+    public bool UseIfExistsClause { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to delete the associated topic when dropping the entity.
+    /// </summary>
+    public bool DeleteTopic { get; init; }
+  }
+}

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Properties/DropTypeProperties.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Properties/DropTypeProperties.cs
@@ -1,0 +1,9 @@
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties
+{
+  /// <summary>
+  /// Represents a configuration for dropping a ksqlDB type.
+  /// </summary>
+  public record DropTypeProperties : EntityProperties
+  {
+  }
+}

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Properties/EntityProperties.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Properties/EntityProperties.cs
@@ -1,0 +1,26 @@
+using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
+
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties
+{
+  /// <summary>
+  /// Represents a configuration for a ksqlDB entity.
+  /// </summary>
+  public record EntityProperties : IEntityProperties
+  {
+    /// <summary>
+    /// Gets or sets the entity name that overrides the automatically inferred name.
+    /// </summary>
+    public string EntityName { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the entity name should be pluralized.
+    /// </summary>
+    public bool ShouldPluralizeEntityName { get; init; } = true;
+
+    /// <summary>
+    /// Gets or sets the identifier escaping type.
+    /// As ksqlDB automatically converts all identifiers to uppercase by default, it's crucial to enclose them within backticks to maintain the desired casing.
+    /// </summary>
+    public IdentifierEscaping IdentifierEscaping { get; init; } = IdentifierEscaping.Never;
+  }
+}

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Properties/IEntityCreationProperties.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Properties/IEntityCreationProperties.cs
@@ -1,5 +1,0 @@
-namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
-
-public interface IEntityCreationProperties : IEntityProperties
-{
-}

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Properties/IEntityCreationProperties.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Properties/IEntityCreationProperties.cs
@@ -1,22 +1,5 @@
-using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
-
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
 
-public interface IEntityCreationProperties
+public interface IEntityCreationProperties : IEntityProperties
 {
-  /// <summary>
-  /// Gets the entity name that overrides the automatically inferred name.
-  /// </summary>
-  public string EntityName { get; }
-
-  /// <summary>
-  /// Gets a value indicating whether the entity name should be pluralized.
-  /// </summary>
-  public bool ShouldPluralizeEntityName { get; }
-
-  /// <summary>
-  /// Gets the identifier escaping type.
-  /// As ksqlDB automatically converts all identifiers to uppercase by default, it's crucial to enclose them within backticks to maintain the desired casing.
-  /// </summary>
-  public IdentifierEscaping IdentifierEscaping { get; }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Properties/IEntityProperties.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Properties/IEntityProperties.cs
@@ -1,0 +1,23 @@
+using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
+
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties
+{
+  public interface IEntityProperties
+  {
+    /// <summary>
+    /// Gets the entity name that overrides the automatically inferred name.
+    /// </summary>
+    public string EntityName { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the entity name should be pluralized.
+    /// </summary>
+    public bool ShouldPluralizeEntityName { get; }
+
+    /// <summary>
+    /// Gets the identifier escaping type.
+    /// As ksqlDB automatically converts all identifiers to uppercase by default, it's crucial to enclose them within backticks to maintain the desired casing.
+    /// </summary>
+    public IdentifierEscaping IdentifierEscaping { get; }
+  }
+}

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Properties/InsertProperties.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Properties/InsertProperties.cs
@@ -1,29 +1,14 @@
-using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
-
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
 
-public record InsertProperties : IEntityCreationProperties, IValueFormatters
+/// <summary>
+/// Represents a configuration for insert statements.
+/// </summary>
+public record InsertProperties : EntityProperties, IValueFormatters
 {
-  /// <summary>
-  /// Gets the entity name that overrides the automatically inferred name.
-  /// </summary>
-  public string EntityName { get; set; }
-
   /// <summary>
   /// Determines whether to use the instance type for inferring the entity name instead of utilizing typeof(T).
   /// </summary>
   public bool UseInstanceType { get; set; }
-
-  /// <summary>
-  /// Gets or sets a value indicating whether the entity name should be pluralized.
-  /// </summary>
-  public bool ShouldPluralizeEntityName { get; set; } = true;
-
-  /// <summary>
-  /// Gets or sets the identifier escaping type.
-  /// As ksqlDB automatically converts all identifiers to uppercase by default, it's crucial to enclose them within backticks to maintain the desired casing.
-  /// </summary>
-  public IdentifierEscaping IdentifierEscaping { get; init; } = IdentifierEscaping.Never;
 
   /// <summary>
   /// Include read-only properties during insert statement generation.

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Properties/TypeProperties.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Properties/TypeProperties.cs
@@ -1,36 +1,13 @@
-using ksqlDB.RestApi.Client.Infrastructure.Extensions;
-using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
-
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties
 {
-  public class TypeProperties<T> : IEntityCreationProperties
+  /// <summary>
+  /// Represents a configuration for a ksqlDB type.
+  /// </summary>
+  public record TypeProperties : EntityProperties
   {
-    private readonly string entityName = typeof(T).ExtractTypeName().ToUpper();
-
-    /// <summary>
-    /// Is initialized to the type parameter name. Cannot be initialized with a null or empty value.
-    /// </summary>
-    public string EntityName
+    public TypeProperties()
     {
-      get => entityName;
-      init
-      {
-        if (!string.IsNullOrEmpty(value))
-        {
-          entityName = value;
-        }
-      }
+      ShouldPluralizeEntityName = false;
     }
-
-    /// <summary>
-    /// Gets a value indicating whether the entity name should be pluralized.
-    /// </summary>
-    public bool ShouldPluralizeEntityName => false;
-
-    /// <summary>
-    /// Gets or sets the identifier escaping type.
-    /// As ksqlDB automatically converts all identifiers to uppercase by default, it's crucial to enclose them within backticks to maintain the desired casing.
-    /// </summary>
-    public IdentifierEscaping IdentifierEscaping { get; init; } = IdentifierEscaping.Never;
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Providers/EntityProvider.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Providers/EntityProvider.cs
@@ -6,7 +6,7 @@ using Pluralize.NET;
 
 namespace ksqlDb.RestApi.Client.KSql.RestApi.Statements.Providers
 {
-  internal class EntityProvider
+  internal sealed class EntityProvider
   {
     private readonly Pluralizer englishPluralizationService = new();
 

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Providers/EntityProvider.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Providers/EntityProvider.cs
@@ -1,0 +1,24 @@
+using ksqlDb.RestApi.Client.KSql.RestApi.Parsers;
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
+using Pluralize.NET;
+
+namespace ksqlDb.RestApi.Client.KSql.RestApi.Statements.Providers
+{
+  internal class EntityProvider
+  {
+    private readonly Pluralizer englishPluralizationService = new();
+
+    internal string GetName<T>(IEntityProperties entityProperties)
+    {
+      string entityName = entityProperties.EntityName;
+
+      if (string.IsNullOrEmpty(entityName))
+        entityName = typeof(T).Name;
+
+      if (entityProperties is { ShouldPluralizeEntityName: true })
+        entityName = englishPluralizationService.Pluralize(entityName);
+
+      return IdentifierUtil.Format(entityName, entityProperties.IdentifierEscaping);
+    }
+  }
+}

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/StatementTemplates.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/StatementTemplates.cs
@@ -1,4 +1,4 @@
-﻿using static System.String;
+using static System.String;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 
@@ -15,6 +15,7 @@ internal static class StatementTemplates
 
   public static string ShowConnectors => "SHOW CONNECTORS;";
   public static string DropConnector(string connectorName) => $"DROP CONNECTOR {connectorName};";
+  public static string DropConnectorIfExists(string connectorName) => $"DROP CONNECTOR IF EXISTS {connectorName};";
 
   public static string DropType(string typeName) => $"DROP TYPE {typeName};";
   public static string DropTypeIfExists(string typeName) => $"DROP TYPE IF EXISTS {typeName};";

--- a/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
+++ b/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
@@ -15,9 +15,9 @@
             Documentation for the library can be found at https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/README.md.
         </Description>
         <PackageTags>ksql ksqlDB LINQ .NET csharp push query</PackageTags>
-        <Version>3.6.1</Version>
-        <AssemblyVersion>3.6.1.0</AssemblyVersion>
-        <LangVersion>10.0</LangVersion>
+        <Version>3.7.0</Version>
+        <AssemblyVersion>3.7.0.0</AssemblyVersion>
+        <LangVersion>12.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <PackageReleaseNotes>https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/ksqlDb.RestApi.Client/ChangeLog.md</PackageReleaseNotes>

--- a/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
+++ b/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
@@ -15,7 +15,7 @@
             Documentation for the library can be found at https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/README.md.
         </Description>
         <PackageTags>ksql ksqlDB LINQ .NET csharp push query</PackageTags>
-        <Version>4.0.0-rc.1</Version>
+        <Version>4.0.0-rc.2</Version>
         <AssemblyVersion>4.0.0.0</AssemblyVersion>
         <LangVersion>12.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
+++ b/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
@@ -15,8 +15,8 @@
             Documentation for the library can be found at https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/README.md.
         </Description>
         <PackageTags>ksql ksqlDB LINQ .NET csharp push query</PackageTags>
-        <Version>3.7.0</Version>
-        <AssemblyVersion>3.7.0.0</AssemblyVersion>
+        <Version>4.0.0-rc.1</Version>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
         <LangVersion>12.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
@@ -28,12 +28,12 @@
     <ItemGroup>
         <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
         <PackageReference Include="Antlr4BuildTasks" Version="12.8.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
         <PackageReference Include="System.Interactive.Async" Version="6.0.1" />
         <PackageReference Include="System.Reactive" Version="6.0.0" />
-        <PackageReference Include="System.Text.Json" Version="7.0.0" />
+        <PackageReference Include="System.Text.Json" Version="8.0.2" />
         <PackageReference Include="Pluralize.NET" Version="1.0.2" />
     </ItemGroup>
 


### PR DESCRIPTION
- introduced new overloads for dropping entities: `DropTableAsync`, `DropTypeAsync`, and `DropStreamAsync` in `KSqlDbRestApiClient`. These overloads now accept an argument `DropFromItemProperties`, providing more flexibility in configuring the drop operations.
- extracted `IKSqlDbDropRestApiClient` interface from `IKSqlDbRestApiClient`