### PR TITLE
[ksqlDb.RestApi.Client]: fix colum names in sql

### DIFF
--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/PullQueries/PullQueryExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/PullQueries/PullQueryExtensionsTests.cs
@@ -1,9 +1,13 @@
 using FluentAssertions;
 using ksqlDB.RestApi.Client.KSql.Linq.PullQueries;
+using ksqlDB.RestApi.Client.KSql.Query.Context;
 using ksqlDB.RestApi.Client.KSql.Query.Functions;
+using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
+using ksqlDb.RestApi.Client.Tests.Models;
 using ksqlDb.RestApi.Client.Tests.Models.Sensors;
 using NUnit.Framework;
 using UnitTests;
+using static ksqlDB.RestApi.Client.KSql.RestApi.Enums.IdentifierEscaping;
 using TestParameters = ksqlDb.RestApi.Client.Tests.Helpers.TestParameters;
 
 namespace ksqlDb.RestApi.Client.Tests.KSql.Linq.PullQueries;
@@ -142,5 +146,77 @@ WHERE SensorId = '{sensorId}' AND (WINDOWSTART > '{windowStart}') AND (WINDOWEND
 
     //Assert
     ksql.Should().BeEquivalentTo($"SELECT * FROM {MaterializedViewName} LIMIT {limit};");
+  }
+
+  [TestCase(Never, ExpectedResult = $"SELECT sub FROM {nameof(JsonPropertyNameTestData)};")]
+  [TestCase(Keywords, ExpectedResult = $"SELECT sub FROM {nameof(JsonPropertyNameTestData)};")]
+  [TestCase(Always, ExpectedResult = $"SELECT `sub` FROM `{nameof(JsonPropertyNameTestData)}`;")]
+  public string SelectColumnsUsingPullQueryThatHaveJsonPropertyName(IdentifierEscaping escaping)
+  {
+    //Arrange
+    var dbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
+      { IdentifierEscaping = escaping });
+
+    //Act
+    var ksql = dbContext.CreatePullQuery<JsonPropertyNameTestData>()
+      .Select(c => new { c.SubProperty })
+      .ToQueryString();
+
+    //Assert
+    return ksql.ReplaceLineEndings();
+  }
+
+  [TestCase(Never, ExpectedResult = $"SELECT sub AS Prop FROM {nameof(JsonPropertyNameTestData)};")]
+  [TestCase(Keywords, ExpectedResult = $"SELECT sub AS Prop FROM {nameof(JsonPropertyNameTestData)};")]
+  [TestCase(Always, ExpectedResult = $"SELECT `sub` AS `Prop` FROM `{nameof(JsonPropertyNameTestData)}`;")]
+  public string SelectColumnsUsingPullQueryThatHaveJsonPropertyNameWithAlias(IdentifierEscaping escaping)
+  {
+    //Arrange
+    var dbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
+      { IdentifierEscaping = escaping });
+
+    //Act
+    var ksql = dbContext.CreatePullQuery<JsonPropertyNameTestData>()
+      .Select(c => new { Prop = c.SubProperty })
+      .ToQueryString();
+
+    //Assert
+    return ksql.ReplaceLineEndings();
+  }
+
+  [TestCase(Never, ExpectedResult = $"SELECT RowTime, sub FROM {nameof(JsonPropertyNameTestData)};")]
+  [TestCase(Keywords, ExpectedResult = $"SELECT RowTime, sub FROM {nameof(JsonPropertyNameTestData)};")]
+  [TestCase(Always, ExpectedResult = $"SELECT RowTime, `sub` FROM `{nameof(JsonPropertyNameTestData)}`;")]
+  public string SelectColumnsUsingPullQueryThatHaveJsonPropertyNameWithPseudoColumn(IdentifierEscaping escaping)
+  {
+    //Arrange
+    var dbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
+      { IdentifierEscaping = escaping });
+
+    //Act
+    var ksql = dbContext.CreatePullQuery<JsonPropertyNameTestData>()
+      .Select(c => new { c.RowTime, c.SubProperty })
+      .ToQueryString();
+
+    //Assert
+    return ksql.ReplaceLineEndings();
+  }
+
+  [TestCase(Never, ExpectedResult = $"SELECT RowTime, sub AS Prop FROM {nameof(JsonPropertyNameTestData)};")]
+  [TestCase(Keywords, ExpectedResult = $"SELECT RowTime, sub AS Prop FROM {nameof(JsonPropertyNameTestData)};")]
+  [TestCase(Always, ExpectedResult = $"SELECT RowTime, `sub` AS `Prop` FROM `{nameof(JsonPropertyNameTestData)}`;")]
+  public string SelectColumnsUsingPullQueryThatHaveJsonPropertyNameWithAliasWithPseudoColum(IdentifierEscaping escaping)
+  {
+    //Arrange
+    var dbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
+      { IdentifierEscaping = escaping });
+
+    //Act
+    var ksql = dbContext.CreatePullQuery<JsonPropertyNameTestData>()
+      .Select(c => new { c.RowTime, Prop = c.SubProperty })
+      .ToQueryString();
+
+    //Assert
+    return ksql.ReplaceLineEndings();
   }
 }

