### PR TITLE
68 Linq where ignores jsonpropertynameattribute when using new for column selection causing failing ksqldb request

### DIFF
--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Metadata/EntityMetadataTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Metadata/EntityMetadataTests.cs
@@ -1,0 +1,93 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using ksqlDb.RestApi.Client.KSql.Metadata;
+using NUnit.Framework;
+
+namespace ksqlDb.RestApi.Client.Tests.KSql.Metadata
+{
+  public class EntityMetadataTests
+  {
+    private EntityMetadata entityMetadata = null!;
+
+    [SetUp]
+    public void TestInitialize()
+    {
+      entityMetadata = new();
+    }
+
+    [Test]
+    public void Add_MemberWasStored()
+    {
+      //Arrange
+      var memberInfo = GetTitleMemberInfo();
+
+      //Act
+      var added = entityMetadata.Add(memberInfo);
+
+      //Assert
+      added.Should().BeTrue();
+    }
+
+    private static MemberInfo GetTitleMemberInfo()
+    {
+      Expression<Func<Foo, object>> expression = foo => new { foo.Title };
+      var argument = ((NewExpression)expression.Body).Arguments[0];
+      var memberInfo = ((MemberExpression)argument).Member;
+      return memberInfo;
+    }
+
+    [Test]
+    public void Add_MemberWasNotStoredSecondTime()
+    {
+      //Arrange
+      var memberInfo = GetTitleMemberInfo();
+      entityMetadata.Add(memberInfo);
+
+      //Act
+      var added = entityMetadata.Add(GetTitleMemberInfo());
+
+      //Assert
+      added.Should().BeFalse();
+    }
+
+    [Test]
+    public void TryGetMemberInfo_UnknownMemberName_NullIsReturned()
+    {
+      //Arrange
+      var memberInfo = GetTitleMemberInfo();
+      entityMetadata.Add(memberInfo);
+
+      //Act
+      var result = entityMetadata.TryGetMemberInfo(nameof(Foo.Title));
+
+      //Assert
+      result.Should().NotBeNull();
+      result!.GetCustomAttribute<JsonPropertyNameAttribute>().Should().NotBeNull();
+    }
+
+    [Test]
+    public void TryGetMemberInfo_KnownMemberName_MemberInfoIsReturned()
+    {
+      //Arrange
+      var memberInfo = GetTitleMemberInfo();
+      entityMetadata.Add(memberInfo);
+
+      //Act
+      var result = entityMetadata.TryGetMemberInfo(nameof(Foo.Id));
+
+      //Assert
+      result.Should().BeNull();
+    }
+
+    private record Foo
+    {
+      public string Id { get; set; } = null!;
+
+      [JsonPropertyName("title")]
+      public string Title { get; init; } = null!;
+    }
+  }
+
+}

--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -1,5 +1,8 @@
 # ksqlDB.RestApi.Client
 
+# 4.0.1
+- fixes LINQ Where ignores `JsonPropertyNameAttribute` when using new for column selection, causing failing ksqldb request. #68
+
 # 4.0.0
 - introduced new overloads for dropping entities: `DropTableAsync`, `DropTypeAsync`, and `DropStreamAsync` in `KSqlDbRestApiClient`. These overloads now accept an argument `DropFromItemProperties`, providing more flexibility in configuring the drop operations.
 - extracted `IKSqlDbDropRestApiClient` and `IKSqlDbCreateRestApiClient` interfaces from `IKSqlDbRestApiClient`