--- a/Tests/ksqlDB.RestApi.Client.Tests/Models/JsonPropertyNameTestData.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/Models/JsonPropertyNameTestData.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+using ksqlDB.RestApi.Client.KSql.Query;
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Annotations;
+
+namespace ksqlDb.RestApi.Client.Tests.Models
+{
+  public class JsonPropertyNameTestData : Record
+  {
+    [JsonPropertyName("sub")] public SubProperty SubProperty { get; set; }
+  }
+
+  [Struct]
+  public class SubProperty
+  {
+    [JsonPropertyName("prop")] public string Property { get; set; }
+  }
+}

--- a/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlVisitor.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlVisitor.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
+using System.Text.Json.Serialization;
 using ksqlDB.RestApi.Client.Infrastructure.Extensions;
 using ksqlDb.RestApi.Client.KSql.Entities;
 using ksqlDB.RestApi.Client.KSql.RestApi.Extensions;
@@ -120,7 +121,7 @@ internal class KSqlVisitor : ExpressionVisitor
         break;
 
       case ExpressionType.Conditional:
-        VisitConditional((ConditionalExpression) expression);
+        VisitConditional((ConditionalExpression)expression);
         break;
     }
 
@@ -135,7 +136,7 @@ internal class KSqlVisitor : ExpressionVisitor
     Append(" THEN ");
     Visit(node.IfTrue);
 
-    if(node.IfFalse.NodeType != ExpressionType.Conditional)
+    if (node.IfFalse.NodeType != ExpressionType.Conditional)
       Append(" ELSE ");
 
     Visit(node.IfFalse);
@@ -219,7 +220,8 @@ internal class KSqlVisitor : ExpressionVisitor
       }
     }
 
-    if (methodCallExpression.Method.DeclaringType == typeof(Enumerable) && methodCallExpression.Method.Name == nameof(Enumerable.Contains))
+    if (methodCallExpression.Method.DeclaringType == typeof(Enumerable) &&
+        methodCallExpression.Method.Name == nameof(Enumerable.Contains))
     {
       PrintArrayContainsForEnumerable(methodCallExpression.Arguments);
     }
@@ -355,7 +357,8 @@ internal class KSqlVisitor : ExpressionVisitor
       return;
     }
 
-    if (expression is MemberExpression { Expression: MemberExpression {Expression: not null} me3 } && me3.Expression.Type.IsKsqlGrouping())
+    if (expression is MemberExpression { Expression: MemberExpression { Expression: not null } me1 } &&
+        me1.Expression.Type.IsKsqlGrouping())
     {
       Append(memberInfo.Format(QueryMetadata.IdentifierEscaping));
       return;
@@ -367,12 +370,22 @@ internal class KSqlVisitor : ExpressionVisitor
       Append(" ");
     }
 
-    if (expression is MemberExpression { Expression.NodeType: ExpressionType.MemberAccess} me)
-      Destructure(me);
-    else if (expression is MemberExpression {Expression.NodeType: ExpressionType.Constant})
-      Visit(expression);
-    else
-      Append(memberInfo.Format(QueryMetadata.IdentifierEscaping));
+    switch (expression)
+    {
+      case MemberExpression { Expression.NodeType: ExpressionType.MemberAccess } me:
+        Destructure(me);
+        break;
+      case MemberExpression me2 when me2.Member.GetCustomAttribute<JsonPropertyNameAttribute>() != null ||
+                                     me2.Member.GetCustomAttribute<PseudoColumnAttribute>() != null:
+        Append(me2.Member.Format(QueryMetadata.IdentifierEscaping));
+        break;
+      case MemberExpression { Expression.NodeType: ExpressionType.Constant }:
+        Visit(expression);
+        break;
+      default:
+        Append(memberInfo.Format(QueryMetadata.IdentifierEscaping));
+        break;
+    }
   }
 
   protected override Expression VisitMember(MemberExpression memberExpression)
@@ -387,7 +400,8 @@ internal class KSqlVisitor : ExpressionVisitor
 
         var memberName = memberExpression.Member.Format(QueryMetadata.IdentifierEscaping);
 
-        var alias = IdentifierUtil.Format(((ParameterExpression)memberExpression.Expression).Name, QueryMetadata.IdentifierEscaping);
+        var alias = IdentifierUtil.Format(((ParameterExpression)memberExpression.Expression).Name,
+          QueryMetadata.IdentifierEscaping);
 
         Append(foundFromItem?.Alias ?? alias);
         Append(".");
@@ -493,7 +507,7 @@ internal class KSqlVisitor : ExpressionVisitor
 
     if (type != fromItem?.Type)
     {
-        Append(memberExpression.Member.Format(QueryMetadata.IdentifierEscaping));
+      Append(memberExpression.Member.Format(QueryMetadata.IdentifierEscaping));
     }
   }
 
@@ -601,7 +615,7 @@ internal class KSqlVisitor : ExpressionVisitor
       else
         Append(ColumnsSeparator);
 
-      if(value is ConstantExpression constantExpression)
+      if (value is ConstantExpression constantExpression)
         Visit(constantExpression);
       else
         Visit(Expression.Constant(value));


### PR DESCRIPTION
JsonPropertyName and PseudoColumn attributes are taken into account when setting column names in linq column selection syntax.

#61