--- a/ksqlDb.RestApi.Client/KSql/Metadata/EntityMetadata.cs
+++ b/ksqlDb.RestApi.Client/KSql/Metadata/EntityMetadata.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+
+namespace ksqlDb.RestApi.Client.KSql.Metadata;
+
+internal class EntityMetadata
+{
+  internal Type Type { get; set; } = null!;
+
+  private readonly IDictionary<MemberInfo, FieldMetadata> fieldsMetadata = new Dictionary<MemberInfo, FieldMetadata>();
+  internal IEnumerable<FieldMetadata> FieldsMetadata => fieldsMetadata.Values;
+
+  internal bool Add(MemberInfo memberInfo)
+  {
+    if (!fieldsMetadata.ContainsKey(memberInfo))
+    {
+      var fieldMetadata = new FieldMetadata
+      {
+        MemberInfo = memberInfo
+      };
+      fieldsMetadata[memberInfo] = fieldMetadata;
+      return true;
+    }
+
+    return false;
+  }
+
+  internal MemberInfo? TryGetMemberInfo(string memberInfoName)
+  {
+    return FieldsMetadata.Where(c => c.MemberInfo.Name == memberInfoName).Select(c => c.MemberInfo).FirstOrDefault();
+  }
+}

--- a/ksqlDb.RestApi.Client/KSql/Metadata/FieldMetadata.cs
+++ b/ksqlDb.RestApi.Client/KSql/Metadata/FieldMetadata.cs
@@ -1,0 +1,8 @@
+using System.Reflection;
+
+namespace ksqlDb.RestApi.Client.KSql.Metadata;
+
+internal class FieldMetadata
+{
+  internal MemberInfo MemberInfo { get; init; } = null!;
+}

--- a/ksqlDb.RestApi.Client/KSql/Query/KSqlQueryGenerator.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/KSqlQueryGenerator.cs
@@ -47,7 +47,7 @@ internal class KSqlQueryGenerator(KSqlDBContextOptions options) : ExpressionVisi
 
     queryContext.AutoOffsetReset = autoOffsetReset;
 
-    queryMetadata.FromItemType = fromItemType;
+    queryMetadata.EntityMetadata.Type = fromItemType;
 
     if (joins is {Count: > 0})
     {

--- a/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlQueryMetadata.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlQueryMetadata.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using ksqlDb.RestApi.Client.KSql.Entities;
+using ksqlDb.RestApi.Client.KSql.Metadata;
 using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
 using ksqlDb.RestApi.Client.KSql.RestApi.Parsers;
 
@@ -7,7 +8,9 @@ namespace ksqlDB.RestApi.Client.KSql.Query.Visitors;
 
 internal sealed record KSqlQueryMetadata
 {
-  public Type? FromItemType { get; set; }
+  internal EntityMetadata EntityMetadata { get; } = new();
+
+  public Type FromItemType => EntityMetadata.Type;
 
   public FromItem[]? Joins { get; set; }
 

--- a/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlVisitor.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlVisitor.cs
@@ -378,6 +378,7 @@ internal class KSqlVisitor : ExpressionVisitor
         break;
       case MemberExpression me2 when me2.Member.GetCustomAttribute<JsonPropertyNameAttribute>() != null ||
                                      me2.Member.GetCustomAttribute<PseudoColumnAttribute>() != null:
+        QueryMetadata.EntityMetadata.Add(me2.Member);
         Append(me2.Member.Format(QueryMetadata.IdentifierEscaping));
         break;
       case MemberExpression { Expression.NodeType: ExpressionType.Constant }:
@@ -508,7 +509,8 @@ internal class KSqlVisitor : ExpressionVisitor
 
     if (type != fromItem?.Type)
     {
-      Append(memberExpression.Member.Format(QueryMetadata.IdentifierEscaping));
+      var memberInfo = QueryMetadata.EntityMetadata.TryGetMemberInfo(memberExpression.Member.Name) ?? memberExpression.Member;
+      Append(memberInfo.Format(QueryMetadata.IdentifierEscaping));
     }
   }
 

--- a/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
+++ b/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
@@ -15,8 +15,8 @@
             Documentation for the library can be found at https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/README.md.
         </Description>
         <PackageTags>ksql ksqlDB LINQ .NET csharp push query</PackageTags>
-        <Version>4.0.0</Version>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+        <Version>4.0.1</Version>
+        <AssemblyVersion>4.0.1.0</AssemblyVersion>
         <LangVersion>12.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <PackageReleaseNotes>https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/ksqlDb.RestApi.Client/ChangeLog.md</PackageReleaseNotes>


### PR DESCRIPTION

#68