### PR TITLE
77 Distinguish the configuration for push and pull queries using KSqlDbContextOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ dotnet add package ksqlDb.RestApi.Client
 ```
 This adds a `<PackageReference>` to your csproj file, similar to the following:
 ```XML
-<PackageReference Include="ksqlDb.RestApi.Client" Version="4.0.0" />
+<PackageReference Include="ksqlDb.RestApi.Client" Version="6.0.0" />
 ```
 
 Alternative option is to use [Protobuf content type](https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/docs/protobuf.md):
@@ -24,7 +24,7 @@ Alternative option is to use [Protobuf content type](https://github.com/tomasfab
 dotnet add package ksqlDb.RestApi.Client.ProtoBuf
 ```
 
-The following example can be tried out with a [.NET interactive Notebook](https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/tree/main/Samples/Notebooks):
+Feel free to experiment with the following example in a [.NET interactive Notebook](https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/tree/main/Samples/Notebooks):
 
 ```C#
 using ksqlDB.RestApi.Client.KSql.Linq;
@@ -65,7 +65,8 @@ public class Tweet : Record
 }
 ```
 
-An entity class in **ksqlDB.RestApi.Client** represents the structure of a table or stream. An instance of the class represents a record in that stream while properties are mapped to columns respectively.
+An entity class in **ksqlDB.RestApi.Client** represents the structure of a table or stream.
+An instance of the class represents a record in that stream or table while properties are mapped to columns respectively.
 
 LINQ code written in C# from the sample is equivalent to this KSQL query:
 ```SQL
@@ -164,7 +165,7 @@ This ensures smooth integration with the `ksqlDB.RestApi.Client` library, allowi
 The **server-side Blazor** application communicates with ksqlDB using the `ksqlDB.RestApi.Client`.
 Whenever an event in `ksqlDB` occurs, the server-side Blazor app responds and signals the UI in the client's browser to update. This setup allows a smooth and continuous update flow, creating a real-time, reactive user interface.
 
-- set `docker-compose.csproj` as startup project in [InsideOut.sln](https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/tree/main/Samples/InsideOut) for an embedded Kafka connect integration and stream processing examples.
+- set `docker-compose.csproj` as startup project in [InsideOut.sln](https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/tree/main/Samples/InsideOut) for embedded Kafka connect integration and stream processing examples.
 
 # ```IQbservable<T>``` extension methods
 As depicted below `IObservable<T>` is the dual of `IEnumerable<T>` and `IQbservable<T>` is the dual of `IQueryable<T>`. In all four cases LINQ providers are using deferred execution.
@@ -237,9 +238,8 @@ var contextOptions = new KSqlDbContextOptionsBuilder()
   .SetAutoOffsetReset(AutoOffsetReset.Latest)
   .SetProcessingGuarantee(ProcessingGuarantee.ExactlyOnce)
   .SetIdentifierEscaping(IdentifierEscaping.Keywords)
-  .SetupQueryStream(options =>
+  .SetupPushQuery(options =>
   {
-    //SetupQueryStream affects only IKSqlDBContext.CreateQueryStream<T>
     options.Properties["ksql.query.push.v2.enabled"] = "true";
   })
   .Options;
@@ -253,7 +253,7 @@ This code initializes a `KSqlDbContextOptionsBuilder` to configure settings for 
 - `SetAutoOffsetReset(AutoOffsetReset.Latest)`: Sets the offset reset behavior to start consuming messages from the **latest** available when no committed offset is found. By default, 'auto.offset.reset' is configured to 'earliest'.
 - `SetProcessingGuarantee(ProcessingGuarantee.ExactlyOnce)`: Specifies the processing guarantee as **exactly-once** semantics.
 - `SetIdentifierEscaping(IdentifierEscaping.Keywords)`: Escapes identifiers such as table and column names that are SQL keywords.
-- `SetupQueryStream(options => { ... })`: Configures query stream options, specifically enabling KSQL query push version 2.
+- `SetupPushQuery(options => { ... })`: Configures push query options, specifically enabling KSQL query push version 2.
 
 Finally, `.Options` returns the configured options for the `ksqlDB` context.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ var contextOptions = new KSqlDBContextOptions(ksqlDbUrl)
 
 await using var context = new KSqlDBContext(contextOptions);
 
-using var subscription = context.CreateQueryStream<Tweet>()
+using var subscription = context.CreatePushQuery<Tweet>()
   .WithOffsetResetPolicy(AutoOffsetReset.Latest)
   .Where(p => p.Message != "Hello world" || p.Id == 1)
   .Select(l => new { l.Message, l.Id })
@@ -263,7 +263,7 @@ Stream names are generated based on the generic record types. They are pluralize
 **By default the generated from item names such as stream and table names are pluralized**. This behavior could be switched off with the following `ShouldPluralizeStreamName` configuration.
 
 ```C#
-context.CreateQueryStream<Person>();
+context.CreatePushQuery<Person>();
 ```
 ```SQL
 FROM People
@@ -275,7 +275,7 @@ var contextOptions = new KSqlDBContextOptions(@"http://localhost:8088")
   ShouldPluralizeFromItemName = false
 };
 
-new KSqlDBContext(contextOptions).CreateQueryStream<Person>();
+new KSqlDBContext(contextOptions).CreatePushQuery<Person>();
 ```
 ```SQL
 FROM Person
@@ -283,7 +283,7 @@ FROM Person
 
 Setting an arbitrary stream name (from_item name):
 ```C#
-context.CreateQueryStream<Tweet>("custom_topic_name");
+context.CreatePushQuery<Tweet>("custom_topic_name");
 ```
 ```SQL
 FROM custom_topic_name

--- a/Samples/Aggregations/Aggregations.csproj
+++ b/Samples/Aggregations/Aggregations.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-        <PackageReference Include="ksqlDb.RestApi.Client" Version="5.0.0" />
+        <PackageReference Include="ksqlDb.RestApi.Client" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
 	</ItemGroup>
 

--- a/Samples/Aggregations/KSqlDbContext/ApplicationKSqlDbContext.cs
+++ b/Samples/Aggregations/KSqlDbContext/ApplicationKSqlDbContext.cs
@@ -15,7 +15,7 @@ internal class ApplicationKSqlDbContext : KSqlDBContext, IApplicationKSqlDbConte
   {
   }
 
-  public ksqlDB.RestApi.Client.KSql.Linq.IQbservable<Tweet> Tweets => CreateQueryStream<Tweet>();
+  public ksqlDB.RestApi.Client.KSql.Linq.IQbservable<Tweet> Tweets => CreatePushQuery<Tweet>();
 }
 
 public interface IApplicationKSqlDbContext : IKSqlDBContext

--- a/Samples/Avro/Avro.Samples.csproj
+++ b/Samples/Avro/Avro.Samples.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="ksqlDb.RestApi.Client" Version="5.0.0" />
+        <PackageReference Include="ksqlDb.RestApi.Client" Version="6.0.0" />
 	<PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.3.0" />
     </ItemGroup>
 </Project>

--- a/Samples/Avro/Program.cs
+++ b/Samples/Avro/Program.cs
@@ -50,7 +50,7 @@ Console.WriteLine(httpResponse);
 
 await using var context = new KSqlDBContext(ksqlDbUrl);
 
-using var disposable = context.CreateQueryStream<IoTSensor>()
+using var disposable = context.CreatePushQuery<IoTSensor>()
   .ToObservable()
   .Subscribe(onNext: sensor =>
     {

--- a/Samples/Blazor.Sample/Blazor.Sample.csproj
+++ b/Samples/Blazor.Sample/Blazor.Sample.csproj
@@ -22,7 +22,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ksqlDb.RestApi.Client" Version="6.0.0-rc.2" />
+		<PackageReference Include="ksqlDb.RestApi.Client" Version="6.0.0" />
 		<PackageReference Include="SqlServer.Connector" Version="1.0.0" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.0" />
 	</ItemGroup>

--- a/Samples/Blazor.Sample/Blazor.Sample.csproj
+++ b/Samples/Blazor.Sample/Blazor.Sample.csproj
@@ -22,7 +22,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ksqlDb.RestApi.Client" Version="4.0.0" />
+		<PackageReference Include="ksqlDb.RestApi.Client" Version="6.0.0-rc.2" />
 		<PackageReference Include="SqlServer.Connector" Version="1.0.0" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.0" />
 	</ItemGroup>
@@ -30,7 +30,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\Samples\InsideOut\InsideOut.csproj" />
 		<!-- <ProjectReference Include="..\..\SqlServer.Connector\SqlServer.Connector.csproj" /> -->
-        <!-- <ProjectReference Include="..\..\ksqlDb.RestApi.Client\ksqlDb.RestApi.Client.csproj" />  -->
+        <!-- <ProjectReference Include="..\..\ksqlDb.RestApi.Client\ksqlDb.RestApi.Client.csproj" /> -->
 	</ItemGroup>
 
 </Project>

--- a/Samples/Blazor.Sample/Components/Pages/KafkaStreamComponent.razor.cs
+++ b/Samples/Blazor.Sample/Components/Pages/KafkaStreamComponent.razor.cs
@@ -81,7 +81,7 @@ partial class KafkaStreamComponent : IDisposable
 
     await using var context = new KSqlDBContext(options);
 
-    context.CreateQuery<SensorsStream>("SensorsStream")
+    context.CreateQueryStream<SensorsStream>("SensorsStream")
       .ToObservable()
       .ObserveOn(synchronizationContext)
       .Subscribe(c =>

--- a/Samples/Blazor.Sample/Components/Pages/KafkaStreamComponent.razor.cs
+++ b/Samples/Blazor.Sample/Components/Pages/KafkaStreamComponent.razor.cs
@@ -81,7 +81,7 @@ partial class KafkaStreamComponent : IDisposable
 
     await using var context = new KSqlDBContext(options);
 
-    context.CreateQueryStream<SensorsStream>("SensorsStream")
+    context.CreatePushQuery<SensorsStream>("SensorsStream")
       .ToObservable()
       .ObserveOn(synchronizationContext)
       .Subscribe(c =>

--- a/Samples/Blazor.Sample/Components/Pages/KafkaTableComponent.razor.cs
+++ b/Samples/Blazor.Sample/Components/Pages/KafkaTableComponent.razor.cs
@@ -37,7 +37,7 @@ public partial class KafkaTableComponent : IDisposable
       
     await using var context = new KSqlDBContext(options);
 
-    subscription = context.CreateQuery<IoTSensorStats>(TopicNames.SensorsTable)
+    subscription = context.CreateQueryStream<IoTSensorStats>(TopicNames.SensorsTable)
       .ToObservable()
       .ObserveOn(synchronizationContext)
       .Subscribe(c =>

--- a/Samples/Blazor.Sample/Components/Pages/KafkaTableComponent.razor.cs
+++ b/Samples/Blazor.Sample/Components/Pages/KafkaTableComponent.razor.cs
@@ -37,7 +37,7 @@ public partial class KafkaTableComponent : IDisposable
       
     await using var context = new KSqlDBContext(options);
 
-    subscription = context.CreateQueryStream<IoTSensorStats>(TopicNames.SensorsTable)
+    subscription = context.CreatePushQuery<IoTSensorStats>(TopicNames.SensorsTable)
       .ToObservable()
       .ObserveOn(synchronizationContext)
       .Subscribe(c =>

--- a/Samples/Blazor.Sample/Components/Pages/SqlServerCDC/SqlServerComponent.razor.cs
+++ b/Samples/Blazor.Sample/Components/Pages/SqlServerCDC/SqlServerComponent.razor.cs
@@ -213,7 +213,7 @@ CREATE STREAM IF NOT EXISTS sqlserversensors (
 
     await using var context = new KSqlDBContext(options);
 
-    cdcSubscription = context.CreateQueryStream<IoTSensorChange>("sqlserversensors")
+    cdcSubscription = context.CreatePushQuery<IoTSensorChange>("sqlserversensors")
       .WithOffsetResetPolicy(AutoOffsetReset.Latest)
       .Where(c => c.Op != "r" && (c.After == null || c.After.SensorId != "d542a2b3-c"))
       .ToObservable()
@@ -237,7 +237,7 @@ CREATE STREAM IF NOT EXISTS sqlserversensors (
 
     await using var context = new KSqlDBContext(options);
 
-    cdcSubscription = context.CreateQueryStream<IoTSensorRawChange>("sqlserversensors")
+    cdcSubscription = context.CreatePushQuery<IoTSensorRawChange>("sqlserversensors")
       .WithOffsetResetPolicy(AutoOffsetReset.Latest)
       .ToObservable()
       .ObserveOn(synchronizationContext)

--- a/Samples/Blazor.Sample/Components/Pages/SqlServerCDC/SqlServerComponent.razor.cs
+++ b/Samples/Blazor.Sample/Components/Pages/SqlServerCDC/SqlServerComponent.razor.cs
@@ -213,7 +213,7 @@ CREATE STREAM IF NOT EXISTS sqlserversensors (
 
     await using var context = new KSqlDBContext(options);
 
-    cdcSubscription = context.CreateQuery<IoTSensorChange>("sqlserversensors")
+    cdcSubscription = context.CreateQueryStream<IoTSensorChange>("sqlserversensors")
       .WithOffsetResetPolicy(AutoOffsetReset.Latest)
       .Where(c => c.Op != "r" && (c.After == null || c.After.SensorId != "d542a2b3-c"))
       .ToObservable()
@@ -237,7 +237,7 @@ CREATE STREAM IF NOT EXISTS sqlserversensors (
 
     await using var context = new KSqlDBContext(options);
 
-    cdcSubscription = context.CreateQuery<IoTSensorRawChange>("sqlserversensors")
+    cdcSubscription = context.CreateQueryStream<IoTSensorRawChange>("sqlserversensors")
       .WithOffsetResetPolicy(AutoOffsetReset.Latest)
       .ToObservable()
       .ObserveOn(synchronizationContext)

--- a/Samples/DataTypes/DataTypes.csproj
+++ b/Samples/DataTypes/DataTypes.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-        <PackageReference Include="ksqlDb.RestApi.Client" Version="5.0.0" />
+        <PackageReference Include="ksqlDb.RestApi.Client" Version="6.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/Samples/DataTypes/Program.cs
+++ b/Samples/DataTypes/Program.cs
@@ -29,7 +29,7 @@ Console.ReadKey();
 
 static async Task StructType(KSqlDBContext context)
 {
-  var moviesStream = context.CreateQueryStream<Movie>();
+  var moviesStream = context.CreatePushQuery<Movie>();
 
   var source = moviesStream.Select(c => new
   {
@@ -46,12 +46,12 @@ static async Task StructType(KSqlDBContext context)
 static IDisposable Arrays(KSqlDBContext context)
 {
   var subscription =
-    context.CreateQueryStream<Movie>()
+    context.CreatePushQuery<Movie>()
       .Select(_ => new { FirstItem = new[] { 1, 2, 3 }[1] })
       .Subscribe(onNext: c => { Console.WriteLine($"Array first value: {c}"); },
         onError: error => { Console.WriteLine($"Exception: {error.Message}"); });
 
-  var arrayLengthQuery = context.CreateQueryStream<Movie>()
+  var arrayLengthQuery = context.CreatePushQuery<Movie>()
     .Select(_ => new[] { 1, 2, 3 }.Length)
     .ToQueryString();
 
@@ -61,7 +61,7 @@ static IDisposable Arrays(KSqlDBContext context)
 static IDisposable NestedTypes(KSqlDBContext context)
 {
   var disposable =
-    context.CreateQueryStream<Movie>()
+    context.CreatePushQuery<Movie>()
       .Select(c => new
       {
         MapValue = new Dictionary<string, Dictionary<string, int>>
@@ -86,7 +86,7 @@ static IDisposable NestedTypes(KSqlDBContext context)
 
 static async Task DeeplyNestedTypes(KSqlDBContext context)
 {
-  var moviesStream = context.CreateQueryStream<Movie>();
+  var moviesStream = context.CreatePushQuery<Movie>();
 
   var source = moviesStream.Select(c => new
   {
@@ -140,12 +140,12 @@ static async Task TimeTypes(IKSqlDbRestApiClient restApiClient, IKSqlDBContext c
   var from = new TimeSpan(1, 0, 0);
   var to = new TimeSpan(22, 0, 0);
 
-  var query = context.CreateQueryStream<Dates>()
+  var query = context.CreatePushQuery<Dates>()
     .Select(c => new { c.Ts, to, FromTime = from, DateTime.Now, New = new TimeSpan(1, 0, 0) })
     .ToQueryString();
 
   //.Select(c => new { c.Ts, to, FromTime = from, DateTime.Now, New = new TimeSpan(1, 0, 0) })
-  using var subscription = context.CreateQueryStream<Dates>()
+  using var subscription = context.CreatePushQuery<Dates>()
     .Where(c => c.Ts.Between(from, to))
     .Subscribe(onNext: m =>
     {
@@ -169,7 +169,7 @@ static async Task TimeTypes(IKSqlDbRestApiClient restApiClient, IKSqlDBContext c
 
 static void Bytes(IKSqlDBContext ksqlDbContext)
 {
-  var ksql = ksqlDbContext.CreateQuery<Thumbnail>()
+  var ksql = ksqlDbContext.CreatePushQuery<Thumbnail>()
     .Select(c => new { Col = K.Functions.FromBytes(c.Image, "hex") })
     .ToQueryString();
 }
@@ -186,7 +186,7 @@ Drop table {nameof(Event)};
   httpResponseMessage = await restApiClient.CreateTypeAsync<EventCategory>();
   httpResponseMessage = await restApiClient.CreateTableAsync<Event>(new EntityCreationMetadata("Events") { Partitions = 1 });
 
-  var subscription = ksqlDbContext.CreateQueryStream<Event>()
+  var subscription = ksqlDbContext.CreatePushQuery<Event>()
     .Subscribe(value =>
     {
       Console.WriteLine("Categories: ");

--- a/Samples/GraphQL/GraphQL.csproj
+++ b/Samples/GraphQL/GraphQL.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="HotChocolate.AspNetCore" Version="13.9.0" />
     <PackageReference Include="HotChocolate.Data" Version="13.9.0" />
-    <PackageReference Include="ksqlDb.RestApi.Client" Version="4.0.0" />
+    <PackageReference Include="ksqlDb.RestApi.Client" Version="6.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
   </ItemGroup>
 </Project>

--- a/Samples/GraphQL/ksqlDB/MoviesKSqlDbContext.cs
+++ b/Samples/GraphQL/ksqlDB/MoviesKSqlDbContext.cs
@@ -16,5 +16,5 @@ internal class MoviesKSqlDbContext : KSqlDBContext, IMoviesKSqlDbContext
   {
   }
 
-  public IQbservable<Movie> Movies => CreateQueryStream<Movie>();
+  public IQbservable<Movie> Movies => CreatePushQuery<Movie>();
 }

--- a/Samples/Joins/Joins.csproj
+++ b/Samples/Joins/Joins.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-        <PackageReference Include="ksqlDb.RestApi.Client" Version="5.0.0" />
+        <PackageReference Include="ksqlDb.RestApi.Client" Version="6.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/Samples/Joins/Program.cs
+++ b/Samples/Joins/Program.cs
@@ -40,7 +40,7 @@ async Task SubscribeAsync(IKSqlDbRestApiClient restApiClient)
 
   var value = new Foo { Prop = 42 };
 
-  var query = (from o in context.CreateQueryStream<Order>()
+  var query = (from o in context.CreatePushQuery<Order>()
                join p1 in Source.Of<Payment>() on o.PaymentId equals p1.Id
                join s1 in Source.Of<Shipment>() on o.ShipmentId equals s1.Id into gj
                from sa in gj.DefaultIfEmpty()
@@ -94,7 +94,7 @@ static IDisposable JoinTables(KSqlDBContext context)
 {
   var queryWithin = Source.Of<Lead_Actor>().Within(Duration.OfHours(1), Duration.OfDays(5));
 
-  var rightJoinQueryString = context.CreateQueryStream<Movie>()
+  var rightJoinQueryString = context.CreatePushQuery<Movie>()
     .RightJoin(
       Source.Of<Lead_Actor>(nameof(Lead_Actor)),
       movie => movie.Title,
@@ -106,7 +106,7 @@ static IDisposable JoinTables(KSqlDBContext context)
       }
     ).ToQueryString();
 
-  var query = context.CreateQueryStream<Movie>()
+  var query = context.CreatePushQuery<Movie>()
     .Join(
       Source.Of<Lead_Actor>(nameof(Lead_Actor)),
       movie => movie.Title,
@@ -130,7 +130,7 @@ static IDisposable JoinTables(KSqlDBContext context)
 
 static IQbservable<dynamic> LeftJoin()
 {
-  var query = new KSqlDBContext(@"http://localhost:8088").CreateQueryStream<Movie>()
+  var query = new KSqlDBContext(@"http://localhost:8088").CreatePushQuery<Movie>()
     .LeftJoin(
       Source.Of<Lead_Actor>(),
       movie => movie.Title,
@@ -147,7 +147,7 @@ static IQbservable<dynamic> LeftJoin()
 
 static IDisposable FullOuterJoinTables(KSqlDBContext context)
 {
-  var query = context.CreateQueryStream<MovieNullableFields>("Movies")
+  var query = context.CreatePushQuery<MovieNullableFields>("Movies")
     .FullOuterJoin(
       Source.Of<Lead_Actor>(nameof(Lead_Actor)),
       movie => movie.Title,

--- a/Samples/Statements/Program.cs
+++ b/Samples/Statements/Program.cs
@@ -147,7 +147,7 @@ static async Task GetKsqlDbInformationAsync(IKSqlDbRestApiClient restApiProvider
 
 static async Task TerminatePushQueryAsync(IKSqlDBContext context, IKSqlDbRestApiClient restApiClient)
 {
-  var subscription = await context.CreateQueryStream<Event>()
+  var subscription = await context.CreatePushQuery<Event>()
     .SubscribeOn(ThreadPoolScheduler.Instance)
     .SubscribeAsync(onNext: _ => { }, onError: e => { }, onCompleted: () => { });
 

--- a/Samples/Statements/Statements.csproj
+++ b/Samples/Statements/Statements.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-        <PackageReference Include="ksqlDb.RestApi.Client" Version="5.0.0" />
+        <PackageReference Include="ksqlDb.RestApi.Client" Version="6.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/Samples/ksqlDB.RestApi.Client.DotNetFramework.Sample/Program.cs
+++ b/Samples/ksqlDB.RestApi.Client.DotNetFramework.Sample/Program.cs
@@ -8,13 +8,13 @@ using ksqlDB.RestApi.Client.DotNetFramework.Sample.Models;
 using ksqlDB.RestApi.Client.DotNetFramework.Sample.Models.Movies;
 using ksqlDB.RestApi.Client.DotNetFramework.Sample.Providers;
 using ksqlDB.RestApi.Client.DotNetFramework.Sample.PullQuery;
+using ksqlDB.RestApi.Client.KSql.Config;
 using ksqlDB.RestApi.Client.KSql.Linq;
 using ksqlDB.RestApi.Client.KSql.Query.Context;
 using ksqlDB.RestApi.Client.KSql.Query.Context.Options;
 using ksqlDB.RestApi.Client.KSql.Query.Functions;
 using ksqlDB.RestApi.Client.KSql.Query.Options;
 using ksqlDB.RestApi.Client.KSql.RestApi.Http;
-using ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
 
 namespace ksqlDB.RestApi.Client.DotNetFramework.Sample
 {
@@ -24,9 +24,10 @@ namespace ksqlDB.RestApi.Client.DotNetFramework.Sample
     {
       var contextOptions = new KSqlDbContextOptionsBuilder()
         .UseKSqlDb(ksqlDbUrl)
-        .SetupQueryStream(options =>
+        .SetupPushQuery(options =>
         {
-          options.Properties[QueryParameters.AutoOffsetResetPropertyName] = AutoOffsetReset.Earliest.ToString().ToLower(); // "latest"
+          options.AutoOffsetReset = AutoOffsetReset.Earliest;
+          options.Properties[KSqlDbConfigs.KsqlQueryPushV2Enabled] = "true";
         })
         .Options;
 
@@ -52,7 +53,7 @@ namespace ksqlDB.RestApi.Client.DotNetFramework.Sample
 
       var context = new KSqlDBContext(contextOptions);
 
-      var subscription = context.CreateQueryStream<Movie>()
+      var subscription = context.CreatePushQuery<Movie>()
         .Where(p => p.Title != "E.T.")
         .Where(c => K.Functions.Like(c.Title.ToLower(), "%hard%".ToLower()) || c.Id == 1)
         .Where(p => p.RowTime >= 1510923225000) //AND RowTime >= 1510923225000
@@ -94,7 +95,7 @@ namespace ksqlDB.RestApi.Client.DotNetFramework.Sample
 
     private static IDisposable CountDistinct(KSqlDBContext context)
     {
-      var subscription = context.CreateQueryStream<Tweet>()
+      var subscription = context.CreatePushQuery<Tweet>()
         .GroupBy(c => c.Id)
         .Select(g => new { Id = g.Key, Count = g.LongCountDistinct(c => c.Message) })
         .Subscribe(c =>
@@ -109,7 +110,7 @@ namespace ksqlDB.RestApi.Client.DotNetFramework.Sample
     {
       bool sorted = true;
 
-      var subscription = context.CreateQueryStream<Movie>()
+      var subscription = context.CreatePushQuery<Movie>()
         .Select(c => new
         {
           Entries = KSqlFunctions.Instance.Entries(new Dictionary<string, string>()
@@ -144,7 +145,7 @@ namespace ksqlDB.RestApi.Client.DotNetFramework.Sample
     
     private static async Task DeeplyNestedTypes(KSqlDBContext context)
     {
-      var moviesStream = context.CreateQueryStream<Movie>();
+      var moviesStream = context.CreatePushQuery<Movie>();
 
       var source = moviesStream.Select(c => new
       {

--- a/Samples/ksqlDB.RestApi.Client.DotNetFramework.Sample/Program.cs
+++ b/Samples/ksqlDB.RestApi.Client.DotNetFramework.Sample/Program.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
@@ -25,7 +24,7 @@ namespace ksqlDB.RestApi.Client.DotNetFramework.Sample
     {
       var contextOptions = new KSqlDbContextOptionsBuilder()
         .UseKSqlDb(ksqlDbUrl)
-        .SetupQuery(options =>
+        .SetupQueryStream(options =>
         {
           options.Properties[QueryParameters.AutoOffsetResetPropertyName] = AutoOffsetReset.Earliest.ToString().ToLower(); // "latest"
         })
@@ -53,7 +52,7 @@ namespace ksqlDB.RestApi.Client.DotNetFramework.Sample
 
       var context = new KSqlDBContext(contextOptions);
 
-      var subscription = context.CreateQuery<Movie>()
+      var subscription = context.CreateQueryStream<Movie>()
         .Where(p => p.Title != "E.T.")
         .Where(c => K.Functions.Like(c.Title.ToLower(), "%hard%".ToLower()) || c.Id == 1)
         .Where(p => p.RowTime >= 1510923225000) //AND RowTime >= 1510923225000
@@ -95,7 +94,7 @@ namespace ksqlDB.RestApi.Client.DotNetFramework.Sample
 
     private static IDisposable CountDistinct(KSqlDBContext context)
     {
-      var subscription = context.CreateQuery<Tweet>()
+      var subscription = context.CreateQueryStream<Tweet>()
         .GroupBy(c => c.Id)
         .Select(g => new { Id = g.Key, Count = g.LongCountDistinct(c => c.Message) })
         .Subscribe(c =>
@@ -110,7 +109,7 @@ namespace ksqlDB.RestApi.Client.DotNetFramework.Sample
     {
       bool sorted = true;
 
-      var subscription = context.CreateQuery<Movie>()
+      var subscription = context.CreateQueryStream<Movie>()
         .Select(c => new
         {
           Entries = KSqlFunctions.Instance.Entries(new Dictionary<string, string>()
@@ -145,7 +144,7 @@ namespace ksqlDB.RestApi.Client.DotNetFramework.Sample
     
     private static async Task DeeplyNestedTypes(KSqlDBContext context)
     {
-      var moviesStream = context.CreateQuery<Movie>();
+      var moviesStream = context.CreateQueryStream<Movie>();
 
       var source = moviesStream.Select(c => new
       {

--- a/Samples/ksqlDB.RestApi.Client.DotNetFramework.Sample/ksqlDB.RestApi.Client.DotNetFramework.Sample.csproj
+++ b/Samples/ksqlDB.RestApi.Client.DotNetFramework.Sample/ksqlDB.RestApi.Client.DotNetFramework.Sample.csproj
@@ -66,7 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ksqlDb.RestApi.Client">
-      <Version>6.0.0-rc.2</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
       <Version>8.0.0</Version>

--- a/Samples/ksqlDB.RestApi.Client.DotNetFramework.Sample/ksqlDB.RestApi.Client.DotNetFramework.Sample.csproj
+++ b/Samples/ksqlDB.RestApi.Client.DotNetFramework.Sample/ksqlDB.RestApi.Client.DotNetFramework.Sample.csproj
@@ -66,7 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ksqlDb.RestApi.Client">
-      <Version>5.0.0</Version>
+      <Version>6.0.0-rc.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
       <Version>8.0.0</Version>

--- a/Samples/ksqlDB.RestApi.Client.LinqPad/ksqlDB.RestApi.Client.linq
+++ b/Samples/ksqlDB.RestApi.Client.LinqPad/ksqlDB.RestApi.Client.linq
@@ -39,7 +39,7 @@ async Task Main()
 
 	var semaphoreSlim = new SemaphoreSlim(0, 1);
 
-	using var disposable = context.CreateQueryStream<Movie>(MoviesStreamName)
+	using var disposable = context.CreatePushQuery<Movie>(MoviesStreamName)
 		.Where(p => p.Title != "E.T.")
 		.Where(c => K.Functions.Like(c.Title.ToLower(), "%hard%".ToLower()) || c.Id == 1)
 		.Where(p => p.RowTime >= 1510923225000)

--- a/Samples/ksqlDB.RestApi.Client.LinqPad/sqlserver.connector.linq
+++ b/Samples/ksqlDB.RestApi.Client.LinqPad/sqlserver.connector.linq
@@ -40,7 +40,7 @@ async Task Main()
 
 	var semaphoreSlim = new SemaphoreSlim(0, 1);
 	
-	var cdcSubscription = context.CreateQuery<DatabaseChangeObject<IoTSensor>>("sqlserversensors")
+	var cdcSubscription = context.CreatePushQuery<DatabaseChangeObject<IoTSensor>>("sqlserversensors")
 		.WithOffsetResetPolicy(ksqlDB.RestApi.Client.KSql.Query.Options.AutoOffsetReset.Latest)
 		.Take(5)
 		.ToObservable()

--- a/Samples/ksqlDB.RestApi.Client.Sample/Program.cs
+++ b/Samples/ksqlDB.RestApi.Client.Sample/Program.cs
@@ -58,10 +58,9 @@ public static class Program
         //SetupQueryStream affects only EndpointType.QueryStream
         options.Properties[KSqlDbConfigs.KsqlQueryPushV2Enabled] = "true";
       })
-      .SetupQuery(options =>
+      .SetupPullQuery(options =>
       {
-        //SetupQuery affects only EndpointType.Query
-        options.Properties[KSqlDbConfigs.ProcessingGuarantee] = ProcessingGuarantee.ExactlyOnce.ToKSqlValue();
+        options[KSqlDbConfigs.KsqlQueryPullTableScanEnabled] = "false";
       })
       .Options;
 

--- a/Samples/ksqlDB.RestApi.Client.Sample/Program.cs
+++ b/Samples/ksqlDB.RestApi.Client.Sample/Program.cs
@@ -38,7 +38,7 @@ namespace ksqlDB.RestApi.Client.Samples;
 // ReSharper disable UnusedVariable
 public static class Program
 {
-  public static KSqlDBContextOptions CreateQueryStreamOptions(string ksqlDbUrl)
+  public static KSqlDBContextOptions CreateKSqlDbContextOptions(string ksqlDbUrl)
   {
     var contextOptions = new KSqlDbContextOptionsBuilder()
       .UseKSqlDb(ksqlDbUrl)
@@ -85,7 +85,7 @@ public static class Program
 
     await moviesProvider.CreateTablesAsync();
 
-    var contextOptions = CreateQueryStreamOptions(ksqlDbUrl);
+    var contextOptions = CreateKSqlDbContextOptions(ksqlDbUrl);
 
     await using var context = new KSqlDBContext(contextOptions, loggerFactory);
 

--- a/Samples/ksqlDB.RestApi.Client.Sample/Program.cs
+++ b/Samples/ksqlDB.RestApi.Client.Sample/Program.cs
@@ -53,9 +53,8 @@ public static class Program
       .SetIdentifierEscaping(IdentifierEscaping.Keywords)
       .SetEndpointType(EndpointType.QueryStream) // uses HTTP/2.0
       //.SetEndpointType(EndpointType.Query) // uses HTTP/1.0
-      .SetupQueryStream(options =>
+      .SetupPushQuery(options =>
       {
-        //SetupQueryStream affects only EndpointType.QueryStream
         options.Properties[KSqlDbConfigs.KsqlQueryPushV2Enabled] = "true";
       })
       .SetupPullQuery(options =>
@@ -417,7 +416,8 @@ public static class Program
     QueryStreamParameters queryStreamParameters = new QueryStreamParameters
     {
       Sql = ksql,
-      [QueryStreamParameters.AutoOffsetResetPropertyName] = "earliest",
+      AutoOffsetReset = AutoOffsetReset.Earliest,
+      [KSqlDbConfigs.KsqlQueryPushV2Enabled] = "true"
     };
 
     var disposable = context.CreateQueryStream<Movie>(queryStreamParameters)

--- a/Samples/ksqlDB.RestApi.Client.Sample/Program.cs
+++ b/Samples/ksqlDB.RestApi.Client.Sample/Program.cs
@@ -89,7 +89,7 @@ public static class Program
 
     await using var context = new KSqlDBContext(contextOptions, loggerFactory);
 
-    var query = context.CreateQueryStream<Movie>()
+    var query = context.CreatePushQuery<Movie>()
       .Where(p => p.Title != "E.T.")
       .Where(c => c.Title.ToLower().Contains("hard".ToLower()) || c.Id == 1)
       .Where(p => p.RowTime >= 1510923225000)
@@ -201,7 +201,7 @@ public static class Program
 
     var semaphoreSlim = new SemaphoreSlim(0, 1);
 
-    using var d1 = context.CreateQueryStream<Movie>()
+    using var d1 = context.CreatePushQuery<Movie>()
       .Take(2)
       //Movies are deserialized with SourceGenerationContext (see SetJsonSerializerOptions above)
       .Subscribe(onNext: movie =>
@@ -239,7 +239,7 @@ public static class Program
 
     try
     {
-      var subscription = await context.CreateQueryStream<Movie>()
+      var subscription = await context.CreatePushQuery<Movie>()
         .SubscribeOn(ThreadPoolScheduler.Instance)
         .ObserveOn(TaskPoolScheduler.Default)
         .SubscribeAsync(onNext: movie =>
@@ -263,7 +263,7 @@ public static class Program
 
   private static IDisposable ClientSideBatching(KSqlDBContext context)
   {
-    var disposable = context.CreateQueryStream<Tweet>()
+    var disposable = context.CreatePushQuery<Tweet>()
       .ToObservable()
       .Buffer(TimeSpan.FromMilliseconds(250), 100)
       .Where(c => c.Count > 0)
@@ -282,7 +282,7 @@ public static class Program
   private static async Task AsyncEnumerable(KSqlDBContext context)
   {
     var cts = new CancellationTokenSource();
-    var asyncTweetsEnumerable = context.CreateQueryStream<Movie>().ToAsyncEnumerable();
+    var asyncTweetsEnumerable = context.CreatePushQuery<Movie>().ToAsyncEnumerable();
 
     await foreach (var movie in asyncTweetsEnumerable.WithCancellation(cts.Token))
     {
@@ -294,7 +294,7 @@ public static class Program
 
   private static void Between(IKSqlDBContext context)
   {
-    var ksql = context.CreateQueryStream<Tweet>().Where(c => c.Id.Between(1, 5))
+    var ksql = context.CreatePushQuery<Tweet>().Where(c => c.Id.Between(1, 5))
       .ToQueryString();
   }
 
@@ -303,7 +303,7 @@ public static class Program
     var contextOptions = new KSqlDBContextOptions(ksqlDbUrl);
     var context = new KSqlDBContext(contextOptions);
 
-    var subscription = context.CreateQueryStream<Tweet>()
+    var subscription = context.CreatePushQuery<Tweet>()
       .Where(p => p.Message != "Hello world" && p.Id != 1)
       .Take(2)
       .Subscribe(new TweetsObserver());
@@ -316,7 +316,7 @@ public static class Program
     var contextOptions = new KSqlDBContextOptions(ksqlDbUrl);
     var context = new KSqlDBContext(contextOptions);
 
-    var subscriptions = context.CreateQueryStream<Tweet>()
+    var subscriptions = context.CreatePushQuery<Tweet>()
       .ToObservable()
       .Delay(TimeSpan.FromSeconds(2)) // IObservable extensions
       .Subscribe(new TweetsObserver());
@@ -336,7 +336,7 @@ public static class Program
     var contextOptions = new KSqlDBContextOptions(ksqlDbUrl);
     await using var context = new KSqlDBContext(contextOptions);
 
-    var ksql = context.CreateQueryStream<Person>().ToQueryString();
+    var ksql = context.CreatePushQuery<Person>().ToQueryString();
 
     //prints SELECT * FROM People EMIT CHANGES;
     Console.WriteLine(ksql);
@@ -344,7 +344,7 @@ public static class Program
 
   private static IDisposable NotNull(KSqlDBContext context)
   {
-    return context.CreateQueryStream<Click>()
+    return context.CreatePushQuery<Click>()
       .Where(c => c.IP_ADDRESS != null)
       .Select(c => new { c.IP_ADDRESS, c.URL, c.TIMESTAMP })
       .Subscribe(Console.WriteLine, error => { Console.WriteLine($"Exception: {error.Message}"); });
@@ -352,11 +352,11 @@ public static class Program
 
   private static IDisposable DynamicFunctionCall(KSqlDBContext context)
   {
-    var ifNullQueryString = context.CreateQueryStream<Tweet>()
+    var ifNullQueryString = context.CreatePushQuery<Tweet>()
       .Select(c => new { c.Id, c.Amount, Col = K.F.Dynamic("IFNULL(Message, 'n/a')") as string })
       .ToQueryString();
 
-    return context.CreateQueryStream<Tweet>()
+    return context.CreatePushQuery<Tweet>()
       .Select(c => K.Functions.Dynamic("ARRAY_DISTINCT(ARRAY[1, 1, 2, 3, 1, 2])") as int[])
       .Subscribe(
         array => Console.WriteLine($"{array![0]} - {array[^1]}"),
@@ -365,7 +365,7 @@ public static class Program
 
   private static void ScalarFunctions(KSqlDBContext context)
   {
-    context.CreateQueryStream<Tweet>()
+    context.CreatePushQuery<Tweet>()
       .Select(c => new
       {
         Abs = K.Functions.Abs(c.Amount),
@@ -381,7 +381,7 @@ public static class Program
   {
     bool sorted = true;
 
-    var subscription = context.CreateQueryStream<Movie>()
+    var subscription = context.CreatePushQuery<Movie>()
       .Select(c => new
       {
         Entries = KSqlFunctions.Instance.Entries(new Dictionary<string, string>()
@@ -409,7 +409,7 @@ public static class Program
 
   private static IDisposable QueryStreamRawKSql(KSqlDBContext context)
   {
-    string ksql = context.CreateQueryStream<Movie>()
+    string ksql = context.CreatePushQuery<Movie>()
       .Where(p => p.Title != "E.T.").Take(2)
       .ToQueryString();
 
@@ -420,7 +420,7 @@ public static class Program
       [KSqlDbConfigs.KsqlQueryPushV2Enabled] = "true"
     };
 
-    var disposable = context.CreateQueryStream<Movie>(queryStreamParameters)
+    var disposable = context.CreatePushQuery<Movie>(queryStreamParameters)
       .ToObservable()
       .Subscribe(onNext: movie =>
         {
@@ -460,7 +460,7 @@ public static class Program
 
     string queryId = "insert_query_book";
 
-    var response = await context.CreateQueryStream<Book>(streamNameFrom)
+    var response = await context.CreatePushQuery<Book>(streamNameFrom)
       .Where(c => c.Title != "Apocalypse now")
       .InsertIntoAsync(streamName, queryId);
 
@@ -479,7 +479,7 @@ WHERE Title != 'E.T.' EMIT CHANGES LIMIT 2;";
       [QueryStreamParameters.AutoOffsetResetPropertyName] = AutoOffsetReset.Earliest.ToKSqlValue(),
     };
 
-    var disposable = context.CreateQueryStream<Movie>(queryParameters)
+    var disposable = context.CreatePushQuery<Movie>(queryParameters)
       .ToObservable()
       .Subscribe(onNext: movie =>
         {
@@ -494,7 +494,7 @@ WHERE Title != 'E.T.' EMIT CHANGES LIMIT 2;";
   private static void Cast(IKSqlDBContext context)
   {
     //SELECT Id, CAST(COUNT(*) AS VARCHAR) Count, CAST('42' AS INT) TheAnswer FROM Movies GROUP BY Id EMIT CHANGES;
-    var query = context.CreateQueryStream<Movie>()
+    var query = context.CreatePushQuery<Movie>()
       .GroupBy(c => c.Id)
       .Select(c => new { Id = c.Key, Count = c.Count().ToString(), TheAnswer = KSQLConvert.ToInt32("42") })
       .ToQueryString();
@@ -502,7 +502,7 @@ WHERE Title != 'E.T.' EMIT CHANGES LIMIT 2;";
 
   private static void WithOffsetResetPolicy(IKSqlDBContext context)
   {
-    var subscription = context.CreateQueryStream<Movie>()
+    var subscription = context.CreatePushQuery<Movie>()
       .WithOffsetResetPolicy(AutoOffsetReset.Latest)
       .Subscribe(movie =>
       {
@@ -512,7 +512,7 @@ WHERE Title != 'E.T.' EMIT CHANGES LIMIT 2;";
 
   private static void InvocationFunctions(IKSqlDBContext ksqlDbContext)
   {
-    var ksql = ksqlDbContext.CreateQueryStream<Lambda>()
+    var ksql = ksqlDbContext.CreatePushQuery<Lambda>()
       .Select(c => new
       {
         Transformed = c.Lambda_Arr.Transform(x => x + 1),
@@ -523,7 +523,7 @@ WHERE Title != 'E.T.' EMIT CHANGES LIMIT 2;";
 
     Console.WriteLine(ksql);
 
-    var ksqlMap = ksqlDbContext.CreateQueryStream<Lambda>()
+    var ksqlMap = ksqlDbContext.CreatePushQuery<Lambda>()
       .Select(c => new
       {
         Transformed = K.Functions.Transform(c.DictionaryArrayValues, (k, v) => K.Functions.Concat(k, "_new"), (k, v) => K.Functions.Transform(v, x => x * x)),

--- a/Samples/ksqlDB.RestApi.Client.Sample/ProtoBuf/ProtoBufQueryStream.cs
+++ b/Samples/ksqlDB.RestApi.Client.Sample/ProtoBuf/ProtoBufQueryStream.cs
@@ -13,7 +13,7 @@ public class ProtoBufQueryStream
 
     await using var context = new ProtoBufKSqlDbContext(ksqlDbUrl);
 
-    var query = context.CreateQueryStream<MovieProto>("movie")
+    var query = context.CreatePushQuery<MovieProto>("movie")
     // var query = context.CreateQuery<MovieProto>("movie")
       .Where(p => p.Title != "E.T.")
       .Where(c => c.Title.ToLower().Contains("hard".ToLower()) || c.Id == 1)

--- a/Samples/ksqlDB.RestApi.Client.Sample/ksqlDB.RestApi.Client.Samples.csproj
+++ b/Samples/ksqlDB.RestApi.Client.Sample/ksqlDB.RestApi.Client.Samples.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <!-- <PackageReference Include="ksqlDb.RestApi.Client" Version="5.1.0" /> -->
+        <!-- <PackageReference Include="ksqlDb.RestApi.Client" Version="6.0.0-rc.2" /> -->
         <ProjectReference Include="..\..\ksqlDb.RestApi.Client\ksqlDb.RestApi.Client.csproj" />
         <PackageReference Include="ksqlDb.RestApi.Client.ProtoBuf" Version="3.0.0" />
         <!-- <ProjectReference Include="..\..\ksqlDb.RestApi.Client.ProtoBuf\ksqlDb.RestApi.Client.ProtoBuf.csproj" /> -->

--- a/Samples/ksqlDB.RestApi.Client.Sample/ksqlDB.RestApi.Client.Samples.csproj
+++ b/Samples/ksqlDB.RestApi.Client.Sample/ksqlDB.RestApi.Client.Samples.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <!-- <PackageReference Include="ksqlDb.RestApi.Client" Version="6.0.0-rc.2" /> -->
+        <!-- <PackageReference Include="ksqlDb.RestApi.Client" Version="6.0.0" /> -->
         <ProjectReference Include="..\..\ksqlDb.RestApi.Client\ksqlDb.RestApi.Client.csproj" />
         <PackageReference Include="ksqlDb.RestApi.Client.ProtoBuf" Version="3.0.0" />
         <!-- <ProjectReference Include="..\..\ksqlDb.RestApi.Client.ProtoBuf\ksqlDb.RestApi.Client.ProtoBuf.csproj" /> -->

--- a/Samples/ksqldB.RestApi.Client.WorkerService/ksqlDB.RestApi.Client.WorkerService/Worker.cs
+++ b/Samples/ksqldB.RestApi.Client.WorkerService/ksqlDB.RestApi.Client.WorkerService/Worker.cs
@@ -19,7 +19,7 @@ public class Worker(IMoviesKSqlDbContext context, ILogger<Worker> logger) : IHos
 
   private void SubscribeToMovies()
   {
-    subscription = context.CreateQueryStream<Movie>()
+    subscription = context.CreatePushQuery<Movie>()
       .Where( c => !c.Title.StartsWith("Star"))
       .Subscribe(onNext: movie =>
       {

--- a/Samples/ksqldB.RestApi.Client.WorkerService/ksqlDB.RestApi.Client.WorkerService/ksqlDB.RestApi.Client.WorkerService.csproj
+++ b/Samples/ksqldB.RestApi.Client.WorkerService/ksqlDB.RestApi.Client.WorkerService/ksqlDB.RestApi.Client.WorkerService.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="ksqlDb.RestApi.Client" Version="5.0.0" />
+        <PackageReference Include="ksqlDb.RestApi.Client" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
     </ItemGroup>

--- a/Samples/ksqldB.RestApi.Client.WorkerService/ksqlDB.RestApi.Client.WorkerService/ksqlDB/MoviesKSqlDbContext.cs
+++ b/Samples/ksqldB.RestApi.Client.WorkerService/ksqlDB.RestApi.Client.WorkerService/ksqlDB/MoviesKSqlDbContext.cs
@@ -16,5 +16,5 @@ internal class MoviesKSqlDbContext : KSqlDBContext, IMoviesKSqlDbContext
   {
   }
 
-  public IQbservable<Movie> Movies => CreateQueryStream<Movie>();
+  public IQbservable<Movie> Movies => CreatePushQuery<Movie>();
 }

--- a/SqlServer.Connector/SqlServer.Connector.csproj
+++ b/SqlServer.Connector/SqlServer.Connector.csproj
@@ -28,7 +28,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
-		<PackageReference Include="ksqlDb.RestApi.Client" Version="3.6.0" />
+		<PackageReference Include="ksqlDb.RestApi.Client" Version="6.0.0" />
         <PackageReference Include="Microsoft.IdentityModel.Abstractions" Version="7.5.0" />
         <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.5.0" />
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.5.0" />

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/Infrastructure/IntegrationTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/Infrastructure/IntegrationTests.cs
@@ -1,5 +1,6 @@
 using ksqlDb.RestApi.Client.IntegrationTests.KSql.RestApi;
 using ksqlDB.RestApi.Client.KSql.Query.Context;
+using ksqlDB.RestApi.Client.KSql.Query.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using UnitTests;
 
@@ -10,19 +11,36 @@ public abstract class IntegrationTests : TestBase
 {
   protected static KSqlDbRestApiProvider RestApiProvider = null!;
   protected KSqlDBContextOptions ContextOptions = null!;
-  protected KSqlDBContext Context = null!;
+  private KSqlDBContext? context;
+
+  protected KSqlDBContext Context
+  {
+    get => context ??= (CreateKSqlDbContext(EndpointType.QueryStream));
+    set
+    {
+      context?.Dispose();
+
+      context = value;
+    }
+  }
 
   [TestInitialize]
   public override void TestInitialize()
   {
     base.TestInitialize();
 
+    Context = CreateKSqlDbContext(EndpointType.QueryStream);
+  }
+
+  protected KSqlDBContext CreateKSqlDbContext(EndpointType endpointType)
+  {
     ContextOptions = new KSqlDBContextOptions(KSqlDbRestApiProvider.KsqlDbUrl)
     {
-      ShouldPluralizeFromItemName = false
+      ShouldPluralizeFromItemName = false,
+      EndpointType = endpointType
     };
-      
-    Context = new KSqlDBContext(ContextOptions);
+
+    return new KSqlDBContext(ContextOptions);
   }
 
   [TestCleanup]

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/AggregationTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/AggregationTests.cs
@@ -3,6 +3,7 @@ using ksqlDb.RestApi.Client.IntegrationTests.KSql.RestApi;
 using ksqlDb.RestApi.Client.IntegrationTests.Models;
 using ksqlDb.RestApi.Client.IntegrationTests.Models.Movies;
 using ksqlDB.RestApi.Client.KSql.Linq;
+using ksqlDB.RestApi.Client.KSql.Query.Options;
 using NUnit.Framework;
 
 namespace ksqlDb.RestApi.Client.IntegrationTests.KSql.Linq;
@@ -70,6 +71,7 @@ public class AggregationTests : Infrastructure.IntegrationTests
   [Test]
   public async Task Histogram_QueryEndPoint()
   {
+    Context = CreateKSqlDbContext(EndpointType.Query);
     await TestHistogram(Context.CreateQueryStream<Movie>(MoviesProvider.MoviesTableName));
   }
     

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/AggregationTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/AggregationTests.cs
@@ -47,7 +47,7 @@ public class AggregationTests : Infrastructure.IntegrationTests
   [Test]
   public async Task Histogram()
   {
-    await TestHistogram(Context.CreateQueryStream<Movie>(MoviesProvider.MoviesTableName));
+    await TestHistogram(Context.CreatePushQuery<Movie>(MoviesProvider.MoviesTableName));
   }
 
   private static async Task TestHistogram(IQbservable<Movie> querySource)
@@ -72,13 +72,13 @@ public class AggregationTests : Infrastructure.IntegrationTests
   public async Task Histogram_QueryEndPoint()
   {
     Context = CreateKSqlDbContext(EndpointType.Query);
-    await TestHistogram(Context.CreateQueryStream<Movie>(MoviesProvider.MoviesTableName));
+    await TestHistogram(Context.CreatePushQuery<Movie>(MoviesProvider.MoviesTableName));
   }
     
   [Test]
   public async Task CollectListStructs()
   {
-    await CollectListStructs(Context.CreateQueryStream<Movie>(MoviesProvider.MoviesTableName));
+    await CollectListStructs(Context.CreatePushQuery<Movie>(MoviesProvider.MoviesTableName));
   }
 
   //Struct(Name :='Karen', Age := 55)
@@ -109,7 +109,7 @@ public class AggregationTests : Infrastructure.IntegrationTests
   [Test]
   public async Task CollectListMaps()
   {
-    await CollectListMaps(Context.CreateQueryStream<Movie>(MoviesProvider.MoviesTableName));
+    await CollectListMaps(Context.CreatePushQuery<Movie>(MoviesProvider.MoviesTableName));
   }
 
   private static async Task CollectListMaps(IQbservable<Movie> querySource)
@@ -138,7 +138,7 @@ public class AggregationTests : Infrastructure.IntegrationTests
   [Test]
   public async Task CollectListArray()
   {
-    await CollectListArray(Context.CreateQueryStream<Movie>(MoviesProvider.MoviesTableName));
+    await CollectListArray(Context.CreatePushQuery<Movie>(MoviesProvider.MoviesTableName));
   }
 
   private static async Task CollectListArray(IQbservable<Movie> querySource)
@@ -162,7 +162,7 @@ public class AggregationTests : Infrastructure.IntegrationTests
   [Test]
   public async Task CollectSetMaps()
   {
-    await CollectSetMaps(Context.CreateQueryStream<Tweet>(TweetsStreamName));
+    await CollectSetMaps(Context.CreatePushQuery<Tweet>(TweetsStreamName));
   }
 
   private static async Task CollectSetMaps(IQbservable<Tweet> querySource)
@@ -193,7 +193,7 @@ public class AggregationTests : Infrastructure.IntegrationTests
   [Test]
   public async Task EarliestByOffsetMaps()
   {
-    await EarliestByOffsetMaps(Context.CreateQueryStream<Tweet>(TweetsStreamName));
+    await EarliestByOffsetMaps(Context.CreatePushQuery<Tweet>(TweetsStreamName));
   }
 
   private static async Task EarliestByOffsetMaps(IQbservable<Tweet> querySource)
@@ -223,7 +223,7 @@ public class AggregationTests : Infrastructure.IntegrationTests
   [Test]
   public async Task LatestByOffsetMaps()
   {
-    await LatestByOffsetMaps(Context.CreateQueryStream<Tweet>(TweetsStreamName));
+    await LatestByOffsetMaps(Context.CreatePushQuery<Tweet>(TweetsStreamName));
   }
 
   private static async Task LatestByOffsetMaps(IQbservable<Tweet> querySource)
@@ -252,7 +252,7 @@ public class AggregationTests : Infrastructure.IntegrationTests
   [Test]
   public async Task LatestByOffsetStructs()
   {
-    await LatestByOffsetStructs(Context.CreateQueryStream<Tweet>(TweetsStreamName));
+    await LatestByOffsetStructs(Context.CreatePushQuery<Tweet>(TweetsStreamName));
   }
 
   private static async Task LatestByOffsetStructs(IQbservable<Tweet> querySource)

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/AggregationTimeTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/AggregationTimeTests.cs
@@ -62,7 +62,7 @@ public class AggregationTimeTests : Infrastructure.IntegrationTests
   [Test]
   public async Task MinDateTime()
   {
-    await MinDateTime(Context.CreateQueryStream<Times>(TimesStreamName));
+    await MinDateTime(Context.CreatePushQuery<Times>(TimesStreamName));
   }
 
   private static async Task MinDateTime(IQbservable<Times> querySource)
@@ -86,7 +86,7 @@ public class AggregationTimeTests : Infrastructure.IntegrationTests
   [Test]
   public async Task MaxTime()
   {
-    await MaxTime(Context.CreateQueryStream<Times>(TimesStreamName));
+    await MaxTime(Context.CreatePushQuery<Times>(TimesStreamName));
   }
 
   private static async Task MaxTime(IQbservable<Times> querySource)
@@ -110,7 +110,7 @@ public class AggregationTimeTests : Infrastructure.IntegrationTests
   [Test]
   public async Task MinDateTimeOffset()
   {
-    await MinDateTimeOffset(Context.CreateQueryStream<Times>(TimesStreamName));
+    await MinDateTimeOffset(Context.CreatePushQuery<Times>(TimesStreamName));
   }
 
   private static async Task MinDateTimeOffset(IQbservable<Times> querySource)

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/ComplexTypesTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/ComplexTypesTests.cs
@@ -63,7 +63,7 @@ Drop table Events;
     var semaphoreSlim = new SemaphoreSlim(0, 1);
 
     var receivedValues = new List<Event>();
-    var subscription = Context.CreateQueryStream<Event>().Take(1)
+    var subscription = Context.CreatePushQuery<Event>().Take(1)
       .Subscribe(value =>
         {
           receivedValues.Add(value);
@@ -101,7 +101,7 @@ Drop table Events;
       { { "A", new Dictionary<string, int>() { { "A", 1 } } } };
 
     string ksql =
-      Context.CreateQueryStream<object>(fromItemName: "Events")
+      Context.CreatePushQuery<object>(fromItemName: "Events")
         .Select(_ => new
         {
           Dict = K.Functions.Transform(value, (k, v) => k.ToUpper(), (k, v) => v["A"] + 1)
@@ -115,7 +115,7 @@ Drop table Events;
     };
 
     //Act
-    var source = Context.CreateQueryStream<Foo>(queryStreamParameters)
+    var source = Context.CreatePushQuery<Foo>(queryStreamParameters)
       .Take(1)
       .ToEnumerable()
       .First();
@@ -138,7 +138,7 @@ Drop table Events;
       { { "A", new MyType { A = 1, B = 2 } } };
 
     string ksql =
-      Context.CreateQueryStream<object>(fromItemName: "Events")
+      Context.CreatePushQuery<object>(fromItemName: "Events")
         .Select(_ => new
         {
           Dict = K.Functions.Transform(value, (k, v) => k.ToUpper(), (k, v) => v.A + 1)
@@ -152,7 +152,7 @@ Drop table Events;
     };
 
     //Act
-    var source = Context.CreateQueryStream<Foo>(queryStreamParameters)
+    var source = Context.CreatePushQuery<Foo>(queryStreamParameters)
       .Take(1)
       .ToEnumerable()
       .First();

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/FunctionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/FunctionsTests.cs
@@ -38,7 +38,7 @@ namespace ksqlDb.RestApi.Client.IntegrationTests.KSql.Linq
     [Test]
     public async Task Explode()
     {
-      await Explode(Context.CreateQueryStream<Tweet>(TweetsStreamName));
+      await Explode(Context.CreatePushQuery<Tweet>(TweetsStreamName));
     }
 
     private static async Task Explode(IQbservable<Tweet> querySource)

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/GroupByTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/GroupByTests.cs
@@ -30,7 +30,7 @@ public class GroupByTests : Infrastructure.IntegrationTests
 
   protected static string CitiesTableName => "test_cities";
 
-  private IQbservable<TestCity> CitiesStream => Context.CreateQueryStream<TestCity>(CitiesTableName);
+  private IQbservable<TestCity> CitiesStream => Context.CreatePushQuery<TestCity>(CitiesTableName);
 
   record TestCity
   {

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/JoinsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/JoinsTests.cs
@@ -141,6 +141,7 @@ public class JoinsTests : Infrastructure.IntegrationTests
   [Test]
   public async Task FullOuterJoin_QueryEndPoint()
   {
+    Context = CreateKSqlDbContext(ksqlDB.RestApi.Client.KSql.Query.Options.EndpointType.Query);
     await FullOuterJoinTest(Context.CreateQueryStream<Movie2>(MoviesTableName));
   }
 

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/JoinsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/JoinsTests.cs
@@ -61,7 +61,7 @@ public class JoinsTests : Infrastructure.IntegrationTests
     //Arrange
     int expectedItemsCount = 1;
 
-    var source = Context.CreateQueryStream<Movie>(MoviesTableName)
+    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Join(
         Source.Of<Lead_Actor>(ActorsTableName),
         movie => movie.Title,
@@ -95,7 +95,7 @@ public class JoinsTests : Infrastructure.IntegrationTests
     //Arrange
     int expectedItemsCount = 2;
 
-    var source = Context.CreateQueryStream<Movie>(MoviesTableName)
+    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .LeftJoin(
         Source.Of<Lead_Actor>(ActorsTableName),
         movie => movie.Title,
@@ -135,14 +135,14 @@ public class JoinsTests : Infrastructure.IntegrationTests
   [Test]
   public async Task FullOuterJoin()
   {
-    await FullOuterJoinTest(Context.CreateQueryStream<Movie2>(MoviesTableName));
+    await FullOuterJoinTest(Context.CreatePushQuery<Movie2>(MoviesTableName));
   }
 
   [Test]
   public async Task FullOuterJoin_QueryEndPoint()
   {
     Context = CreateKSqlDbContext(ksqlDB.RestApi.Client.KSql.Query.Options.EndpointType.Query);
-    await FullOuterJoinTest(Context.CreateQueryStream<Movie2>(MoviesTableName));
+    await FullOuterJoinTest(Context.CreatePushQuery<Movie2>(MoviesTableName));
   }
 
   public static async Task FullOuterJoinTest(IQbservable<Movie2> querySource)
@@ -191,7 +191,7 @@ public class JoinsTests : Infrastructure.IntegrationTests
     //Arrange
     int expectedItemsCount = 1;
 
-    var source = Context.CreateQueryStream<Lead_Actor>(ActorsTableName)
+    var source = Context.CreatePushQuery<Lead_Actor>(ActorsTableName)
       .RightJoin(
         Source.Of<Movie>(MoviesTableName),
         actor => actor.Title,
@@ -258,7 +258,7 @@ public class JoinsTests : Infrastructure.IntegrationTests
 
     var value = new Foo { Prop = 42 };
 
-    var query = (from o in context.CreateQueryStream<Order>()
+    var query = (from o in context.CreatePushQuery<Order>()
         join p1 in Source.Of<Payment>() on o.PaymentId equals p1.Id
         join s1 in Source.Of<Shipment>() on o.ShipmentId equals s1.Id into gj
         from sa in gj.DefaultIfEmpty()
@@ -309,7 +309,7 @@ public class JoinsTests : Infrastructure.IntegrationTests
 
     var context = new KSqlDBContext(TestConfig.KSqlDbUrl);
 
-    var query = from o in context.CreateQueryStream<Order>()
+    var query = from o in context.CreatePushQuery<Order>()
       join p in Source.Of<Payment>(nameof(Payment) + "Stream").Within(Duration.OfSeconds(0), Duration.OfSeconds(25)) on o.OrderId equals p.Id
       select new
       {
@@ -358,7 +358,7 @@ public class JoinsTests : Infrastructure.IntegrationTests
       
     string prop = "Nested";
 
-    var query = from o in context.CreateQueryStream<Order>()
+    var query = from o in context.CreatePushQuery<Order>()
       join p in Source.Of<PaymentExt>() on o.OrderId equals p.Id
       where p.Nested.Prop == prop
       select new

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/PullQueries/PullQueryExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/PullQueries/PullQueryExtensionsTests.cs
@@ -22,7 +22,7 @@ public class PullQueryExtensionsTests
   {
     contextOptions = new KSqlDBContextOptions(KSqlDbRestApiProvider.KsqlDbUrl)
     {
-      EndpointType = EndpointType.Query //TODO: test QueryStream end point
+      EndpointType = EndpointType.QueryStream
     };
 
     context = new KSqlDBContext(contextOptions);

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/QbservableExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/QbservableExtensionsTests.cs
@@ -64,7 +64,7 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
   }
 
   protected virtual ksqlDB.RestApi.Client.KSql.Linq.IQbservable<Tweet> QuerySource =>
-    Context.CreateQueryStream<Tweet>(StreamName);
+    Context.CreatePushQuery<Tweet>(StreamName);
 
   private readonly TimeSpan timeOut = TimeSpan.FromSeconds(10);
 
@@ -193,7 +193,7 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
   public void SubscribeAsync_UnknownTopic()
   {
     //Arrange
-    var source = Context.CreateQueryStream<Tweet>(StreamName + "xyz");
+    var source = Context.CreatePushQuery<Tweet>(StreamName + "xyz");
 
     NUnit.Framework.Assert.ThrowsAsync<KSqlQueryException>(() =>
     {
@@ -208,7 +208,7 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
   public async Task SubscribeAsync_UnknownTopic_NullQueryId()
   {
     //Arrange
-    var source = Context.CreateQueryStream<Tweet>(StreamName + "xyz");
+    var source = Context.CreatePushQuery<Tweet>(StreamName + "xyz");
 
     Subscription? subscription = null;
 
@@ -448,7 +448,7 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
       [QueryStreamParameters.AutoOffsetResetPropertyName] = "earliest",
     };
 
-    var source = Context.CreateQueryStream<Tweet>(queryParameters);
+    var source = Context.CreatePushQuery<Tweet>(queryParameters);
 
     //Act
     var actualValues = await CollectActualValues(source, expectedItemsCount);
@@ -471,7 +471,7 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
       [QueryStreamParameters.AutoOffsetResetPropertyName] = "earliest",
     };
 
-    var source = Context.CreateQueryStream<Tweet>(queryStreamParameters);
+    var source = Context.CreatePushQuery<Tweet>(queryStreamParameters);
 
     //Act
     var actualValues = await CollectActualValues(source, expectedItemsCount);
@@ -615,7 +615,7 @@ WHERE MESSAGE = 'ET' EMIT CHANGES;");
     //Arrange
     int expectedItemsCount = 1;
 
-    var source = Context.CreateQueryStream<SingleLady>(SingleLadiesStreamName)
+    var source = Context.CreatePushQuery<SingleLady>(SingleLadiesStreamName)
       .ToAsyncEnumerable();
 
     //Act
@@ -660,7 +660,7 @@ WHERE MESSAGE = 'ET' EMIT CHANGES;");
       [QueryParameters.AutoOffsetResetPropertyName] = "earliest",
     };
 
-    var source = Context.CreateQueryStream<int>(queryStreamParameters);
+    var source = Context.CreatePushQuery<int>(queryStreamParameters);
 
     //Act
     var actualValues = await CollectActualValues(source, expectedItemsCount);
@@ -684,7 +684,7 @@ WHERE MESSAGE = 'ET' EMIT CHANGES;");
       [QueryParameters.AutoOffsetResetPropertyName] = "earliest",
     };
 
-    var source = Context.CreateQueryStream<int[]>(queryStreamParameters);
+    var source = Context.CreatePushQuery<int[]>(queryStreamParameters);
 
     //Act
     var actualValues = await CollectActualValues(source, expectedItemsCount);
@@ -713,7 +713,7 @@ WHERE MESSAGE = 'ET' EMIT CHANGES;");
       [QueryParameters.AutoOffsetResetPropertyName] = "earliest",
     };
 
-    var source = Context.CreateQueryStream<MyStruct>(queryStreamParameters);
+    var source = Context.CreatePushQuery<MyStruct>(queryStreamParameters);
 
     //Act
     var actualValues = await CollectActualValues(source, expectedItemsCount);

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Query/Context/KSqlDbContextTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Query/Context/KSqlDbContextTests.cs
@@ -134,7 +134,7 @@ public class KSqlDbContextTests : Infrastructure.IntegrationTests
     var receivedValues = new List<TimeTypes>();
 
     //Act
-    using var subscription = context.CreateQueryStream<TimeTypes>()
+    using var subscription = context.CreatePushQuery<TimeTypes>()
       .Take(1)
       .Subscribe(value =>
         {

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Query/Functions/KSqlFunctionsExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Query/Functions/KSqlFunctionsExtensionsTests.cs
@@ -7,6 +7,7 @@ using ksqlDb.RestApi.Client.IntegrationTests.KSql.RestApi;
 using ksqlDb.RestApi.Client.IntegrationTests.Models.Movies;
 using ksqlDB.RestApi.Client.KSql.Linq;
 using ksqlDB.RestApi.Client.KSql.Query.Functions;
+using ksqlDB.RestApi.Client.KSql.Query.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NUnit.Framework;
 using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
@@ -45,6 +46,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
   [Test]
   public async Task DateToString_QueryEndPoint()
   {
+    Context = CreateKSqlDbContext(EndpointType.Query);
     await DateToStringTest(Context.CreateQueryStream<Movie>(MoviesTableName));
   }
 
@@ -78,6 +80,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
   [Test]
   public async Task Entries_QueryEndPoint()
   {
+    Context = CreateKSqlDbContext(EndpointType.Query);
     await EntriesTest(Context.CreateQueryStream<Movie>(MoviesTableName));
   }
     

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Query/Functions/KSqlFunctionsExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Query/Functions/KSqlFunctionsExtensionsTests.cs
@@ -40,14 +40,14 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
   [Test]
   public async Task DateToString()
   {
-    await DateToStringTest(Context.CreateQueryStream<Movie>(MoviesTableName));
+    await DateToStringTest(Context.CreatePushQuery<Movie>(MoviesTableName));
   }
 
   [Test]
   public async Task DateToString_QueryEndPoint()
   {
     Context = CreateKSqlDbContext(EndpointType.Query);
-    await DateToStringTest(Context.CreateQueryStream<Movie>(MoviesTableName));
+    await DateToStringTest(Context.CreatePushQuery<Movie>(MoviesTableName));
   }
 
   public async Task DateToStringTest(IQbservable<Movie> querySource)
@@ -74,14 +74,14 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
   [Test]
   public async Task Entries()
   {
-    await EntriesTest(Context.CreateQueryStream<Movie>(MoviesTableName));
+    await EntriesTest(Context.CreatePushQuery<Movie>(MoviesTableName));
   }
 
   [Test]
   public async Task Entries_QueryEndPoint()
   {
     Context = CreateKSqlDbContext(EndpointType.Query);
-    await EntriesTest(Context.CreateQueryStream<Movie>(MoviesTableName));
+    await EntriesTest(Context.CreatePushQuery<Movie>(MoviesTableName));
   }
     
   public async Task EntriesTest(IQbservable<Movie> querySource)
@@ -114,7 +114,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;
       
     //Act
-    var source = Context.CreateQueryStream<Movie>(MoviesTableName)
+    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = KSqlFunctions.Instance.ArrayIntersect(new [] { 1, 2 }, new []{ 1 } )})
       .ToAsyncEnumerable();
       
@@ -133,7 +133,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;
       
     //Act
-    var source = Context.CreateQueryStream<Movie>(MoviesTableName)
+    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = KSqlFunctions.Instance.ArrayJoin(new [] { 1, 2 }, ";" )})
       .ToAsyncEnumerable();
       
@@ -152,7 +152,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;
       
     //Act
-    var source = Context.CreateQueryStream<Movie>(MoviesTableName)
+    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = KSqlFunctions.Instance.ArrayLength(new [] { 1, 2 } )})
       .ToAsyncEnumerable();
       
@@ -171,7 +171,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;
       
     //Act
-    var source = Context.CreateQueryStream<Movie>(MoviesTableName)
+    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = KSqlFunctions.Instance.ArrayMin(new [] { 1, 2 } )})
       .ToAsyncEnumerable();
       
@@ -191,7 +191,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;
       
     //Act
-    var source = Context.CreateQueryStream<Movie>(MoviesTableName)
+    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = KSqlFunctions.Instance.ArrayMin(new string [] { })})
       .ToAsyncEnumerable();
 
@@ -210,7 +210,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;
       
     //Act
-    var source = Context.CreateQueryStream<Movie>(MoviesTableName)
+    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = KSqlFunctions.Instance.ArrayRemove(new [] { 1, 2 }, 2)})
       .ToAsyncEnumerable();
       
@@ -229,7 +229,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;
       
     //Act
-    var source = Context.CreateQueryStream<Movie>(MoviesTableName)
+    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = K.Functions.ArraySort(new int?[]{ 3, null, 1}, ListSortDirection.Ascending)})
       .ToAsyncEnumerable();
       
@@ -246,7 +246,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;
       
     //Act
-    var source = Context.CreateQueryStream<Movie>(MoviesTableName)
+    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = K.Functions.ArrayUnion(new int?[]{ 3, null, 1}, new int?[]{ 4, null})})
       .ToAsyncEnumerable();
       
@@ -264,7 +264,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     string message = "_Hello";
 
     //Act
-    var source = Context.CreateQueryStream<Movie>(MoviesTableName)
+    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = K.Functions.Concat(c.Title, message), ColWS = K.Functions.ConcatWS(" - ", c.Title, message) })
       .ToAsyncEnumerable();
       
@@ -283,7 +283,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;
 
     //Act
-    var source = Context.CreateQueryStream<Movie>(MoviesTableName)
+    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = K.Functions.ToBytes(c.Title, "utf8") })
       .ToAsyncEnumerable();
       
@@ -303,7 +303,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;
 
     //Act
-    var source = Context.CreateQueryStream<Movie>(MoviesTableName)
+    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = K.Functions.FromBytes(K.Functions.ToBytes(c.Title, "utf8"), "utf8") })
       .ToAsyncEnumerable();
       
@@ -325,7 +325,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     //QWxpZW4=
 
     //Act
-    var source = Context.CreateQueryStream<Movie>(MoviesTableName)
+    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = K.Functions.FromBytes(bytes, "utf8") })
       .ToAsyncEnumerable();
       
@@ -344,7 +344,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;
 
     //Act
-    var source = Context.CreateQueryStream<Movie>(MoviesTableName)
+    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = K.Functions.AsMap(new []{ "1", "2" }, new []{ 11, 22 }) })
       .ToAsyncEnumerable();
       
@@ -362,7 +362,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;
 
     //Act
-    var source = Context.CreateQueryStream<Movie>(MoviesTableName)
+    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = K.Functions.JsonArrayContains("[1, 2, 3]", 2) })
       .ToAsyncEnumerable();
       
@@ -380,7 +380,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;
 
     //Act
-    var source = Context.CreateQueryStream<Movie>(MoviesTableName)
+    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = K.Functions.MapKeys(new Dictionary<string, int>
       {
         {"apple", 10},
@@ -407,7 +407,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     Expression<Func<Movie, string>> expression = c => K.Functions.Encode(c.Title, inputEncoding, outputEncoding);
 
     //Act
-    var source = Context.CreateQueryStream<Movie>(MoviesTableName)
+    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(expression)
       .ToAsyncEnumerable();
       
@@ -430,7 +430,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     string jsonPath = "$.log.cloud";
 
     //Act
-    var source = Context.CreateQueryStream<Movie>(MoviesTableName)
+    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Extracted = K.Functions.ExtractJsonField(json, jsonPath) })
       .ToAsyncEnumerable();
       

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Query/Functions/KSqlInvocationFunctionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Query/Functions/KSqlInvocationFunctionsTests.cs
@@ -63,7 +63,7 @@ public class KSqlInvocationFunctionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;
 
     //Act
-    var source = Context.CreateQueryStream<Lambda>(StreamName)
+    var source = Context.CreatePushQuery<Lambda>(StreamName)
       .Select(c => new { Col = KSqlFunctions.Instance.Transform(c.Arr, x => x + 1) })
       .ToAsyncEnumerable();
       
@@ -90,7 +90,7 @@ public class KSqlInvocationFunctionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;      
       
     //Act
-    var source = Context.CreateQueryStream<LambdaMap>(streamNameWithMap)
+    var source = Context.CreatePushQuery<LambdaMap>(streamNameWithMap)
       .Select(c => new { Col = K.Functions.Transform(c.Map, (k, v) => K.Functions.Concat(k, "_new"), (k, v) => K.Functions.Transform(v, x => x * x)) })
       .ToAsyncEnumerable();
       
@@ -110,7 +110,7 @@ public class KSqlInvocationFunctionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;
 
     //Act
-    var source = Context.CreateQueryStream<Lambda>(StreamName)
+    var source = Context.CreatePushQuery<Lambda>(StreamName)
       .Select(c => new { Col = KSqlFunctions.Instance.Filter(c.Arr, x => x > 1) })
       .ToAsyncEnumerable();
       
@@ -128,7 +128,7 @@ public class KSqlInvocationFunctionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;      
       
     //Act
-    var source = Context.CreateQueryStream<LambdaMap>(streamNameWithMap)
+    var source = Context.CreatePushQuery<LambdaMap>(streamNameWithMap)
       .Select(c => new { Col = K.Functions.Filter(c.Map, (k, v) => k != "E.T" && v[1] > 0) })
       .ToAsyncEnumerable();
       
@@ -147,7 +147,7 @@ public class KSqlInvocationFunctionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;
 
     //Act
-    var source = Context.CreateQueryStream<Lambda>(StreamName)
+    var source = Context.CreatePushQuery<Lambda>(StreamName)
       .Select(c => new { Acc = K.Functions.Reduce(c.Arr, 0, (x,y) => x + y) })
       .ToAsyncEnumerable();
       
@@ -165,7 +165,7 @@ public class KSqlInvocationFunctionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;      
       
     //Act
-    var source = Context.CreateQueryStream<LambdaMap>(streamNameWithMap)
+    var source = Context.CreatePushQuery<LambdaMap>(streamNameWithMap)
       .Select(c => new { Col = K.Functions.Reduce(c.Map, 2, (s, k, v) => K.Functions.Ceil(s / v[1])) })
       .ToAsyncEnumerable();
       

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Query/KSqlLexicalPrecedenceTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Query/KSqlLexicalPrecedenceTests.cs
@@ -36,7 +36,7 @@ public class KSqlLexicalPrecedenceTests : Infrastructure.IntegrationTests
 
   protected static string MoviesTableName => MoviesProvider.MoviesTableName;
 
-  protected virtual IQbservable<Movie> MoviesStream => Context.CreateQueryStream<Movie>(MoviesTableName);
+  protected virtual IQbservable<Movie> MoviesStream => Context.CreatePushQuery<Movie>(MoviesTableName);
 
   [Test]
   public async Task Select()

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Query/KSqlNestedTypesQueryTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Query/KSqlNestedTypesQueryTests.cs
@@ -18,5 +18,5 @@ public class KSqlNestedTypesQueryTests : KSqlNestedTypesTests
     await MoviesProvider.DropTablesAsync();
   }
 
-  protected override IQbservable<Movie> MoviesStream => Context.CreateQueryStream<Movie>(MoviesTableName);
+  protected override IQbservable<Movie> MoviesStream => Context.CreatePushQuery<Movie>(MoviesTableName);
 }

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Query/KSqlNestedTypesTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Query/KSqlNestedTypesTests.cs
@@ -35,7 +35,7 @@ public class KSqlNestedTypesTests : Infrastructure.IntegrationTests
 
   protected static string MoviesTableName => MoviesProvider.MoviesTableName;
 
-  protected virtual IQbservable<Movie> MoviesStream => Context.CreateQueryStream<Movie>(MoviesTableName);
+  protected virtual IQbservable<Movie> MoviesStream => Context.CreatePushQuery<Movie>(MoviesTableName);
 
   [Test]
   public async Task ArrayInArray()

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/RestApi/KSqlDbRestApiClientTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/RestApi/KSqlDbRestApiClientTests.cs
@@ -322,7 +322,7 @@ Drop type {nameof(Address)};
     var cts = new CancellationTokenSource();
       
     var subscription = await context
-      .CreateQueryStream<MyMoviesTable>()
+      .CreatePushQuery<MyMoviesTable>()
       .SubscribeOn(ThreadPoolScheduler.Instance)
       .SubscribeAsync(_ => {}, e => { }, () => { }, cts.Token);
       

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/QbservableExtensionsExplainTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/QbservableExtensionsExplainTests.cs
@@ -35,7 +35,7 @@ public class QbservableExtensionsExplainTests : TestBase
   public async Task ExplainAsync()
   {
     //Arrange
-    var query = dbProvider.CreateQueryStream<string>();
+    var query = dbProvider.CreatePushQuery<string>();
 
     //Act
     var description = await query.ExplainAsync();
@@ -49,7 +49,7 @@ public class QbservableExtensionsExplainTests : TestBase
   public async Task ExplainAsStringAsync()
   {
     //Arrange
-    var query = dbProvider.CreateQueryStream<string>();
+    var query = dbProvider.CreatePushQuery<string>();
 
     //Act
     var description = await query.ExplainAsStringAsync();
@@ -62,7 +62,7 @@ public class QbservableExtensionsExplainTests : TestBase
   public void CreateExplainStatement()
   {
     //Arrange
-    var query = dbProvider.CreateQueryStream<string>().Where(c => c == "ET");
+    var query = dbProvider.CreatePushQuery<string>().Where(c => c == "ET");
 
     //Act
     var explainStatement = QbservableExtensions.CreateExplainStatement((KStreamSet<string>)query);

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/QbservableExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/QbservableExtensionsTests.cs
@@ -40,8 +40,8 @@ public class QbservableExtensionsTests : TestBase
     //Arrange
     var context = new TestableDbProvider(TestParameters.KsqlDbUrl);
 
-    var query1 = context.CreateQueryStream<Location>();
-    var query2 = context.CreateQueryStream<Location>("Place");
+    var query1 = context.CreatePushQuery<Location>();
+    var query2 = context.CreatePushQuery<Location>("Place");
 
     var providedParameters = new IKSqlDbParameters[2];
     int i = 0;
@@ -271,7 +271,7 @@ WHERE (({columnName} = '1') OR ({columnName} != '2')) AND ({columnName} = '3') E
     var context = new TestableDbProvider(TestParameters.KsqlDbUrl);
     context.KSqlDbProviderMock.Setup(c => c.Run<string>(It.IsAny<object>(), It.IsAny<CancellationToken>()))
       .Returns(GetTestValues);
-    var query = context.CreateQueryStream<string>();
+    var query = context.CreatePushQuery<string>();
 
     //Act
     var asyncEnumerable = query.ToAsyncEnumerable();
@@ -305,7 +305,7 @@ WHERE (({columnName} = '1') OR ({columnName} != '2')) AND ({columnName} = '3') E
     //Arrange
     var context = new TestableDbProvider(TestParameters.KsqlDbUrl);
       
-    var query = context.CreateQueryStream<string>();
+    var query = context.CreatePushQuery<string>();
 
     //Act
     var observable = query.ToObservable();
@@ -327,7 +327,7 @@ WHERE (({columnName} = '1') OR ({columnName} != '2')) AND ({columnName} = '3') E
       .Callback<object, CancellationToken>((par, ct) => { cancellationToken = ct; })
       .Returns(GetTestValues);
 
-    var query = context.CreateQueryStream<string>();
+    var query = context.CreatePushQuery<string>();
 
     //Act
     query.ToObservable().Subscribe().Dispose();
@@ -437,7 +437,7 @@ WHERE (({columnName} = '1') OR ({columnName} != '2')) AND ({columnName} = '3') E
   {
     var context = new TestableDbProvider(TestParameters.KsqlDbUrl);
       
-    return context.CreateQueryStream<Location>();
+    return context.CreatePushQuery<Location>();
   }
 
   private static IQbservable<string> CreateTestableKStreamSet()
@@ -455,7 +455,7 @@ WHERE (({columnName} = '1') OR ({columnName} != '2')) AND ({columnName} = '3') E
     context.KSqlDbRestApiClientMock.Setup(c => c.ExecuteStatementAsync(It.IsAny<KSqlDbStatement>(), It.IsAny<CancellationToken>()))
       .ReturnsAsync(new HttpResponseMessage());
       
-    return context.CreateQueryStream<string>();
+    return context.CreatePushQuery<string>();
   }
     
   [Test]
@@ -478,7 +478,7 @@ WHERE (({columnName} = '1') OR ({columnName} != '2')) AND ({columnName} = '3') E
     //Arrange
     var context = new TestableDbProvider(TestParameters.KsqlDbUrl);
 
-    var grouping = context.CreateQueryStream<Click>()
+    var grouping = context.CreatePushQuery<Click>()
       .Where(c => c.IP_ADDRESS != null)
       .Select(c => new { c.IP_ADDRESS, c.URL, c.TIMESTAMP });
 
@@ -498,7 +498,7 @@ WHERE IP_ADDRESS IS NOT NULL EMIT CHANGES;".ReplaceLineEndings();
     //Arrange
     var context = new TestableDbProvider(TestParameters.KsqlDbUrl);
 
-    var grouping = context.CreateQueryStream<Click>()
+    var grouping = context.CreatePushQuery<Click>()
       .Where(c => c.IP_ADDRESS == null)
       .Select(c => new { c.IP_ADDRESS, c.URL, c.TIMESTAMP });
 
@@ -539,7 +539,7 @@ WHERE Id = '{uniqueId}' EMIT CHANGES;".ReplaceLineEndings();
   internal static IQbservable<T> GetQuery<T>(TestableDbProvider context, string tableName, Guid uniqueId)
     where T : IIdentifiable
   {
-    return context.CreateQueryStream<T>(tableName).Where(l => l.Id == uniqueId);
+    return context.CreatePushQuery<T>(tableName).Where(l => l.Id == uniqueId);
   }
   
   [Test]

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/QbservableExtensionsWindowsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/QbservableExtensionsWindowsTests.cs
@@ -20,7 +20,7 @@ public class QbservableExtensionsWindowsTests : TestBase
     //Arrange
     var context = new TransactionsDbProvider(TestParameters.KsqlDbUrl);
 
-    var grouping = context.CreateQueryStream<Transaction>()
+    var grouping = context.CreatePushQuery<Transaction>()
       .GroupBy(c => c.CardNumber)
       .WindowedBy(new SessionWindow(Duration.OfSeconds(5)))
       .Select(g => new { CardNumber = g.Key, Count = g.Count() });
@@ -38,7 +38,7 @@ public class QbservableExtensionsWindowsTests : TestBase
     //Arrange
     var context = new TransactionsDbProvider(TestParameters.KsqlDbUrl);
 
-    var grouping = context.CreateQueryStream<Transaction>()
+    var grouping = context.CreatePushQuery<Transaction>()
       .GroupBy(c => c.CardNumber)
       .WindowedBy(new HoppingWindows(Duration.OfSeconds(5)))
       .Select(g => new { CardNumber = g.Key, Count = g.Count() });
@@ -56,7 +56,7 @@ public class QbservableExtensionsWindowsTests : TestBase
     //Arrange
     var context = new TransactionsDbProvider(TestParameters.KsqlDbUrl);
 
-    var grouping = context.CreateQueryStream<Transaction>()
+    var grouping = context.CreatePushQuery<Transaction>()
       .GroupBy(c => c.CardNumber)
       .WindowedBy(new HoppingWindows(Duration.OfSeconds(5)))
       .Select(g => new { g.WindowStart, g.WindowEnd, CardNumber = g.Key, Count = g.Count() });
@@ -74,7 +74,7 @@ public class QbservableExtensionsWindowsTests : TestBase
     //Arrange
     var context = new TransactionsDbProvider(TestParameters.KsqlDbUrl);
 
-    var grouping = context.CreateQueryStream<Transaction>()
+    var grouping = context.CreatePushQuery<Transaction>()
       .GroupBy(c => c.CardNumber)
       .WindowedBy(new HoppingWindows(Duration.OfMinutes(5)).WithAdvanceBy(Duration.OfMinutes(4)))
       .Select(g => new { CardNumber = g.Key, Count = g.Count() });
@@ -92,7 +92,7 @@ public class QbservableExtensionsWindowsTests : TestBase
     //Arrange
     var context = new TransactionsDbProvider(TestParameters.KsqlDbUrl);
 
-    var grouping = context.CreateQueryStream<Transaction>()
+    var grouping = context.CreatePushQuery<Transaction>()
       .GroupBy(c => c.CardNumber)
       .WindowedBy(new HoppingWindows(Duration.OfSeconds(5)).WithRetention(Duration.OfDays(7)))
       .Select(g => new { CardNumber = g.Key, Count = g.Count() });
@@ -114,7 +114,7 @@ public class QbservableExtensionsWindowsTests : TestBase
     Assert.ThrowsException<InvalidOperationException>(() =>
     {
       //Act
-      var grouping = context.CreateQueryStream<Transaction>()
+      var grouping = context.CreatePushQuery<Transaction>()
         .GroupBy(c => c.CardNumber)
         .WindowedBy(new HoppingWindows(Duration.OfSeconds(5)).WithAdvanceBy(Duration.OfSeconds(7)))
         .Select(g => new { CardNumber = g.Key, Count = g.Count() });
@@ -127,7 +127,7 @@ public class QbservableExtensionsWindowsTests : TestBase
     //Arrange
     var context = new TransactionsDbProvider(TestParameters.KsqlDbUrl);
 
-    var grouping = context.CreateQueryStream<Transaction>()
+    var grouping = context.CreatePushQuery<Transaction>()
       .GroupBy(c => c.CardNumber)
       .WindowedBy(new TimeWindows(Duration.OfSeconds(5)))
       .Select(g => new { CardNumber = g.Key, Count = g.Count() });
@@ -145,7 +145,7 @@ public class QbservableExtensionsWindowsTests : TestBase
     //Arrange
     var context = new TransactionsDbProvider(TestParameters.KsqlDbUrl);
 
-    var grouping = context.CreateQueryStream<Transaction>()
+    var grouping = context.CreatePushQuery<Transaction>()
       .GroupBy(c => c.CardNumber)
       .WindowedBy(new TimeWindows(Duration.OfSeconds(5), OutputRefinement.Final))
       .Select(g => new { CardNumber = g.Key, Count = g.Count() });
@@ -163,7 +163,7 @@ public class QbservableExtensionsWindowsTests : TestBase
     //Arrange
     var context = new TransactionsDbProvider(TestParameters.KsqlDbUrl);
 
-    var grouping = context.CreateQueryStream<Transaction>()
+    var grouping = context.CreatePushQuery<Transaction>()
       .GroupBy(c => c.CardNumber)
       .WindowedBy(new TimeWindows(Duration.OfSeconds(5)).WithGracePeriod(Duration.OfHours(2)))
       .Select(g => new { CardNumber = g.Key, Count = g.Count() });
@@ -186,11 +186,11 @@ public class QbservableExtensionsWindowsTests : TestBase
 
     var context = new TransactionsDbProvider(options);
 
-    var grouping1 = context.CreateQueryStream<Transaction>("authorization_attempts_1")
+    var grouping1 = context.CreatePushQuery<Transaction>("authorization_attempts_1")
       .GroupBy(c => c.CardNumber)
       .Select(g => new { CardNumber = g.Key, Count = g.Count() });
 
-    var grouping2 = context.CreateQueryStream<Transaction>("authorization_attempts_2")
+    var grouping2 = context.CreatePushQuery<Transaction>("authorization_attempts_2")
       .GroupBy(c => c.CardNumber)
       .Select(g => new { CardNumber = g.Key, Count = g.Count() });
 

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/QbservableGroupByExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/QbservableGroupByExtensionsTests.cs
@@ -25,7 +25,7 @@ public class QbservableGroupByExtensionsTests : TestBase
     context.KSqlDbProviderMock.Setup(c => c.Run<int>(It.IsAny<object>(), It.IsAny<CancellationToken>())).Returns(GetTestValues);
     context.KSqlDbProviderMock.Setup(c => c.Run<long>(It.IsAny<object>(), It.IsAny<CancellationToken>())).Returns(GetDecimalTestValues);
 
-    return context.CreateQueryStream<City>();
+    return context.CreatePushQuery<City>();
   }
 
   private TestScheduler testScheduler = null!;
@@ -208,7 +208,7 @@ public class QbservableGroupByExtensionsTests : TestBase
     var context = new TestableDbProvider(TestParameters.KsqlDbUrl);
 
     //https://kafka-tutorials.confluent.io/finding-distinct-events/ksql.html
-    var grouping = context.CreateQueryStream<Click>()
+    var grouping = context.CreatePushQuery<Click>()
       .GroupBy(c => new { c.IP_ADDRESS, c.URL, c.TIMESTAMP })
       .WindowedBy(new TimeWindows(Duration.OfMinutes(2)))
       .Having(c => c.Count(g => c.Key.IP_ADDRESS) == 1)

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/KSqlDBContextOptionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/KSqlDBContextOptionsTests.cs
@@ -73,7 +73,7 @@ public class KSqlDBContextOptionsTests : TestBase<KSqlDBContextOptions>
 
     //Assert
     Assert.ThrowsException<KeyNotFoundException>(() =>
-      ClassUnderTest.QueryParameters[parameterName].Should().BeEmpty());
+      ClassUnderTest.QueryStreamParameters[parameterName].Should().BeEmpty());
   }
 
   [Test]
@@ -89,7 +89,6 @@ public class KSqlDBContextOptionsTests : TestBase<KSqlDBContextOptions>
     //Assert
     string expectedValue = "at_least_once";
 
-    ClassUnderTest.QueryParameters[parameterName].Should().Be(expectedValue);
     ClassUnderTest.QueryStreamParameters[parameterName].Should().Be(expectedValue);
   }
 
@@ -106,7 +105,6 @@ public class KSqlDBContextOptionsTests : TestBase<KSqlDBContextOptions>
     //Assert
     string expectedValue = "exactly_once";
 
-    ClassUnderTest.QueryParameters[parameterName].Should().Be(expectedValue);
     ClassUnderTest.QueryStreamParameters[parameterName].Should().Be(expectedValue);
   }
 
@@ -123,7 +121,6 @@ public class KSqlDBContextOptionsTests : TestBase<KSqlDBContextOptions>
     //Assert
     string expectedValue = "exactly_once_v2";
 
-    ClassUnderTest.QueryParameters[parameterName].Should().Be(expectedValue);
     ClassUnderTest.QueryStreamParameters[parameterName].Should().Be(expectedValue);
   }
 
@@ -139,29 +136,9 @@ public class KSqlDBContextOptionsTests : TestBase<KSqlDBContextOptions>
     //Assert
     string expectedValue = autoOffsetReset.ToString().ToLower();
 
-    ClassUnderTest.QueryParameters[QueryParameters.AutoOffsetResetPropertyName].Should().Be(expectedValue);
     ClassUnderTest.QueryStreamParameters[QueryStreamParameters.AutoOffsetResetPropertyName].Should().Be(expectedValue);
   }
-    
-  [Test]
-  public void Clone()
-  {
-    //Arrange
-    var processingGuarantee = ProcessingGuarantee.AtLeastOnce;
-    string parameterName = KSqlDbConfigs.ProcessingGuarantee;
-    ClassUnderTest.SetProcessingGuarantee(processingGuarantee);
 
-    //Act
-    var clone = ClassUnderTest.Clone();
-
-    //Assert
-    string expectedValue = "at_least_once";
-      
-    ClassUnderTest.Url.Should().Be(TestParameters.KsqlDbUrl);
-
-    clone.QueryParameters[parameterName].Should().Be(expectedValue);
-    clone.QueryStreamParameters[parameterName].Should().Be(expectedValue);
-  }
     
   [Test]
   public void JsonSerializerOptions()

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/KSqlDBContextTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/KSqlDBContextTests.cs
@@ -23,13 +23,13 @@ namespace ksqlDb.RestApi.Client.Tests.KSql.Query.Context;
 public class KSqlDBContextTests : TestBase
 {
   [Test]
-  public void CreateQueryStream_Subscribe_KSqlDbProvidersRunWasCalled()
+  public void CreatePushQuery_Subscribe_KSqlDbProvidersRunWasCalled()
   {
     //Arrange
     var context = new TestableDbProvider<string>(TestParameters.KsqlDbUrl);
 
     //Act
-    using var subscription = context.CreateQueryStream<string>().Subscribe(_ => { });
+    using var subscription = context.CreatePushQuery<string>().Subscribe(_ => { });
 
     //Assert
     subscription.Should().NotBeNull();
@@ -52,7 +52,7 @@ public class KSqlDBContextTests : TestBase
     var context = new TestableDbProvider<string>(contextOptions);
 
     //Act
-    using var subscription = context.CreateQueryStream<string>().Subscribe(_ => { });
+    using var subscription = context.CreatePushQuery<string>().Subscribe(_ => { });
 
     //Assert
     context.KSqlDbProviderMock.Verify(
@@ -72,7 +72,7 @@ public class KSqlDBContextTests : TestBase
     };
 
     //Act
-    var subscription = context.CreateQueryStream<string>().WithOffsetResetPolicy(AutoOffsetReset.Latest)
+    var subscription = context.CreatePushQuery<string>().WithOffsetResetPolicy(AutoOffsetReset.Latest)
       .Subscribe(_ => { });
 
     //Assert
@@ -93,7 +93,7 @@ public class KSqlDBContextTests : TestBase
     var context = new TestableDbProvider<string>(contextOptions);
 
     //Act
-    using var subscription = context.CreateQueryStream<string>().Subscribe(_ => { });
+    using var subscription = context.CreatePushQuery<string>().Subscribe(_ => { });
 
     //Assert
     context.KSqlDbProviderMock.Verify(
@@ -111,7 +111,7 @@ public class KSqlDBContextTests : TestBase
     var context = new TestableDbProvider<string>(contextOptions);
 
     //Act
-    using var subscription = context.CreateQueryStream<string>().Subscribe(_ => { });
+    using var subscription = context.CreatePushQuery<string>().Subscribe(_ => { });
 
     //Assert
     context.KSqlDbProviderMock.Verify(
@@ -126,7 +126,7 @@ public class KSqlDBContextTests : TestBase
     var context = new TestableDbProvider<string>(TestParameters.KsqlDbUrl);
 
     //Act
-    using var subscription = context.CreateQueryStream<string>().Subscribe(_ => { });
+    using var subscription = context.CreatePushQuery<string>().Subscribe(_ => { });
 
     //Assert
     context.KSqlQueryGenerator.Verify(c => c.BuildKSql(It.IsAny<Expression>(), It.IsAny<QueryContext>()), Times.Once);
@@ -147,7 +147,7 @@ public class KSqlDBContextTests : TestBase
     var context = new TestableDbProvider<string>(contextOptions);
 
     //Act
-    using var subscription = context.CreateQueryStream<string>().Subscribe(_ => { }, e => { });
+    using var subscription = context.CreatePushQuery<string>().Subscribe(_ => { }, e => { });
 
     //Assert
     context.KSqlDbProviderMock.Verify(
@@ -173,7 +173,7 @@ public class KSqlDBContextTests : TestBase
   {
     //Arrange
     var context = new TestableDbProvider<string>(TestParameters.KsqlDbUrl);
-    context.CreateQueryStream<string>();
+    context.CreatePushQuery<string>();
 
     //Act
     await context.DisposeAsync().ConfigureAwait(false);
@@ -183,7 +183,7 @@ public class KSqlDBContextTests : TestBase
   }
 
   [Test]
-  public void CreateQueryStream_RawKSQL_ReturnAsyncEnumerable()
+  public void CreatePushQuery_RawKSQL_ReturnAsyncEnumerable()
   {
     //Arrange
     string ksql = "SELECT * FROM tweetsTest EMIT CHANGES LIMIT 2;";
@@ -197,7 +197,7 @@ public class KSqlDBContextTests : TestBase
     var context = new TestableDbProvider<string>(TestParameters.KsqlDbUrl);
 
     //Act
-    var source = context.CreateQueryStream<string>(queryStreamParameters);
+    var source = context.CreatePushQuery<string>(queryStreamParameters);
 
     //Assert
     source.Should().NotBeNull();
@@ -205,7 +205,7 @@ public class KSqlDBContextTests : TestBase
 
 
   [Test]
-  public void CreateQueryStream_InvalidQueryParameterTypeThrows()
+  public void CreatePushQuery_InvalidQueryParameterTypeThrows()
   {
     //Arrange
     string ksql = "SELECT * FROM tweetsTest EMIT CHANGES LIMIT 2;";
@@ -222,7 +222,7 @@ public class KSqlDBContextTests : TestBase
     Assert.Throws<InvalidOperationException>(() =>
     {
       //Act
-      context.CreateQueryStream<string>(queryParameters);
+      context.CreatePushQuery<string>(queryParameters);
     });
   }
 
@@ -241,7 +241,7 @@ public class KSqlDBContextTests : TestBase
     var context = new TestableDbProvider<string>(TestParameters.KsqlDbUrl);
 
     //Act
-    var source = context.CreateQueryStream<string>(queryParameters);
+    var source = context.CreatePushQuery<string>(queryParameters);
 
     //Assert
     source.Should().NotBeNull();
@@ -347,7 +347,7 @@ public class KSqlDBContextTests : TestBase
     };
     var context = new KSqlDBContext(contextOptions);
 
-    _ = context.CreateQueryStream<int>();
+    _ = context.CreatePushQuery<int>();
 
     var serviceProvider = context.ServiceCollection
       .BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
@@ -374,7 +374,7 @@ public class KSqlDBContextTests : TestBase
     };
     var context = new KSqlDBContext(contextOptions);
 
-    _ = context.CreateQueryStream<int>();
+    _ = context.CreatePushQuery<int>();
 
     var serviceProvider = context.ServiceCollection
       .BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/Options/KSqlDbContextOptionsBuilderTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/Options/KSqlDbContextOptionsBuilderTests.cs
@@ -89,7 +89,6 @@ public class KSqlDbContextOptionsBuilderTests : TestBase<KSqlDbContextOptionsBui
     var options = setupParameters.SetProcessingGuarantee(ProcessingGuarantee.AtLeastOnce).Options;
 
     //Assert
-    options.QueryParameters[KSqlDbConfigs.ProcessingGuarantee].Should().Be("at_least_once");
     options.QueryStreamParameters[KSqlDbConfigs.ProcessingGuarantee].Should().Be("at_least_once");
   }
 
@@ -107,7 +106,6 @@ public class KSqlDbContextOptionsBuilderTests : TestBase<KSqlDbContextOptionsBui
       }).Options;
 
     //Assert
-    options.QueryParameters[KSqlDbConfigs.ProcessingGuarantee].Should().Be("at_least_once");
     options.QueryStreamParameters[KSqlDbConfigs.ProcessingGuarantee].Should().Be("at_least_once");
   }
 
@@ -125,7 +123,6 @@ public class KSqlDbContextOptionsBuilderTests : TestBase<KSqlDbContextOptionsBui
 
     //Assert
     string expectedValue = autoOffsetReset.ToString().ToLower();
-    options.QueryParameters.Properties[QueryParameters.AutoOffsetResetPropertyName].Should().Be(expectedValue);
     options.QueryStreamParameters[QueryStreamParameters.AutoOffsetResetPropertyName].Should().Be(expectedValue);
   }
 
@@ -250,53 +247,22 @@ public class KSqlDbContextOptionsBuilderTests : TestBase<KSqlDbContextOptionsBui
 
   #endregion
 
-  #region Query
+  #region SetupPullQuery
 
   [Test]
-  public void SetupQuery_OptionsQueryParameters_AutoOffsetResetIsSetToDefault()
+  public void SetupPullQuery_PropertyWasSet()
   {
     //Arrange
     var setupParameters = ClassUnderTest.UseKSqlDb(TestParameters.KsqlDbUrl);
 
     //Act
-    var options = setupParameters.SetupQuery(_ =>
+    var options = setupParameters.SetupPullQuery(opt =>
     {
+      opt[KSqlDbConfigs.KsqlQueryPullTableScanEnabled] = "true";
     }).Options;
 
     //Assert
-    options.QueryParameters.Properties[QueryParameters.AutoOffsetResetPropertyName].Should().BeEquivalentTo("earliest");
+    options.PullQueryParameters.Properties[KSqlDbConfigs.KsqlQueryPullTableScanEnabled].Should().BeEquivalentTo("true");
   }
-
-  [Test]
-  public void SetupQueryNotCalled_OptionsQueryParameters_AutoOffsetResetIsSetToDefault()
-  {
-    //Arrange
-    var setupParameters = ClassUnderTest.UseKSqlDb(TestParameters.KsqlDbUrl);
-    string earliestAtoOffsetReset = AutoOffsetReset.Earliest.ToString().ToLower();
-
-    //Act
-    var options = setupParameters.Options;
-
-    //Assert
-    options.QueryParameters.Properties[QueryParameters.AutoOffsetResetPropertyName].Should().BeEquivalentTo(earliestAtoOffsetReset);
-  }
-
-  [Test]
-  public void SetupQuery_AmendOptionsQueryParametersProperty_AutoOffsetResetWasChanged()
-  {
-    //Arrange
-    var setupParameters = ClassUnderTest.UseKSqlDb(TestParameters.KsqlDbUrl);
-    string latestAtoOffsetReset = AutoOffsetReset.Latest.ToString().ToLower();
-
-    //Act
-    var options = setupParameters.SetupQuery(c =>
-    {
-      c.Properties[QueryParameters.AutoOffsetResetPropertyName] = latestAtoOffsetReset;
-    }).Options;
-
-    //Assert
-    options.QueryParameters.Properties[QueryParameters.AutoOffsetResetPropertyName].Should().BeEquivalentTo(latestAtoOffsetReset);
-  }
-
   #endregion
 }

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/Options/KSqlDbContextOptionsBuilderTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/Options/KSqlDbContextOptionsBuilderTests.cs
@@ -93,7 +93,7 @@ public class KSqlDbContextOptionsBuilderTests : TestBase<KSqlDbContextOptionsBui
   }
 
   [Test]
-  public void SetProcessingGuarantee_ThenSetupQueryStream()
+  public void SetProcessingGuarantee_ThenSetupPushQuery()
   {
     //Arrange
     var setupParameters = ClassUnderTest.UseKSqlDb(TestParameters.KsqlDbUrl)
@@ -101,7 +101,7 @@ public class KSqlDbContextOptionsBuilderTests : TestBase<KSqlDbContextOptionsBui
 
     //Act
     var options = setupParameters
-      .SetupQueryStream(_ =>
+      .SetupPushQuery(_ =>
       {
       }).Options;
 
@@ -168,16 +168,16 @@ public class KSqlDbContextOptionsBuilderTests : TestBase<KSqlDbContextOptionsBui
     ((KSqlDbContextOptionsBuilder)setupParameters).InternalOptions.IdentifierEscaping.Should().Be(escaping);
   }
 
-  #region QueryStream
+  #region SetupPushQuery
 
   [Test]
-  public void SetupQueryStream_OptionsQueryStreamParameters_AutoOffsetResetIsSetToDefault()
+  public void SetupPushQuery_OptionsQueryStreamParameters_AutoOffsetResetIsSetToDefault()
   {
     //Arrange
     var setupParameters = ClassUnderTest.UseKSqlDb(TestParameters.KsqlDbUrl);
 
     //Act
-    var options = setupParameters.SetupQueryStream(_ =>
+    var options = setupParameters.SetupPushQuery(_ =>
     {
     }).Options;
 
@@ -186,7 +186,7 @@ public class KSqlDbContextOptionsBuilderTests : TestBase<KSqlDbContextOptionsBui
   }
 
   [Test]
-  public void SetupQueryStreamNotCalled_OptionsQueryStreamParameters_AutoOffsetResetIsSetToDefault()
+  public void SetupPushQueryNotCalled_OptionsQueryStreamParameters_AutoOffsetResetIsSetToDefault()
   {
     //Arrange
     var setupParameters = ClassUnderTest.UseKSqlDb(TestParameters.KsqlDbUrl);
@@ -200,14 +200,14 @@ public class KSqlDbContextOptionsBuilderTests : TestBase<KSqlDbContextOptionsBui
   }
 
   [Test]
-  public void SetupQueryStream_AmendOptionsQueryStreamParametersProperty_AutoOffsetResetWasChanged()
+  public void SetupPushQuery_AmendOptionsQueryStreamParametersProperty_AutoOffsetResetWasChanged()
   {
     //Arrange
     var setupParameters = ClassUnderTest.UseKSqlDb(TestParameters.KsqlDbUrl);
     string latestAtoOffsetReset = AutoOffsetReset.Latest.ToString().ToLower();
 
     //Act
-    var options = setupParameters.SetupQueryStream(c =>
+    var options = setupParameters.SetupPushQuery(c =>
     {
       c.Properties[QueryStreamParameters.AutoOffsetResetPropertyName] = latestAtoOffsetReset;
     }).Options;

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/KSqlQueryLanguageVisitorTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/KSqlQueryLanguageVisitorTests.cs
@@ -44,14 +44,14 @@ public class KSqlQueryLanguageVisitorTests : TestBase
 
     var context = new TestableDbProvider(contextOptions);
 
-    return context.CreateQueryStream<Location>();
+    return context.CreatePushQuery<Location>();
   }
 
   private IQbservable<Tweet> CreateTweetsStreamSource()
   {
     var context = new TestableDbProvider(contextOptions);
 
-    return context.CreateQueryStream<Tweet>();
+    return context.CreatePushQuery<Tweet>();
   }
 
   #region Select
@@ -72,7 +72,7 @@ public class KSqlQueryLanguageVisitorTests : TestBase
   {
     //Arrange
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<MySensor>()
+      .CreatePushQuery<MySensor>()
       .Where(c => c.SensorId2 == "1")
       .Select(c => c.SensorId2);
 
@@ -96,7 +96,7 @@ WHERE SensorId = '1' EMIT CHANGES;";
     string stream2TableName = "stream2";
 
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<MySensor>(stream1TableName)
+      .CreatePushQuery<MySensor>(stream1TableName)
       .Join(Source.Of<MySensor>(stream2TableName).Within(Duration.OfDays(1)),
         endUsers => K.Functions.ExtractJsonField(endUsers.Data, "$.customer_id"),
         transactions => K.Functions.ExtractJsonField(transactions.Data, "$.customer_id"),
@@ -132,7 +132,7 @@ EMIT CHANGES;".ReplaceLineEndings();
     string stream1TableName = "stream1";
     string stream2TableName = "stream2";
 
-    var query = (from a in new TestableDbProvider(contextOptions).CreateQueryStream<MySensor>(stream1TableName)
+    var query = (from a in new TestableDbProvider(contextOptions).CreatePushQuery<MySensor>(stream1TableName)
       join b in Source.Of<MySensor>(stream2TableName) on a.DataId equals b.DataId
       select new
       {
@@ -165,7 +165,7 @@ EMIT CHANGES;".ReplaceLineEndings();
     string stream2TableName = "stream2";
     string stream3TableName = "stream3";
 
-    var query = (from a in new TestableDbProvider(contextOptions).CreateQueryStream<MySensor>(stream1TableName)
+    var query = (from a in new TestableDbProvider(contextOptions).CreatePushQuery<MySensor>(stream1TableName)
       join b in Source.Of<MySensor>(stream2TableName) on a.DataId equals b.DataId
       join c in Source.Of<MySensor>(stream3TableName) on a.DataId equals c.DataId
       select new
@@ -292,7 +292,7 @@ WHERE {nameof(Location.Latitude)} = '1' AND {nameof(Location.Longitude)} = 0.1 E
   {
     //Arrange
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<OrderData>()
+      .CreatePushQuery<OrderData>()
       .Select(l => new List<int> { 1, 3 });
 
     //Act
@@ -311,7 +311,7 @@ WHERE {nameof(Location.Latitude)} = '1' AND {nameof(Location.Longitude)} = 0.1 E
     var orderTypes = new List<int> { 1, 3 };
 
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<OrderData>()
+      .CreatePushQuery<OrderData>()
       .Select(l => new { OrderTypes = orderTypes });
 
     //Act
@@ -330,7 +330,7 @@ WHERE {nameof(Location.Latitude)} = '1' AND {nameof(Location.Longitude)} = 0.1 E
     var orderTypes = new List<int> { 1, 3 };
 
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<OrderData>()
+      .CreatePushQuery<OrderData>()
       .Select(c => orderTypes.Contains(c.OrderType));
 
     //Act
@@ -347,7 +347,7 @@ WHERE {nameof(Location.Latitude)} = '1' AND {nameof(Location.Longitude)} = 0.1 E
     var orderTypes = new List<int> { 1, 3 };
 
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<OrderData>()
+      .CreatePushQuery<OrderData>()
       .Select(c => new { Contains = new List<int> { 1, 3 }.Contains(c.OrderType) });
 
     //Act
@@ -454,7 +454,7 @@ WHERE {nameof(Location.Latitude)} = '1' AND {nameof(Location.Longitude)} = 0.1 E
   {
     //Arrange
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<TimeTypes>()
+      .CreatePushQuery<TimeTypes>()
       .Select(p => new DateTimeOffset(2021, 7, 4, 13, 29, 45, 447, TimeSpan.FromHours(4)));
 
     //Act
@@ -474,7 +474,7 @@ WHERE {nameof(Location.Latitude)} = '1' AND {nameof(Location.Longitude)} = 0.1 E
     var dateTimeOffset = new DateTimeOffset(2021, 7, 4, 13, 29, 45, 447, TimeSpan.FromHours(4));
 
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<TimeTypes>()
+      .CreatePushQuery<TimeTypes>()
       .Select(p => dateTimeOffset);
 
     //Act
@@ -492,7 +492,7 @@ WHERE {nameof(Location.Latitude)} = '1' AND {nameof(Location.Longitude)} = 0.1 E
   {
     //Arrange
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<TimeTypes>()
+      .CreatePushQuery<TimeTypes>()
       .Select(p => new { Time = new DateTime(2021, 4, 1) });
 
     //Act
@@ -510,7 +510,7 @@ WHERE {nameof(Location.Latitude)} = '1' AND {nameof(Location.Longitude)} = 0.1 E
   {
     //Arrange
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<TimeTypes>()
+      .CreatePushQuery<TimeTypes>()
       .Where(c => c.Dt.Between(DateTime.MinValue, DateTime.MaxValue));
 
     //Act
@@ -529,7 +529,7 @@ WHERE Dt BETWEEN '0001-01-01' AND '9999-12-31' EMIT CHANGES;".ReplaceLineEndings
   {
     //Arrange
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<TimeTypes>()
+      .CreatePushQuery<TimeTypes>()
       .Select(c => DateTime.Now);
 
     //Act
@@ -549,7 +549,7 @@ WHERE Dt BETWEEN '0001-01-01' AND '9999-12-31' EMIT CHANGES;".ReplaceLineEndings
     var from = new DateTime(2021, 10, 1);
 
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<TimeTypes>()
+      .CreatePushQuery<TimeTypes>()
       .Select(c => from);
 
     //Act
@@ -569,7 +569,7 @@ WHERE Dt BETWEEN '0001-01-01' AND '9999-12-31' EMIT CHANGES;".ReplaceLineEndings
     var from = new DateTime(2021, 10, 1);
 
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<TimeTypes>()
+      .CreatePushQuery<TimeTypes>()
       .Select(c => new { Ts = from, DateTime.MinValue });
 
     //Act
@@ -663,7 +663,7 @@ WHERE {nameof(Location.Latitude)} = '1' EMIT CHANGES;".ReplaceLineEndings();
   {
     //Arrange
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<OrderData>()
+      .CreatePushQuery<OrderData>()
       .Where(c => K.Functions.ArrayContains(new[] { 1, 3 }, c.OrderType));
 
     //Act
@@ -681,7 +681,7 @@ WHERE ARRAY_CONTAINS(ARRAY[1, 3], {nameof(OrderData.OrderType)}) EMIT CHANGES;".
     var orderTypes = new[] { 1, 3 };
 
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<OrderData>()
+      .CreatePushQuery<OrderData>()
       .Where(c => K.Functions.ArrayContains(orderTypes, c.OrderType));
 
     //Act
@@ -699,7 +699,7 @@ WHERE ARRAY_CONTAINS(ARRAY[1, 3], {nameof(OrderData.OrderType)}) EMIT CHANGES;".
     var orderTypes = new List<int> { 1, 3 };
 
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<OrderData>()
+      .CreatePushQuery<OrderData>()
       .Where(c => orderTypes.Contains(c.OrderType));
 
     //Act
@@ -717,7 +717,7 @@ WHERE {nameof(OrderData.OrderType)} IN (1, 3) EMIT CHANGES;".ReplaceLineEndings(
     var orderTypes = new List<string> { "1", "3" };
 
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<OrderData>()
+      .CreatePushQuery<OrderData>()
       .Where(c => orderTypes.Contains(c.Category));
 
     //Act
@@ -735,7 +735,7 @@ WHERE {nameof(OrderData.Category)} IN ('1', '3') EMIT CHANGES;".ReplaceLineEndin
     var orderTypes = new[] { 1, 3 };
 
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<OrderData>()
+      .CreatePushQuery<OrderData>()
       .Where(c => orderTypes.Contains(c.OrderType));
 
     //Act
@@ -893,7 +893,7 @@ WHERE {nameof(Tweet.Message)} NOT BETWEEN '1' AND '3' EMIT CHANGES;".ReplaceLine
     var to = new DateTime(2021, 10, 12);
 
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<TimeTypes>()
+      .CreatePushQuery<TimeTypes>()
       .Where(p => p.Dt.Between(from, to));
 
     //Act
@@ -912,7 +912,7 @@ WHERE {nameof(CreateEntityTests.TimeTypes.Dt)} BETWEEN '2021-10-01' AND '2021-10
   {
     //Arrange
     var query = new TestableDbProvider(contextOptions)
-      .CreateQueryStream<TimeTypes>()
+      .CreatePushQuery<TimeTypes>()
       .Where(p => p.Dt.Between(new DateTime(2021, 10, 1), new DateTime(2021, 10, 12)));
 
     //Act
@@ -1368,7 +1368,7 @@ WHERE {nameof(CreateEntityTests.TimeTypes.Dt)} BETWEEN '2021-10-01' AND '2021-10
   {
     var context = new TestableDbProvider(contextOptions);
 
-    return context.CreateQueryStream<DatabaseChangeObject<Entity>>();
+    return context.CreatePushQuery<DatabaseChangeObject<Entity>>();
   }
 
   [Test]

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Visitors/JoinVisitorTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Visitors/JoinVisitorTests.cs
@@ -58,7 +58,7 @@ EMIT CHANGES;");
     var (escaping, expectedQuery) = testCase;
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
-    var query = kSqlDbContext.CreateQueryStream<Movie>()
+    var query = kSqlDbContext.CreatePushQuery<Movie>()
       .Join(
         Source.Of<Lead_Actor>("LeadActor"),
         movie => movie.Title,
@@ -107,7 +107,7 @@ EMIT CHANGES;");
     var (escaping, expectedQuery) = testCase;
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
-    var query = kSqlDbContext.CreateQueryStream<Movie>()
+    var query = kSqlDbContext.CreatePushQuery<Movie>()
       .Join(
         Source.Of<Lead_Actor>(),
         movie => movie.Title,
@@ -156,7 +156,7 @@ EMIT CHANGES;");
     var (escaping, expectedQuery) = testCase;
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
-    var query = kSqlDbContext.CreateQueryStream<Movie>()
+    var query = kSqlDbContext.CreatePushQuery<Movie>()
       .Join(
         Source.Of<Lead_Actor>(),
         movie => movie.Title,
@@ -202,7 +202,7 @@ EMIT CHANGES;");
     var (escaping, expectedQuery) = testCase;
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
-    var query = kSqlDbContext.CreateQueryStream<Movie>()
+    var query = kSqlDbContext.CreatePushQuery<Movie>()
       .Join(
         Source.Of<MovieExt>(),
         movie => movie.Title,
@@ -243,7 +243,7 @@ EMIT CHANGES;");
     var (escaping, expectedQuery) = testCase;
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
-    var query = kSqlDbContext.CreateQueryStream<Movie>()
+    var query = kSqlDbContext.CreatePushQuery<Movie>()
       .Join(
         Source.Of<Lead_Actor>("Actors"),
         movie => movie.Title,
@@ -287,7 +287,7 @@ EMIT CHANGES;");
     var (escaping, expectedQuery) = testCase;
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
-    var query = kSqlDbContext.CreateQueryStream<Movie>()
+    var query = kSqlDbContext.CreatePushQuery<Movie>()
       .Join(
         Source.Of<Lead_Actor>("Actors"),
         movie => movie.Title,
@@ -329,7 +329,7 @@ EMIT CHANGES;");
     var (escaping, expectedQuery) = testCase;
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
-    var query = from movie in kSqlDbContext.CreateQueryStream<Movie>()
+    var query = from movie in kSqlDbContext.CreatePushQuery<Movie>()
       join actor in Source.Of<Lead_Actor>("Actors") on movie.Title equals actor.Title
       select new
       {
@@ -390,7 +390,7 @@ EMIT CHANGES;");
     var value = new Foo { Prop = 42 };
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
-    var query = from o in kSqlDbContext.CreateQueryStream<Order>()
+    var query = from o in kSqlDbContext.CreatePushQuery<Order>()
       join p1 in Source.Of<Payment>() on o.OrderId equals p1.Id
       join s1 in Source.Of<Shipment>() on o.OrderId equals s1.Id
       select new
@@ -456,7 +456,7 @@ EMIT CHANGES;");
     var (escaping, expectedQuery) = testCase;
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
-    var query = from o in kSqlDbContext.CreateQueryStream<Order>()
+    var query = from o in kSqlDbContext.CreatePushQuery<Order>()
       join lm in Source.Of<LambdaMap>() on o.OrderId equals lm.Id
       join s1 in Source.Of<Shipment>() on o.OrderId equals s1.Id
       select new
@@ -478,7 +478,7 @@ EMIT CHANGES;");
   public void JoinWithSeveralOnConditions_BuildKSql_Prints()
   {
     //Arrange
-    var query = from o in KSqlDbContext.CreateQueryStream<Order>()
+    var query = from o in KSqlDbContext.CreatePushQuery<Order>()
       join lm in Source.Of<LambdaMap>() on new { OrderId = o.OrderId, NestedProp = "Nested" } equals new { OrderId = lm.Id, NestedProp = lm.Nested.Prop }
       select new
       {
@@ -516,7 +516,7 @@ WHERE `lm`.`Nested`->`Prop` = 'Nested' EMIT CHANGES;");
     var (escaping, expectedQuery) = testCase;
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
-    var query = from o in kSqlDbContext.CreateQueryStream<Order>()
+    var query = from o in kSqlDbContext.CreatePushQuery<Order>()
       join lm in Source.Of<LambdaMap>() on o.OrderId equals lm.Id
       where lm.Nested.Prop == "Nested"
       select new
@@ -558,7 +558,7 @@ EMIT CHANGES;");
     var (escaping, expectedQuery) = testCase;
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
-    var query = from o in kSqlDbContext.CreateQueryStream<Order>()
+    var query = from o in kSqlDbContext.CreatePushQuery<Order>()
       join lm in Source.Of<LambdaMap>() on o.OrderId equals lm.Id
       select new
       {
@@ -605,7 +605,7 @@ EMIT CHANGES LIMIT 2;");
     var (escaping, expectedQuery) = testCase;
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
-    var query = from o in kSqlDbContext.CreateQueryStream<Order>()
+    var query = from o in kSqlDbContext.CreatePushQuery<Order>()
       join p1 in Source.Of<Payment>() on o.OrderId equals p1.Id
       join s1 in Source.Of<Shipment>() on o.OrderId equals s1.Id
       select new
@@ -653,7 +653,7 @@ EMIT CHANGES;");
     var (escaping, expectedQuery) = testCase;
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
-    var query = from o in kSqlDbContext.CreateQueryStream<Order>()
+    var query = from o in kSqlDbContext.CreatePushQuery<Order>()
       join p1 in Source.Of<Payment>() on o.OrderId equals p1.Id
       join s1 in Source.Of<Shipment>() on o.OrderId equals s1.Id into gj
       from sa in gj.DefaultIfEmpty()
@@ -703,7 +703,7 @@ EMIT CHANGES;");
     var (escaping, expectedQuery) = testCase;
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
-    var query = from o in kSqlDbContext.CreateQueryStream<Order>()
+    var query = from o in kSqlDbContext.CreatePushQuery<Order>()
       join p in Source.Of<Payment>().Within(Duration.OfHours(1)) on o.OrderId equals p.Id
       join s in Source.Of<Shipment>().Within(Duration.OfDays(5)) on o.OrderId equals s.Id
       select new
@@ -743,7 +743,7 @@ EMIT CHANGES;");
     var (escaping, expectedQuery) = testCase;
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
-    var query = from o in kSqlDbContext.CreateQueryStream<Order>()
+    var query = from o in kSqlDbContext.CreatePushQuery<Order>()
       join p in Source.Of<Payment>().Within(Duration.OfHours(1), Duration.OfDays(5)) on o.OrderId equals p.Id
       select new
       {
@@ -782,7 +782,7 @@ EMIT CHANGES;");
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
     var query = kSqlDbContext
-      .CreateQueryStream<Movie>("movies")
+      .CreatePushQuery<Movie>("movies")
       .Join(Source.Of<Lead_Actor>("actors").Within(Duration.OfDays(1)),
         movie => K.Functions.ExtractJsonField(movie!.Title, "$.movie_title"),
         actor => K.Functions.ExtractJsonField(actor!.Actor_Name, "$.actor_name"),
@@ -824,7 +824,7 @@ EMIT CHANGES;");
     var (escaping, expectedQuery) = testCase;
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
-    var query = kSqlDbContext.CreateQueryStream<Movie>()
+    var query = kSqlDbContext.CreatePushQuery<Movie>()
       .LeftJoin(
         Source.Of<Lead_Actor>(),
         movie => movie.Title,
@@ -874,7 +874,7 @@ EMIT CHANGES;");
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
     var query =
-      from movie in kSqlDbContext.CreateQueryStream<Movie>()
+      from movie in kSqlDbContext.CreatePushQuery<Movie>()
       join actor in Source.Of<Lead_Actor>("Actors")
         on movie.Title equals actor.Title into gj
       from a in gj.DefaultIfEmpty()
@@ -918,7 +918,7 @@ EMIT CHANGES;");
     var (escaping, expectedQuery) = testCase;
     var kSqlDbContext = new KSqlDBContext(
       new KSqlDBContextOptions(TestParameters.KsqlDbUrl) { IdentifierEscaping = escaping } );
-    var query = kSqlDbContext.CreateQueryStream<Movie>()
+    var query = kSqlDbContext.CreatePushQuery<Movie>()
       .GroupJoin(Source.Of<Lead_Actor>("Actors"), c => c.Title, d => d.Title, (movie, gj) => new
       {
         movie,
@@ -986,7 +986,7 @@ EMIT CHANGES;");
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
     var query =
-      from orders in kSqlDbContext.CreateQueryStream<Order>()
+      from orders in kSqlDbContext.CreatePushQuery<Order>()
       join customer in Source.Of<Customer>()
         on orders.CustomerId equals customer.CustomerId into gj
       from customers in gj.DefaultIfEmpty()
@@ -1034,7 +1034,7 @@ EMIT CHANGES;");
     var (escaping, expectedQuery) = testCase;
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
-    var query = kSqlDbContext.CreateQueryStream<Movie>()
+    var query = kSqlDbContext.CreatePushQuery<Movie>()
       .LeftJoin(
         Source.Of<Lead_Actor>("Actors"),
         movie => movie.Title,
@@ -1083,7 +1083,7 @@ EMIT CHANGES;");
     var (escaping, expectedQuery) = testCase;
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
-    var query = kSqlDbContext.CreateQueryStream<Movie>()
+    var query = kSqlDbContext.CreatePushQuery<Movie>()
       .FullOuterJoin(
         Source.Of<Lead_Actor>("Actors"),
         movie => movie.Title,
@@ -1132,7 +1132,7 @@ EMIT CHANGES;");
     var (escaping, expectedQuery) = testCase;
     var kSqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(TestParameters.KsqlDbUrl)
       { IdentifierEscaping = escaping });
-    var query = kSqlDbContext.CreateQueryStream<Movie>()
+    var query = kSqlDbContext.CreatePushQuery<Movie>()
       .RightJoin(
         Source.Of<Lead_Actor>("Actors"),
         movie => movie.Title,

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Parameters/QueryParametersExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Parameters/QueryParametersExtensionsTests.cs
@@ -9,6 +9,42 @@ namespace ksqlDb.RestApi.Client.Tests.KSql.RestApi.Parameters;
 public class QueryParametersExtensionsTests
 {
   [Test]
+  public void FillFrom_DestinationParametersAreSetFromSource()
+  {
+    //Arrange
+    var source = new QueryStreamParameters
+    {
+      Sql = "Select",
+      ["key"] = "value"
+    };
+    var destination = new QueryStreamParameters();
+
+    //Act
+    destination.FillFrom(source);
+
+    //Assert
+    destination.Sql.Should().BeEquivalentTo(source.Sql);
+    destination.Properties.Count.Should().Be(source.Properties.Count);
+  }
+
+  [Test]
+  public void FillPushQueryParametersFrom_DestinationParametersAreSetFromSource()
+  {
+    //Arrange
+    var source = new QueryStreamParameters()
+    {
+      AutoOffsetReset = AutoOffsetReset.Latest
+    };
+    var destination = new QueryStreamParameters();
+
+    //Act
+    destination.FillPushQueryParametersFrom(source);
+
+    //Assert
+    destination.AutoOffsetReset.Should().Be(source.AutoOffsetReset);
+  }
+
+  [Test]
   public void ToLogInfo_QueryStreamParameters_NoParameters()
   {
     //Arrange

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Parameters/QueryStreamEndpointParametersTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Parameters/QueryStreamEndpointParametersTests.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+using ksqlDB.RestApi.Client.KSql.Query.Options;
+using ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
+using NUnit.Framework;
+
+namespace ksqlDb.RestApi.Client.Tests.KSql.RestApi.Parameters
+{
+  public class QueryStreamEndpointParametersTests
+  {
+    [Test]
+    public void Clone()
+    {
+      //Arrange
+      var source = new QueryStreamParameters
+      {
+        Sql = "Select",
+        ["key"] = "value"
+      };
+
+      //Act
+      var clone = source.Clone();
+
+      //Assert
+      clone.Sql.Should().BeEquivalentTo(source.Sql);
+      clone.Properties.Count.Should().Be(source.Properties.Count);
+    }
+
+    [Test]
+    public void QueryStreamParameters_AutoOffsetReset_CorrectKeyWasUsed()
+    {
+      //Arrange
+      var source = new QueryStreamParameters
+      {
+        AutoOffsetReset = AutoOffsetReset.Earliest
+      };
+
+      //Act
+      var clone = source.Clone();
+
+      //Assert
+      clone.Properties[QueryStreamParameters.AutoOffsetResetPropertyName].Should().Be(nameof(AutoOffsetReset.Earliest).ToLower());
+    }
+
+    [Test]
+    public void QueryParameters_AutoOffsetReset_CorrectKeyWasUsed()
+    {
+      //Arrange
+      var source = new QueryParameters
+      {
+        AutoOffsetReset = AutoOffsetReset.Latest
+      };
+
+      //Act
+      var clone = source.Clone();
+
+      //Assert
+      clone.Properties[QueryParameters.AutoOffsetResetPropertyName].Should().Be(nameof(AutoOffsetReset.Latest).ToLower());
+    }
+  }
+}

--- a/Tests/ksqlDB.RestApi.Client.Tests/Mocking/MockingExamples.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/Mocking/MockingExamples.cs
@@ -137,7 +137,7 @@ class KSqlDb : IKSqlDb
 
   public IQbservable<ElasticSearchEvent> CreateElasticSearchEventQuery()
   {
-    var query = context.CreateQueryStream<ElasticSearchEvent>()
+    var query = context.CreatePushQuery<ElasticSearchEvent>()
       .Where(p => p.Key != 33);
 
     return query;

--- a/Tests/ksqlDb.RestApi.Client.ProtoBuf.Tests/KSql/Query/ProtoBufKSqlDbContextTests.cs
+++ b/Tests/ksqlDb.RestApi.Client.ProtoBuf.Tests/KSql/Query/ProtoBufKSqlDbContextTests.cs
@@ -10,7 +10,7 @@ namespace ksqlDb.RestApi.Client.ProtoBuf.Tests.KSql.Query;
 public class ProtoBufKSqlDbContextTests : TestBase
 {
   [Test]
-  public void CreateQueryStream_Subscribe_KSqlDbProvidersRunWasCalled()
+  public void CreatePushQuery_Subscribe_KSqlDbProvidersRunWasCalled()
   {
     //Arrange
     var context = new TestableProtoBufKSqlDbContext<string>(TestParameters.KsqlDbUrl);

--- a/docs/breaking_changes.md
+++ b/docs/breaking_changes.md
@@ -2,8 +2,10 @@
 
 # v6.0.0
 - `QueryType` enum was renamed to `EndpointType`
-- removed `CreateQuery` from `IKSqlDBContext` interface in the netstandard version. It was replaced with `CreateQueryStream`.
- 
+- removed `CreateQuery` from `IKSqlDBContext` interface, it was merged with `CreateQueryStream`.
+- removed `SetupQuery` from `KSqlDbContextOptionsBuilder`, it was merged with `SetupQueryStream`.
+- introduced distinct parameters designed specifically for pull queries. Before this update, the parameters sent to both the 'query' and 'query-stream' endpoints were shared between pull and push queries.
+
 # v5.0.0
 - removed static modifier from `StatementGenerator` class
 

--- a/docs/breaking_changes.md
+++ b/docs/breaking_changes.md
@@ -2,7 +2,7 @@
 
 # v6.0.0
 - `QueryType` enum was renamed to `EndpointType`
-- removed `CreateQuery` from `IKSqlDBContext` interface, it was merged with `CreateQueryStream`.
+- removed `CreateQuery` from `IKSqlDBContext` interface, it was merged with `CreateQueryStream`.  Subsequently `CreateQueryStream` was renamed to `CreatePushQuery` to align with the nomenclature of `CreatePullQuery`.
 - removed `SetupQuery` from `KSqlDbContextOptionsBuilder`, it was merged with `SetupQueryStream`. Subsequently `SetupQueryStream` was renamed to `SetupPushQuery` to align with the nomenclature of `SetupPullQuery`.
 - introduced distinct parameters designed specifically for pull queries. Before this update, the parameters sent to both the 'query' and 'query-stream' endpoints were shared between pull and push queries.
 

--- a/docs/breaking_changes.md
+++ b/docs/breaking_changes.md
@@ -3,7 +3,7 @@
 # v6.0.0
 - `QueryType` enum was renamed to `EndpointType`
 - removed `CreateQuery` from `IKSqlDBContext` interface, it was merged with `CreateQueryStream`.
-- removed `SetupQuery` from `KSqlDbContextOptionsBuilder`, it was merged with `SetupQueryStream`.
+- removed `SetupQuery` from `KSqlDbContextOptionsBuilder`, it was merged with `SetupQueryStream`. Subsequently `SetupQueryStream` was renamed to `SetupPushQuery` to align with the nomenclature of `SetupPullQuery`.
 - introduced distinct parameters designed specifically for pull queries. Before this update, the parameters sent to both the 'query' and 'query-stream' endpoints were shared between pull and push queries.
 
 # v5.0.0

--- a/docs/cdc.md
+++ b/docs/cdc.md
@@ -55,7 +55,7 @@ class Program
 
     var semaphoreSlim = new SemaphoreSlim(0, 1);
 
-    var cdcSubscription = context.CreateQueryStream<IoTSensorChange>("sqlserversensors")
+    var cdcSubscription = context.CreatePushQuery<IoTSensorChange>("sqlserversensors")
       .WithOffsetResetPolicy(AutoOffsetReset.Latest)
       .Where(c => c.Op != "r" && (c.After == null || c.After.SensorId != "d542a2b3-c"))
       .Take(5)

--- a/docs/data_types.md
+++ b/docs/data_types.md
@@ -119,7 +119,7 @@ MAP('c' := 2, 'd' := 4)['d']
 ```
 Deeply nested types:
 ```C#
-context.CreateQueryStream<Tweet>()
+context.CreatePushQuery<Tweet>()
   .Select(c => new
   {
     Map = new Dictionary<string, int[]>
@@ -186,7 +186,7 @@ INSERT INTO MyClasses (Dt, Ts, DtOffset) VALUES ('2021-04-01', '01:02:03', '2021
 ```
 
 ```C#
-using var subscription = context.CreateQueryStream<MyClass>()
+using var subscription = context.CreatePushQuery<MyClass>()
   .Subscribe(onNext: m =>
   {
     Console.WriteLine($"Time types: {m.Dt} : {m.Ts} : {m.DtOffset}");

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -147,7 +147,7 @@ DATETOSTRING(18672, 'yyyy-MM-dd')
 
 #### TIMESTAMPTOSTRING
 ```C#
-new KSqlDBContext(ksqlDbUrl).CreateQueryStream<Movie>()
+new KSqlDBContext(ksqlDbUrl).CreatePushQuery<Movie>()
   .Select(c => K.Functions.TimestampToString(c.RowTime, "yyyy-MM-dd''T''HH:mm:ssX"))
 ```
 
@@ -165,7 +165,7 @@ FROM tweets EMIT CHANGES;
 bool sorted = true;
       
 var subscription = new KSqlDBContext(@"http://localhost:8088")
-  .CreateQueryStream<Movie>()
+  .CreatePushQuery<Movie>()
   .Select(c => new
   {
     Entries = KSqlFunctions.Instance.Entries(new Dictionary<string, string>()
@@ -194,7 +194,7 @@ FROM movies_test EMIT CHANGES;
 Converts any type to its string representation.
 
 ```C#
-var query = context.CreateQueryStream<Movie>()
+var query = context.CreatePushQuery<Movie>()
   .GroupBy(c => c.Title)
   .Select(c => new { Title = c.Key, Concatenated = K.Functions.Concat(c.Count().ToString(), "_Hello") });
 ```
@@ -276,7 +276,7 @@ Subscribe to the unbounded stream of events:
 ```C#
 public IDisposable Invoke(IKSqlDBContext ksqlDbContext)
 {
-  var subscription = ksqlDbContext.CreateQueryStream<Lambda>(fromItemName: "stream2")
+  var subscription = ksqlDbContext.CreatePushQuery<Lambda>(fromItemName: "stream2")
     .WithOffsetResetPolicy(AutoOffsetReset.Earliest)
     .Select(c => new
     {
@@ -424,7 +424,7 @@ REDUCE(DictionaryInValues, 2, (s, k, v) => CEIL(s / v))
 **v1.5.0**
 
 ```C#
-var ksql = ksqlDbContext.CreateQueryStream<Lambda>()
+var ksql = ksqlDbContext.CreatePushQuery<Lambda>()
   .Select(c => new
   {
     Transformed = c.Lambda_Arr.Transform(x => x + 1),
@@ -453,7 +453,7 @@ By constructing the appropriate function call and providing the necessary parame
 ```C#
 using ksqlDB.RestApi.Client.KSql.Query.Functions;
 
-context.CreateQueryStream<Tweet>()
+context.CreatePushQuery<Tweet>()
   .Select(c => new { Col = KSql.Functions.Dynamic("IFNULL(Message, 'n/a')") as string, c.Id, c.Amount, c.Message });
 ```
 The interesting part from the above query is:
@@ -477,7 +477,7 @@ You can achieve a dynamic function call in C# that returns an array by using the
 ```C#
 using K = ksqlDB.RestApi.Client.KSql.Query.Functions.KSql;
 
-context.CreateQueryStream<Tweet>()
+context.CreatePushQuery<Tweet>()
   .Select(c => K.F.Dynamic("ARRAY_DISTINCT(ARRAY[1, 1, 2, 3, 1, 2])") as int[])
   .Subscribe(
     message => Console.WriteLine($"{message[0]} - {message[^1]}"), 

--- a/docs/joins.md
+++ b/docs/joins.md
@@ -16,7 +16,7 @@ var ksqlDbUrl = @"http://localhost:8088";
 
 var context = new KSqlDBContext(ksqlDbUrl);
 
-var query = (from o in context.CreateQueryStream<Order>()
+var query = (from o in context.CreatePushQuery<Order>()
     join p1 in Source.Of<Payment>() on o.PaymentId equals p1.Id
     join s1 in Source.Of<Shipment>() on o.ShipmentId equals s1.Id into gj
     from sa in gj.DefaultIfEmpty()
@@ -112,7 +112,7 @@ response = await restApiClient.InsertIntoAsync(shipment);
 Left joins can be also constructed in the following (less readable) way:
 
 ```C#
-var query2 = KSqlDBContext.CreateQueryStream<Order>()
+var query2 = KSqlDBContext.CreatePushQuery<Order>()
   .GroupJoin(Source.Of<Payment>(), c => c.OrderId, c => c.Id, (order, gj) => new
                                                                              {
                                                                                order,
@@ -141,7 +141,7 @@ SELECT o.OrderId OrderId, p.Id AS shipmentId
 - specifies a time window for stream-stream joins
 
 ```C#
-var query = from o in KSqlDBContext.CreateQueryStream<Order>()
+var query = from o in KSqlDBContext.CreatePushQuery<Order>()
   join p in Source.Of<Payment>().Within(Duration.OfHours(1), Duration.OfDays(5)) on o.OrderId equals p.Id
   select new
          {
@@ -166,7 +166,7 @@ Define nullable primitive value types in POCOs:
 
 ```C#
 var source = new KSqlDBContext(@"http://localhost:8088")
-  .CreateQueryStream<Movie>()
+  .CreatePushQuery<Movie>()
   .FullOuterJoin(
     Source.Of<Lead_Actor>("Actors"),
     movie => movie.Title,
@@ -211,7 +211,7 @@ SELECT m.Id Id, m.Title Title, m.Release_Year Release_Year, l.Title ActorTitle
 
 **LEFT OUTER** joins will contain leftRecord-NULL records in the result stream, which means that the join contains NULL values for fields selected from the right-hand stream where no match is made.
 ```C#
-var query = new KSqlDBContext(@"http://localhost:8088").CreateQueryStream<Movie>()
+var query = new KSqlDBContext(@"http://localhost:8088").CreatePushQuery<Movie>()
   .LeftJoin(
     Source.Of<Lead_Actor>(),
     movie => movie.Title,
@@ -242,7 +242,7 @@ Select all records for the right side of the join and the matching records from 
 ```C#
 using ksqlDB.RestApi.Client.KSql.Linq;
 
-var query = KSqlDBContext.CreateQueryStream<Lead_Actor>(ActorsTableName)
+var query = KSqlDBContext.CreatePushQuery<Lead_Actor>(ActorsTableName)
   .RightJoin(
     Source.Of<Movie>(MoviesTableName),
     actor => actor.Title,
@@ -275,7 +275,7 @@ How to [join table and table](https://kafka-tutorials.confluent.io/join-a-table-
 ```C#
 using ksqlDB.RestApi.Client.KSql.Linq;
 
-var query = context.CreateQueryStream<Movie>()
+var query = context.CreatePushQuery<Movie>()
   .Join(
     Source.Of<Lead_Actor>(nameof(Lead_Actor)),
     movie => movie.Title,

--- a/docs/ksqldbcontext.md
+++ b/docs/ksqldbcontext.md
@@ -391,6 +391,21 @@ public static KSqlDBContextOptions CreateQueryStreamOptions(string ksqlDbUrl)
 }
 ```
 
+> ⚠ In version 6.0.0 `SetupQuery` was unified with `SetupQueryStream`.
+
+### SetupPullQuery
+**v6.0.0**
+
+- configures the parameters for setting up a pull query
+
+```C#
+contextOptions
+  .SetupPullQuery(options =>
+  {
+    options[KSqlDbConfigs.KsqlQueryPullTableScanEnabled] = "true";
+  })
+```
+
 ### Setting processing guarantee with KSqlDbContextOptionsBuilder
 **v1.0.0**
 

--- a/docs/ksqldbcontext.md
+++ b/docs/ksqldbcontext.md
@@ -34,7 +34,7 @@ var contextOptions = new KSqlDBContextOptions(ksqlDbUrl);
 
 await using var context = new KSqlDBContext(contextOptions);
 
-using var disposable = context.CreateQueryStream<Movie>()
+using var disposable = context.CreatePushQuery<Movie>()
   .Subscribe(onNext: movie =>
   {
     Console.WriteLine($"{nameof(Movie)}: {movie.Id} - {movie.Title} - {movie.RowTime}");
@@ -80,10 +80,10 @@ using var disposable = context.CreateQuery<Movie>()
   }, onError: error => { Console.WriteLine($"Exception: {error.Message}"); }, onCompleted: () => Console.WriteLine("Completed"));
 ```
 
-⚠️ In version 6.0.0, CreateQuery has been merged into CreateQueryStream.
+⚠️ In version 6.0.0, CreateQuery has been merged into CreatePushQuery.
 
 # TFM netstandard 2.0 (.Net Framework, NetCoreApp 2.0 etc.)
-The lack of support for **HTTP 2.0** in netstandard 2.0 prevents the exposure of `IKSqlDBContext.CreateQueryStream<TEntity>` in the current version. To address this limitation, `IKSqlDBContext.CreateQuery<TEntity>` was introduced as an alternative solution utilizing **HTTP 1.1** to provide the same functionality.
+The lack of support for **HTTP 2.0** in netstandard 2.0 prevents the exposure of `IKSqlDBContext.CreatePushQuery<TEntity>` in the current version. To address this limitation, `IKSqlDBContext.CreateQuery<TEntity>` was introduced as an alternative solution utilizing **HTTP 1.1** to provide the same functionality.
 
 ## Basic auth
 **v1.0.0**
@@ -144,7 +144,7 @@ internal class ApplicationKSqlDbContext : KSqlDBContext, Program.IApplicationKSq
   {
   }
 
-  public ksqlDB.RestApi.Client.KSql.Linq.IQbservable<Movie> Movies => CreateQueryStream<Movie>();
+  public ksqlDB.RestApi.Client.KSql.Linq.IQbservable<Movie> Movies => CreatePushQuery<Movie>();
 }
 
 public interface IApplicationKSqlDbContext : IKSqlDBContext
@@ -290,7 +290,7 @@ public class Worker : IHostedService, IDisposable
   {
     logger.LogInformation("Starting");
 
-    subscription = await context.CreateQueryStream<Movie>()
+    subscription = await context.CreatePushQuery<Movie>()
       .WithOffsetResetPolicy(AutoOffsetReset.Earliest)
       .SubscribeAsync(
         onNext: movie => { },
@@ -374,7 +374,7 @@ var responseMessage = await context.SaveChangesAsync();
 > ⚠When creating `KSqlDBContextOptions` using a constructor or through `KSqlDbContextOptionsBuilder`, the default behavior is to set the `auto.offset.reset` property to "earliest."
 
 ```C#
-public static KSqlDBContextOptions CreateQueryStreamOptions(string ksqlDbUrl)
+public static KSqlDBContextOptions CreatePushQueryOptions(string ksqlDbUrl)
 {
   var contextOptions = new KSqlDbContextOptionsBuilder()
     .UseKSqlDb(ksqlDbUrl)
@@ -482,7 +482,7 @@ INSERT INTO Message (Message, Id, `Values`) VALUES ('Hello', 42, '123, abc');
 Stream the result of the SELECT query into an existing stream and its underlying topic.
 
 ```C#
-var response = await context.CreateQueryStream<Movie>("from_stream")
+var response = await context.CreatePushQuery<Movie>("from_stream")
   .Where(c => c.Title != "Apocalypse now")
   .InsertIntoAsync("stream_name");
 
@@ -503,7 +503,7 @@ Alternatively an optional query ID can be used for INSERT INTO queries:
 ```C#
 string queryId = "insert_query_123";
 
-var response = await context.CreateQueryStream<Movie>("from_stream")
+var response = await context.CreatePushQuery<Movie>("from_stream")
   .Where(c => c.Title != "Apocalypse now")
   .InsertIntoAsync("stream_name", queryId);
 ```

--- a/docs/ksqldbcontext.md
+++ b/docs/ksqldbcontext.md
@@ -378,12 +378,9 @@ public static KSqlDBContextOptions CreateQueryStreamOptions(string ksqlDbUrl)
 {
   var contextOptions = new KSqlDbContextOptionsBuilder()
     .UseKSqlDb(ksqlDbUrl)
-    .SetupQueryStream(options =>
+    .SetupPushQuery(options =>
     {
-    })
-    .SetupQuery(options =>
-    {
-      options.Properties[QueryParameters.AutoOffsetResetPropertyName] = AutoOffsetReset.Latest.ToString().ToLower();
+      options.AutoOffsetReset = AutoOffsetReset.Latest;
     })
     .Options;
 
@@ -391,7 +388,7 @@ public static KSqlDBContextOptions CreateQueryStreamOptions(string ksqlDbUrl)
 }
 ```
 
-> ⚠ In version 6.0.0 `SetupQuery` was unified with `SetupQueryStream`.
+> ⚠ In version 6.0.0 `SetupQuery` was unified with `SetupQueryStream`. Subsequently `SetupQueryStream` was renamed to `SetupPushQuery` to align with the nomenclature of `SetupPullQuery`.
 
 ### SetupPullQuery
 **v6.0.0**

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -24,7 +24,7 @@ The **LIKE** operator is used in combination with the % (percent sign) wildcard 
 Match a string with a specified pattern:
 
 ```C#
-var query = context.CreateQueryStream<Movie>()
+var query = context.CreatePushQuery<Movie>()
   .Where(c => c.Title.ToLower().Contains("hard".ToLower());
 ```
 
@@ -36,7 +36,7 @@ SELECT *
 ```
 
 ```C#
-var query = context.CreateQueryStream<Movie>()
+var query = context.CreatePushQuery<Movie>()
   .Where(c => c.Title.StartsWith("Die");
 ```
 
@@ -54,7 +54,7 @@ The **IS NULL** and **IS NOT NULL** operators are used in the **WHERE** clause t
 
 ```C#
 using var subscription = new KSqlDBContext(@"http://localhost:8088")
-  .CreateQueryStream<Click>()
+  .CreatePushQuery<Click>()
   .Where(c => c.IP_ADDRESS != null || c.URL == null)
   .Select(c => new { c.IP_ADDRESS, c.URL, c.TIMESTAMP });
 ```
@@ -105,7 +105,7 @@ The **BETWEEN** operator provides a concise way to specify range conditions in K
 ```C#
 using ksqlDB.RestApi.Client.KSql.Query.Operators;
 
-IQbservable<Tweet> query = context.CreateQueryStream<Tweet>()
+IQbservable<Tweet> query = context.CreatePushQuery<Tweet>()
   .Where(c => c.Id.Between(1, 5));
 ```
 
@@ -137,7 +137,7 @@ Ts BETWEEN '11:00:00' AND '15:00:00'
 var from = new TimeSpan(11, 0, 0);
 var to = new TimeSpan(15, 0, 0);
 
-var query = context.CreateQueryStream<MyClass>()
+var query = context.CreatePushQuery<MyClass>()
   .Where(c => c.Ts.Between(from, to))
   .Select(c => new { c.Ts, to, FromTime = from, DateTime.Now, New = new TimeSpan(1, 0, 0) }
   .ToQueryString();
@@ -149,7 +149,7 @@ var query = context.CreateQueryStream<MyClass>()
 - Select a condition from one or more expressions.
 ```C#
 var query = new KSqlDBContext(@"http://localhost:8088")
-  .CreateQueryStream<Tweet>()
+  .CreatePushQuery<Tweet>()
   .Select(c =>
     new
     {
@@ -187,7 +187,7 @@ You can use parentheses to change the order of evaluation:
 ```C#
 await using var context = new KSqlDBContext(@"http://localhost:8088");
 
-var query = context.CreateQueryStream<Location>()
+var query = context.CreatePushQuery<Location>()
   .Select(c => (c.Longitude + c.Longitude) * c.Longitude);
 ```
 
@@ -201,7 +201,7 @@ In Where clauses:
 ```C#
 await using var context = new KSqlDBContext(@"http://localhost:8088");
 
-var query = context.CreateQueryStream<Location>()
+var query = context.CreatePushQuery<Location>()
   .Where(c => (c.Latitude == "1" || c.Latitude != "2") && c.Latitude == "3");
 ```
 

--- a/docs/protobuf.md
+++ b/docs/protobuf.md
@@ -51,7 +51,7 @@ var ksqlDbUrl = @"http://localhost:8088";
 
 await using var context = new ProtoBufKSqlDbContext(ksqlDbUrl);
 
-var query = context.CreateQueryStream<MovieProto>("movie")
+var query = context.CreatePushQuery<MovieProto>("movie")
   .Where(p => p.Title != "E.T.")
   .Select(l => new { Id = l.Id, l.Title })
   .Take(2); // LIMIT 2    

--- a/docs/statements.md
+++ b/docs/statements.md
@@ -607,7 +607,7 @@ Drop table {nameof(Event)};
       
   await using var ksqlDbContext = new KSqlDBContext(new KSqlDBContextOptions(ksqlDbUrl));
 
-  var subscription = ksqlDbContext.CreateQueryStream<Event>()
+  var subscription = ksqlDbContext.CreatePushQuery<Event>()
     .Take(1)
     .Subscribe(value =>
     {

--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -1,9 +1,9 @@
 # ksqlDB.RestApi.Client
 
-# 6.0.0-rc.2
+# 6.0.0
 - added `SetEndpointType` to `KSqlDbContextOptionsBuilder` for configuring to use either "/query" or "/query-stream" endpoint
-- `CreateQuery` and `CreateQueryStream` were merged. `CreatePullQuery` by default uses **http/2** now. 
-- removed `SetupQuery` from `KSqlDbContextOptionsBuilder`, it was unified with `SetupQueryStream`.
+- `CreateQuery` and `CreateQueryStream` were merged. `CreatePullQuery` by default uses **http/2** now.  Subsequently `CreateQueryStream` was renamed to `CreatePushQuery` to align with the nomenclature of `CreatePullQuery`.
+- removed `SetupQuery` from `KSqlDbContextOptionsBuilder`, it was unified with `SetupQueryStream`. Subsequently `SetupQueryStream` was renamed to `SetupPushQuery` to align with the nomenclature of `SetupPullQuery`.
 - introduced distinct parameters specifically tailored for pull queries. This modification results in a breaking change. Before this update, the parameters sent to both the 'query' and 'query-stream' endpoints were shared between pull and push queries. #77
 - see also [breakingchanges.md](https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/docs/breaking_changes.md#v600)
 

--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -2,7 +2,7 @@
 
 # 6.0.0-rc.2
 - added `SetEndpointType` to `KSqlDbContextOptionsBuilder` for configuring to use either "/query" or "/query-stream" endpoint
-- `CreateQuery` and `CreateQueryStream` were merged. `CreatePullQuery` by default uses http/2 now. 
+- `CreateQuery` and `CreateQueryStream` were merged. `CreatePullQuery` by default uses **http/2** now. 
 - removed `SetupQuery` from `KSqlDbContextOptionsBuilder`, it was unified with `SetupQueryStream`.
 - introduced distinct parameters specifically tailored for pull queries. This modification results in a breaking change. Before this update, the parameters sent to both the 'query' and 'query-stream' endpoints were shared between pull and push queries. #77
 - see also [breakingchanges.md](https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/docs/breaking_changes.md#v600)

--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -1,9 +1,14 @@
 # ksqlDB.RestApi.Client
 
-# 6.0.0-rc.1
+# 6.0.0-rc.2
 - added `SetEndpointType` to `KSqlDbContextOptionsBuilder` for configuring to use either "/query" or "/query-stream" endpoint
 - `CreateQuery` and `CreateQueryStream` were merged. `CreatePullQuery` by default uses http/2 now. 
+- removed `SetupQuery` from `KSqlDbContextOptionsBuilder`, it was unified with `SetupQueryStream`.
+- introduced distinct parameters specifically tailored for pull queries. This modification results in a breaking change. Before this update, the parameters sent to both the 'query' and 'query-stream' endpoints were shared between pull and push queries. #77
 - see also [breakingchanges.md](https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/docs/breaking_changes.md#v600)
+
+# BugFix
+- CreateQueryStream doesn't always use configured parameters. The PullQuery functionality was overriding the options configured for the PushQuery. #75 reported by @jbkuczma 
 
 # 5.1.0
 - added `InsertIntoAsync` Qbservable extension for executing `INSERT INTO <stream-name> SELECT` statements.
@@ -18,7 +23,7 @@
 - see also [breakingchanges.md](https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/docs/breaking_changes.md#v500)
 
 # 4.0.2
-- fixes Identified an issue where multiple push queries sharing the same QueryStreamParameters SQL were encountered within the same asynchronous context #72
+- fixes Identified an issue where multiple push queries sharing the same `QueryStreamParameters` SQL were encountered within the same asynchronous context #72
 
 # 4.0.1
 - fixes LINQ Where ignores `JsonPropertyNameAttribute` when using new for column selection, causing failing ksqldb request. #68

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/IKSqlDBContext.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/IKSqlDBContext.cs
@@ -9,21 +9,21 @@ namespace ksqlDB.RestApi.Client.KSql.Query.Context;
 public interface IKSqlDBContext : IKSqlDBStatementsContext, IAsyncDisposable, IDisposable
 {
   /// <summary>
-  /// Creates a push query for the query-stream endpoint.
+  /// Creates a push query.
   /// </summary>
   /// <typeparam name="TEntity">The type of the data in the data source.</typeparam>
   /// <param name="fromItemName">Overrides the name of the stream or table which by default is derived from TEntity</param>
   /// <returns>A Qbservable for query composition and execution.</returns>
-  IQbservable<TEntity> CreateQueryStream<TEntity>(string? fromItemName = null);
+  IQbservable<TEntity> CreatePushQuery<TEntity>(string? fromItemName = null);
 
   /// <summary>
-  /// Creates a query stream for retrieving entities asynchronously.
+  /// Creates a push query for retrieving entities asynchronously.
   /// </summary>
   /// <typeparam name="TEntity">The type of the entities to retrieve.</typeparam>
-  /// <param name="queryStreamParameters">The parameters for the query stream.</param>
+  /// <param name="queryParameters">The parameters for the push query.</param>
   /// <param name="cancellationToken">A cancellation token to cancel the asynchronous operation (optional).</param>
-  /// <returns>An asynchronous enumerable of entities representing the query stream.</returns>
-  IAsyncEnumerable<TEntity> CreateQueryStream<TEntity>(IKSqlDbParameters queryStreamParameters, CancellationToken cancellationToken = default);
+  /// <returns>An asynchronous enumerable of entities representing the push query.</returns>
+  IAsyncEnumerable<TEntity> CreatePushQuery<TEntity>(IKSqlDbParameters queryParameters, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Creates a pull query.

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContext.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContext.cs
@@ -76,18 +76,18 @@ public class KSqlDBContext : KSqlDBContextDependenciesProvider, IKSqlDBContext
   }
 
   /// <summary>
-  /// Creates a query stream for retrieving entities asynchronously.
+  /// Creates a push stream for retrieving entities asynchronously.
   /// </summary>
   /// <typeparam name="TEntity">The type of the entities to retrieve.</typeparam>
-  /// <param name="queryStreamParameters">The parameters for the query stream.</param>
+  /// <param name="queryParameters">The parameters for the push query.</param>
   /// <param name="cancellationToken">A cancellation token to cancel the asynchronous operation (optional).</param>
-  /// <returns>An asynchronous enumerable of entities representing the query stream.</returns>
-  public IAsyncEnumerable<TEntity> CreateQueryStream<TEntity>(IKSqlDbParameters queryStreamParameters, CancellationToken cancellationToken = default)
+  /// <returns>An asynchronous enumerable of entities representing the push query.</returns>
+  public IAsyncEnumerable<TEntity> CreatePushQuery<TEntity>(IKSqlDbParameters queryParameters, CancellationToken cancellationToken = default)
   {
-    if (ContextOptions.EndpointType == EndpointType.Query && queryStreamParameters is not QueryParameters)
+    if (ContextOptions.EndpointType == EndpointType.Query && queryParameters is not QueryParameters)
       throw new InvalidOperationException($"Invalid {nameof(IKSqlDbParameters)} for endpoint {EndpointType.Query}");
 #if !NETSTANDARD
-    if (ContextOptions.EndpointType == EndpointType.QueryStream && queryStreamParameters is not QueryStreamParameters)
+    if (ContextOptions.EndpointType == EndpointType.QueryStream && queryParameters is not QueryStreamParameters)
       throw new InvalidOperationException($"Invalid {nameof(IKSqlDbParameters)} for endpoint {EndpointType.QueryStream}");
 #endif
 
@@ -95,16 +95,16 @@ public class KSqlDBContext : KSqlDBContextDependenciesProvider, IKSqlDBContext
 
     var ksqlDbProvider = serviceScopeFactory.CreateScope().ServiceProvider.GetRequiredService<IKSqlDbProvider>();
 
-    return ksqlDbProvider.Run<TEntity>(queryStreamParameters, cancellationToken);
+    return ksqlDbProvider.Run<TEntity>(queryParameters, cancellationToken);
   }
 
   /// <summary>
-  /// Creates a push query for the query-stream endpoint.
+  /// Creates a push query.
   /// </summary>
   /// <typeparam name="TEntity">The type of the data in the data source.</typeparam>
   /// <param name="fromItemName">Overrides the name of the stream or table which by default is derived from TEntity</param>
   /// <returns>A Qbservable for query composition and execution.</returns>
-  public IQbservable<TEntity> CreateQueryStream<TEntity>(string? fromItemName = null)
+  public IQbservable<TEntity> CreatePushQuery<TEntity>(string? fromItemName = null)
   {
     var serviceScopeFactory = ServiceScopeFactory();
 

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContext.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContext.cs
@@ -77,11 +77,14 @@ public class KSqlDBContext : KSqlDBContextDependenciesProvider, IKSqlDBContext
     {
       case EndpointType.Query:
         serviceCollection.TryAddScoped<IKSqlDbProvider, KSqlDbQueryProvider>();
-        serviceCollection.TryAddSingleton<IKSqlDbParameters>(contextOptions.QueryParameters);
 
-        var queryParameters = new PullQueryParameters();
-        queryParameters.FillFrom(contextOptions.PullQueryParameters);
-        serviceCollection.TryAddSingleton<IPullQueryParameters>(queryParameters);
+        var queryParameters = new QueryParameters();
+        queryParameters.FillPushQueryParametersFrom(contextOptions.QueryStreamParameters);
+        serviceCollection.TryAddSingleton<IKSqlDbParameters>(queryParameters);
+
+        var pullQueryParameters = new PullQueryParameters();
+        pullQueryParameters.FillFrom(contextOptions.PullQueryParameters);
+        serviceCollection.TryAddSingleton<IPullQueryParameters>(pullQueryParameters);
         break;
 #if !NETSTANDARD
       case EndpointType.QueryStream:

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContextOptions.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContextOptions.cs
@@ -35,6 +35,8 @@ public sealed class KSqlDBContextOptions : KSqlDbProviderOptions
       [QueryStreamParameters.AutoOffsetResetPropertyName] = AutoOffsetReset.Earliest.ToString().ToLower(),
     };
 
+    PullQueryParameters = new PullQueryParameters();
+
 #if !NETSTANDARD
     EndpointType = EndpointType.QueryStream;
 #endif
@@ -58,9 +60,14 @@ public sealed class KSqlDBContextOptions : KSqlDbProviderOptions
   public QueryStreamParameters QueryStreamParameters { get; internal set; }
 
   /// <summary>
+  /// Gets or sets the pull query parameters.
+  /// </summary>
+  public IPullQueryParameters PullQueryParameters { get; internal set; }
+
+  /// <summary>
   /// Gets or sets the IKSqlDb query parameters.
   /// </summary>
-  public IKSqlDbParameters QueryParameters { get; internal set; }
+  public IPushQueryParameters QueryParameters { get; internal set; }
 
   public static NumberFormatInfo? NumberFormatInfo { get; set; }
 
@@ -97,18 +104,6 @@ public sealed class KSqlDBContextOptions : KSqlDbProviderOptions
   public void SetJsonSerializerOptions(Action<JsonSerializerOptions> optionsAction)
   {
     optionsAction.Invoke(JsonSerializerOptions);
-  }
-
-  internal KSqlDBContextOptions Clone()
-  {
-    var options = new KSqlDBContextOptions(Url)
-    {
-      ShouldPluralizeFromItemName = ShouldPluralizeFromItemName,
-      QueryParameters = ((QueryParameters) QueryParameters).Clone(),
-      QueryStreamParameters = (QueryStreamParameters)QueryStreamParameters.Clone()
-    };
-
-    return options;
   }
 
   public bool UseBasicAuth => userName != null || password != null;

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContextOptions.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContextOptions.cs
@@ -25,11 +25,6 @@ public sealed class KSqlDBContextOptions : KSqlDbProviderOptions
 
     Url = url;
 
-    QueryParameters = new QueryParameters
-    {
-      [RestApi.Parameters.QueryParameters.AutoOffsetResetPropertyName] = AutoOffsetReset.Earliest.ToString().ToLower()
-    };
-
     QueryStreamParameters = new QueryStreamParameters
     {
       [QueryStreamParameters.AutoOffsetResetPropertyName] = AutoOffsetReset.Earliest.ToString().ToLower(),
@@ -64,11 +59,6 @@ public sealed class KSqlDBContextOptions : KSqlDbProviderOptions
   /// </summary>
   public IPullQueryParameters PullQueryParameters { get; internal set; }
 
-  /// <summary>
-  /// Gets or sets the IKSqlDb query parameters.
-  /// </summary>
-  public IPushQueryParameters QueryParameters { get; internal set; }
-
   public static NumberFormatInfo? NumberFormatInfo { get; set; }
 
   /// <summary>
@@ -80,7 +70,6 @@ public sealed class KSqlDBContextOptions : KSqlDbProviderOptions
     string guarantee = processingGuarantee.ToKSqlValue();
 
     QueryStreamParameters[KSqlDbConfigs.ProcessingGuarantee] = guarantee; 
-    QueryParameters[KSqlDbConfigs.ProcessingGuarantee] = guarantee;
   }
 
   /// <summary>
@@ -89,9 +78,6 @@ public sealed class KSqlDBContextOptions : KSqlDbProviderOptions
   /// <param name="autoOffsetReset">The type of auto offset reset.</param>
   public void SetAutoOffsetReset(AutoOffsetReset autoOffsetReset)
   {
-    QueryParameters[RestApi.Parameters.QueryParameters.AutoOffsetResetPropertyName] =
-      autoOffsetReset.ToKSqlValue();
-
     QueryStreamParameters[QueryStreamParameters.AutoOffsetResetPropertyName] =
       autoOffsetReset.ToKSqlValue();
   }

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/Options/ISetupParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/Options/ISetupParameters.cs
@@ -22,12 +22,12 @@ public interface ISetupParameters : ICreateOptions
   ISetupParameters SetAutoOffsetReset(AutoOffsetReset autoOffsetReset);
 
   /// <summary>
-  /// Configures the parameters for setting up a push query for the 'query-stream' endpoint.
+  /// Configures the parameters for setting up a push query.
   /// Allows you to configure ksqlDB query parameters such as processing guarantee or 'auto.offset.reset'.
   /// </summary>
   /// <param name="configure">An action to configure the parameters using <see cref="IPushQueryParameters"/>.</param>
   /// <returns>Returns this instance.</returns>
-  ISetupParameters SetupQueryStream(Action<IPushQueryParameters> configure);
+  ISetupParameters SetupPushQuery(Action<IPushQueryParameters> configure);
 
   /// <summary>
   /// Configures the parameters for setting up a pull query.

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/Options/ISetupParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/Options/ISetupParameters.cs
@@ -22,22 +22,12 @@ public interface ISetupParameters : ICreateOptions
   ISetupParameters SetAutoOffsetReset(AutoOffsetReset autoOffsetReset);
 
   /// <summary>
-  /// Configures the parameters for setting up a push query for the 'query' endpoint.
-  /// Allows you to configure ksqlDB query parameters such as processing guarantee or 'auto.offset.reset'.
-  /// </summary>
-  /// <param name="configure">An action to configure the parameters using <see cref="IPushQueryParameters"/>.</param>
-  /// <returns>Returns this instance.</returns>
-  ISetupParameters SetupQuery(Action<IPushQueryParameters> configure);
-
-#if !NETSTANDARD
-  /// <summary>
   /// Configures the parameters for setting up a push query for the 'query-stream' endpoint.
   /// Allows you to configure ksqlDB query parameters such as processing guarantee or 'auto.offset.reset'.
   /// </summary>
   /// <param name="configure">An action to configure the parameters using <see cref="IPushQueryParameters"/>.</param>
   /// <returns>Returns this instance.</returns>
   ISetupParameters SetupQueryStream(Action<IPushQueryParameters> configure);
-#endif
 
   /// <summary>
   /// Configures the parameters for setting up a pull query.

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/Options/ISetupParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/Options/ISetupParameters.cs
@@ -13,12 +13,45 @@ public interface ISetupParameters : ICreateOptions
   /// <param name="processingGuarantee">Type of processing guarantee.</param>
   /// <returns>Returns this instance.</returns>
   ISetupParameters SetProcessingGuarantee(ProcessingGuarantee processingGuarantee);
+
+  /// <summary>
+  /// Allows you to configure the auto.offset.reset streams property. 
+  /// </summary>
+  /// <param name="autoOffsetReset">The auto offset reset value to set.</param>
+  /// <returns>Returns this instance.</returns>
   ISetupParameters SetAutoOffsetReset(AutoOffsetReset autoOffsetReset);
 
-  ISetupParameters SetupQuery(Action<IKSqlDbParameters> configure);
+  /// <summary>
+  /// Configures the parameters for setting up a push query for the 'query' endpoint.
+  /// Allows you to configure ksqlDB query parameters such as processing guarantee or 'auto.offset.reset'.
+  /// </summary>
+  /// <param name="configure">An action to configure the parameters using <see cref="IPushQueryParameters"/>.</param>
+  /// <returns>Returns this instance.</returns>
+  ISetupParameters SetupQuery(Action<IPushQueryParameters> configure);
+
 #if !NETSTANDARD
-    ISetupParameters SetupQueryStream(Action<IKSqlDbParameters> configure);
+  /// <summary>
+  /// Configures the parameters for setting up a push query for the 'query-stream' endpoint.
+  /// Allows you to configure ksqlDB query parameters such as processing guarantee or 'auto.offset.reset'.
+  /// </summary>
+  /// <param name="configure">An action to configure the parameters using <see cref="IPushQueryParameters"/>.</param>
+  /// <returns>Returns this instance.</returns>
+  ISetupParameters SetupQueryStream(Action<IPushQueryParameters> configure);
 #endif
+
+  /// <summary>
+  /// Configures the parameters for setting up a pull query.
+  /// </summary>
+  /// <param name="configure">An action to configure the parameters using <see cref="IPullQueryParameters"/>.</param>
+  /// <returns>Returns this instance.</returns>
+  ISetupParameters SetupPullQuery(Action<IPullQueryParameters> configure);
+
+  /// <summary>
+  /// Allows you to set basic authentication credentials for an HTTP client. 
+  /// </summary>
+  /// <param name="username">User name</param>
+  /// <param name="password">Password</param>
+  /// <returns>Returns this instance.</returns>
   ISetupParameters SetBasicAuthCredentials(string username, string password);
 
   /// <summary>

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/Options/KSqlDbContextOptionsBuilder.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/Options/KSqlDbContextOptionsBuilder.cs
@@ -64,12 +64,12 @@ public class KSqlDbContextOptionsBuilder : ISetupParameters
   }
 
   /// <summary>
-  /// Configures the parameters for setting up a push query for the 'query-stream' endpoint.
+  /// Configures the parameters for setting up a push query.
   /// Allows you to configure ksqlDB query parameters such as processing guarantee or 'auto.offset.reset'.
   /// </summary>
   /// <param name="configure">An action to configure the parameters using <see cref="IPushQueryParameters"/>.</param>
   /// <returns>Returns this instance.</returns>
-  ISetupParameters ISetupParameters.SetupQueryStream(Action<IPushQueryParameters> configure)
+  ISetupParameters ISetupParameters.SetupPushQuery(Action<IPushQueryParameters> configure)
   {
     configure(InternalOptions.QueryStreamParameters);
 

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/Options/KSqlDbContextOptionsBuilder.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/Options/KSqlDbContextOptionsBuilder.cs
@@ -67,20 +67,6 @@ public class KSqlDbContextOptionsBuilder : ISetupParameters
   /// Configures the parameters for setting up a push query for the 'query-stream' endpoint.
   /// Allows you to configure ksqlDB query parameters such as processing guarantee or 'auto.offset.reset'.
   /// </summary>
-  /// <param name="configure">A delegate that intercepts the creation of an instance of <see cref="IPushQueryParameters"/>.</param>
-  /// <returns>Setup parameters</returns>
-  ISetupParameters ISetupParameters.SetupQuery(Action<IPushQueryParameters> configure)
-  {
-    configure(InternalOptions.QueryParameters);
-
-    return this;
-  }
-
-#if !NETSTANDARD
-  /// <summary>
-  /// Configures the parameters for setting up a push query for the 'query-stream' endpoint.
-  /// Allows you to configure ksqlDB query parameters such as processing guarantee or 'auto.offset.reset'.
-  /// </summary>
   /// <param name="configure">An action to configure the parameters using <see cref="IPushQueryParameters"/>.</param>
   /// <returns>Returns this instance.</returns>
   ISetupParameters ISetupParameters.SetupQueryStream(Action<IPushQueryParameters> configure)
@@ -89,7 +75,6 @@ public class KSqlDbContextOptionsBuilder : ISetupParameters
 
     return this;
   }
-#endif
 
   /// <summary>
   /// Configures the parameters for setting up a pull query.

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/Options/KSqlDbContextOptionsBuilder.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/Options/KSqlDbContextOptionsBuilder.cs
@@ -63,18 +63,48 @@ public class KSqlDbContextOptionsBuilder : ISetupParameters
     return this;
   }
 
+  /// <summary>
+  /// Configures the parameters for setting up a push query for the 'query-stream' endpoint.
+  /// Allows you to configure ksqlDB query parameters such as processing guarantee or 'auto.offset.reset'.
+  /// </summary>
+  /// <param name="configure">A delegate that intercepts the creation of an instance of <see cref="IPushQueryParameters"/>.</param>
+  /// <returns>Setup parameters</returns>
+  ISetupParameters ISetupParameters.SetupQuery(Action<IPushQueryParameters> configure)
+  {
+    configure(InternalOptions.QueryParameters);
+
+    return this;
+  }
+
 #if !NETSTANDARD
-  ISetupParameters ISetupParameters.SetupQueryStream(Action<IKSqlDbParameters> configure)
+  /// <summary>
+  /// Configures the parameters for setting up a push query for the 'query-stream' endpoint.
+  /// Allows you to configure ksqlDB query parameters such as processing guarantee or 'auto.offset.reset'.
+  /// </summary>
+  /// <param name="configure">An action to configure the parameters using <see cref="IPushQueryParameters"/>.</param>
+  /// <returns>Returns this instance.</returns>
+  ISetupParameters ISetupParameters.SetupQueryStream(Action<IPushQueryParameters> configure)
   {
     configure(InternalOptions.QueryStreamParameters);
 
     return this;
   }
-
 #endif
 
   /// <summary>
-  /// allows you to set basic authentication credentials for an HTTP client. 
+  /// Configures the parameters for setting up a pull query.
+  /// </summary>
+  /// <param name="configure">An action to configure the parameters using <see cref="IPullQueryParameters"/>.</param>
+  /// <returns>Returns this instance.</returns>
+  ISetupParameters ISetupParameters.SetupPullQuery(Action<IPullQueryParameters> configure)
+  {
+    configure(InternalOptions.PullQueryParameters);
+
+    return this;
+  }
+
+  /// <summary>
+  /// Allows you to set basic authentication credentials for an HTTP client. 
   /// </summary>
   /// <param name="username">User name</param>
   /// <param name="password">Password</param>
@@ -114,18 +144,6 @@ public class KSqlDbContextOptionsBuilder : ISetupParameters
   }
 
   /// <summary>
-  /// Allows you to configure ksqlDB query parameters such as processing guarantee or 'auto.offset.reset'.
-  /// </summary>
-  /// <param name="configure">A delegate that intercepts the creation of an instance of <typeparamref name="IKSqlDbParameters"/>.</param>
-  /// <returns>Setup parameters</returns>
-  ISetupParameters ISetupParameters.SetupQuery(Action<IKSqlDbParameters> configure)
-  {
-    configure(InternalOptions.QueryParameters);
-
-    return this;
-  }
-
-  /// <summary>
   /// Allows you to configure the 'processing.guarantee' streams property.
   /// </summary>
   /// <param name="processingGuarantee">Type of processing guarantee. exactly_once_v2 or at_least_once semantics</param>
@@ -140,8 +158,8 @@ public class KSqlDbContextOptionsBuilder : ISetupParameters
   /// <summary>
   /// Allows you to configure the auto.offset.reset streams property. 
   /// </summary>
-  /// <param name="autoOffsetReset"></param>
-  /// <returns></returns>
+  /// <param name="autoOffsetReset">The auto offset reset value to set.</param>
+  /// <returns>Returns this instance.</returns>
   ISetupParameters ISetupParameters.SetAutoOffsetReset(AutoOffsetReset autoOffsetReset)
   {
     InternalOptions.SetAutoOffsetReset(autoOffsetReset);

--- a/ksqlDb.RestApi.Client/KSql/Query/KPullSetDependencies.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/KPullSetDependencies.cs
@@ -8,6 +8,6 @@ namespace ksqlDB.RestApi.Client.KSql.Query
     IKSqlQbservableProvider provider,
     IKSqlDbProvider ksqlDbProvider,
     IKSqlQueryGenerator queryGenerator,
-    IKSqlDbParameters queryParameters)
+    IPullQueryParameters queryParameters)
     : KSetDependencies(provider, ksqlDbProvider, queryGenerator, queryParameters), IKPullSetDependencies;
 }

--- a/ksqlDb.RestApi.Client/KSql/Query/KStreamSet.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/KStreamSet.cs
@@ -133,7 +133,7 @@ internal abstract class KStreamSet<TEntity> : KStreamSet, Linq.IQbservable<TEnti
     if (!QueryContext.AutoOffsetReset.HasValue) return queryParameters;
       
     var overridenParameters = queryParameters.Clone();
-    overridenParameters.AutoOffsetReset = QueryContext.AutoOffsetReset.Value;
+    ((IPushQueryParameters)overridenParameters).AutoOffsetReset = QueryContext.AutoOffsetReset.Value;
 
     return overridenParameters;
   }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/KSqlDbRestApiClient.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/KSqlDbRestApiClient.cs
@@ -162,6 +162,7 @@ public class KSqlDbRestApiClient : IKSqlDbRestApiClient
     {
       EndpointType.KSql => "/ksql",
       EndpointType.Query => "/query",
+      EndpointType.QueryStream => "/query-stream",
       EndpointType.CloseQuery => "/close-query",
       _ => throw new ArgumentOutOfRangeException(nameof(endpointType), $"Unknown '{nameof(EndpointType)}' type {endpointType}.")
     };

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/IKSqlDbParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/IKSqlDbParameters.cs
@@ -1,6 +1,13 @@
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
 
+/// <summary>
+/// Represents parameters for a KSqlDb endpoint.
+/// </summary>
 public interface IKSqlDbParameters : IQueryParameters
 {
+  /// <summary>
+  /// Clones the current parameters.
+  /// </summary>
+  /// <returns>A new instance of the parameters with the same values.</returns>
   IKSqlDbParameters Clone();
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/IKSqlDbParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/IKSqlDbParameters.cs
@@ -1,10 +1,6 @@
-using ksqlDB.RestApi.Client.KSql.Query.Options;
-
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
 
 public interface IKSqlDbParameters : IQueryParameters
 {
-  AutoOffsetReset AutoOffsetReset { get; set; }
-
   IKSqlDbParameters Clone();
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/IPullQueryParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/IPullQueryParameters.cs
@@ -1,0 +1,6 @@
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters
+{
+  public interface IPullQueryParameters : IKSqlDbParameters
+  {
+  }
+}

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/IPullQueryParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/IPullQueryParameters.cs
@@ -1,6 +1,8 @@
-namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
+
+/// <summary>
+/// Represents parameters for a pull query.
+/// </summary>
+public interface IPullQueryParameters : IKSqlDbParameters
 {
-  public interface IPullQueryParameters : IKSqlDbParameters
-  {
-  }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/IPushQueryParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/IPushQueryParameters.cs
@@ -1,0 +1,9 @@
+using ksqlDB.RestApi.Client.KSql.Query.Options;
+
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters
+{
+  public interface IPushQueryParameters : IKSqlDbParameters
+  {
+    AutoOffsetReset AutoOffsetReset { get; set; }
+  }
+}

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/IPushQueryParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/IPushQueryParameters.cs
@@ -1,9 +1,11 @@
 using ksqlDB.RestApi.Client.KSql.Query.Options;
 
-namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
+
+/// <summary>
+/// Represents parameters for a push query.
+/// </summary>
+public interface IPushQueryParameters : IKSqlDbParameters
 {
-  public interface IPushQueryParameters : IKSqlDbParameters
-  {
-    AutoOffsetReset AutoOffsetReset { get; set; }
-  }
+  AutoOffsetReset AutoOffsetReset { get; set; }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/IQueryParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/IQueryParameters.cs
@@ -1,8 +1,19 @@
-﻿namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
 
+/// <summary>
+/// Represents query parameters for a KSqlDb endpoint.
+/// </summary>
 public interface IQueryParameters : IQueryOptions
 {
+  /// <summary>
+  /// A semicolon-delimited sequence of SQL statements to run.
+  /// </summary>
   string Sql { get; set; }
-    
+
+  /// <summary>
+  /// Indexer to access properties by key.
+  /// </summary>
+  /// <param name="key">The key of the property.</param>
+  /// <returns>The value of the property.</returns>
   string this[string key] { get; set; }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/PullQueryParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/PullQueryParameters.cs
@@ -1,0 +1,6 @@
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters
+{
+  public class PullQueryParameters : QueryEndpointParameters<PullQueryParameters>, IPullQueryParameters
+  {
+  }
+}

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/PullQueryParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/PullQueryParameters.cs
@@ -1,6 +1,8 @@
-namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
+
+/// <summary>
+/// Represents parameters for a pull query endpoint.
+/// </summary>
+public class PullQueryParameters : QueryEndpointParameters<PullQueryParameters>, IPullQueryParameters
 {
-  public class PullQueryParameters : QueryEndpointParameters<PullQueryParameters>, IPullQueryParameters
-  {
-  }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/PullQueryStreamParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/PullQueryStreamParameters.cs
@@ -1,0 +1,6 @@
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters
+{
+  public class PullQueryStreamParameters : QueryStreamEndpointParameters<PullQueryStreamParameters>, IPullQueryParameters
+  {
+  }
+}

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/PullQueryStreamParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/PullQueryStreamParameters.cs
@@ -1,6 +1,8 @@
-namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
+
+/// <summary>
+/// Represents parameters for a pull query stream endpoint.
+/// </summary>
+public class PullQueryStreamParameters : QueryStreamEndpointParameters<PullQueryStreamParameters>, IPullQueryParameters
 {
-  public class PullQueryStreamParameters : QueryStreamEndpointParameters<PullQueryStreamParameters>, IPullQueryParameters
-  {
-  }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryEndpointParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryEndpointParameters.cs
@@ -1,53 +1,73 @@
 using System.Text.Json.Serialization;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 
-namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
+
+/// <summary>
+/// Represents parameters for a '/query' endpoint.
+/// </summary>
+/// <typeparam name="T">The type of the query stream endpoint parameters.</typeparam>
+public class QueryEndpointParameters<T> : IKSqlDbParameters
+  where T : QueryEndpointParameters<T>, new()
 {
-  public class QueryEndpointParameters<T> : IKSqlDbParameters
-    where T : QueryEndpointParameters<T>, new()
+  /// <summary>
+  /// A semicolon-delimited sequence of SQL statements to run.
+  /// </summary>
+  [JsonPropertyName("ksql")]
+  public string Sql { get; set; } = null!;
+
+  /// <summary>
+  /// Property overrides to run the statements with.
+  /// </summary>
+  [JsonPropertyName("streamsProperties")]
+  public Dictionary<string, string> Properties { get; } = new();
+
+  /// <summary>
+  /// Indexer to access properties by key.
+  /// </summary>
+  /// <param name="key">The key of the property.</param>
+  /// <returns>The value of the property.</returns>
+  public string this[string key]
   {
-    /// <summary>
-    /// A semicolon-delimited sequence of SQL statements to run.
-    /// </summary>
-    [JsonPropertyName("ksql")]
-    public string Sql { get; set; } = null!;
+    get => Properties[key];
+    set => Properties[key] = value;
+  }
 
-    /// <summary>
-    /// Property overrides to run the statements with.
-    /// </summary>
-    [JsonPropertyName("streamsProperties")]
-    public Dictionary<string, string> Properties { get; } = new();
+  internal EndpointType EndpointType { get; set; } = EndpointType.Query;
 
-    public string this[string key]
+  /// <summary>
+  /// Fills the parameters from another set of parameters.
+  /// </summary>
+  /// <param name="parameters">The parameters to fill from.</param>
+  public void FillFrom(IKSqlDbParameters parameters)
+  {
+    this.FillQueryParametersFrom(parameters);
+  }
+
+  /// <summary>
+  /// Clones the current parameters.
+  /// </summary>
+  /// <returns>A new instance of the parameters with the same values.</returns>
+  public IKSqlDbParameters Clone()
+  {
+    var queryParams = new T()
     {
-      get => Properties[key];
-      set => Properties[key] = value;
-    }
+      Sql = Sql,
+      EndpointType = EndpointType
+    };
 
-    internal EndpointType EndpointType { get; set; } = EndpointType.Query;
+    foreach (var entry in Properties)
+      queryParams.Properties.Add(entry.Key, entry.Value);
 
-    public void FillFrom(IKSqlDbParameters parameters)
-    {
-      this.FillQueryParametersFrom(parameters);
-    }
+    return queryParams;
+  }
 
-    public IKSqlDbParameters Clone()
-    {
-      var queryParams = new T()
-      {
-        Sql = Sql,
-        EndpointType = EndpointType
-      };
-
-      foreach (var entry in Properties)
-        queryParams.Properties.Add(entry.Key, entry.Value);
-
-      return queryParams;
-    }
-
-    public override string ToString()
-    {
-      return this.ToLogInfo();
-    }
+  /// <summary>
+  /// Returns a string representation of the object.
+  /// </summary>
+  /// <returns>A string representation of the object.</returns>
+  public override string ToString()
+  {
+    return this.ToLogInfo();
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryEndpointParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryEndpointParameters.cs
@@ -28,7 +28,7 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters
 
     public void FillFrom(IKSqlDbParameters parameters)
     {
-      this.FillFromInternal(parameters);
+      this.FillQueryParametersFrom(parameters);
     }
 
     public IKSqlDbParameters Clone()

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryEndpointParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryEndpointParameters.cs
@@ -1,0 +1,53 @@
+using System.Text.Json.Serialization;
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements;
+
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters
+{
+  public class QueryEndpointParameters<T> : IKSqlDbParameters
+    where T : QueryEndpointParameters<T>, new()
+  {
+    /// <summary>
+    /// A semicolon-delimited sequence of SQL statements to run.
+    /// </summary>
+    [JsonPropertyName("ksql")]
+    public string Sql { get; set; } = null!;
+
+    /// <summary>
+    /// Property overrides to run the statements with.
+    /// </summary>
+    [JsonPropertyName("streamsProperties")]
+    public Dictionary<string, string> Properties { get; } = new();
+
+    public string this[string key]
+    {
+      get => Properties[key];
+      set => Properties[key] = value;
+    }
+
+    internal EndpointType EndpointType { get; set; } = EndpointType.Query;
+
+    public void FillFrom(IKSqlDbParameters parameters)
+    {
+      this.FillFromInternal(parameters);
+    }
+
+    public IKSqlDbParameters Clone()
+    {
+      var queryParams = new T()
+      {
+        Sql = Sql,
+        EndpointType = EndpointType
+      };
+
+      foreach (var entry in Properties)
+        queryParams.Properties.Add(entry.Key, entry.Value);
+
+      return queryParams;
+    }
+
+    public override string ToString()
+    {
+      return this.ToLogInfo();
+    }
+  }
+}

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryParameters.cs
@@ -1,31 +1,12 @@
 using System.Text.Json.Serialization;
 using ksqlDB.RestApi.Client.KSql.Query.Options;
-using EndpointType = ksqlDB.RestApi.Client.KSql.RestApi.Statements.EndpointType;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
 
-public class QueryParameters : IKSqlDbParameters
+public class QueryParameters : QueryEndpointParameters<QueryParameters>, IPushQueryParameters
 {
-  /// <summary>
-  /// A semicolon-delimited sequence of SQL statements to run.
-  /// </summary>
-  [JsonPropertyName("ksql")]
-  public string Sql { get; set; } = null!;
-
-  /// <summary>
-  /// Property overrides to run the statements with.
-  /// </summary>
-  [JsonPropertyName("streamsProperties")]
-  public Dictionary<string, string> Properties { get; } = new();
-
   public static readonly string AutoOffsetResetPropertyName = "ksql.streams.auto.offset.reset";
 
-  public string this[string key]
-  {
-    get => Properties[key];
-    set => Properties[key] = value;
-  }
-    
   [JsonIgnore]
   public AutoOffsetReset AutoOffsetReset
   {
@@ -37,26 +18,5 @@ public class QueryParameters : IKSqlDbParameters
     }
 
     set => this[AutoOffsetResetPropertyName] = value.ToKSqlValue();
-  }
-
-  internal EndpointType EndpointType { get; set; } = EndpointType.Query;
-
-  public IKSqlDbParameters Clone()
-  {
-    var queryParams = new QueryParameters()
-    {
-      Sql = Sql,
-      EndpointType = EndpointType
-    };
-
-    foreach (var entry in Properties)
-      queryParams.Properties.Add(entry.Key, entry.Value);
-
-    return queryParams;
-  }
-
-  public override string ToString()
-  {
-    return this.ToLogInfo();
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryParameters.cs
@@ -3,10 +3,16 @@ using ksqlDB.RestApi.Client.KSql.Query.Options;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
 
+/// <summary>
+/// Represents parameters for a query.
+/// </summary>
 public class QueryParameters : QueryEndpointParameters<QueryParameters>, IPushQueryParameters
 {
   public static readonly string AutoOffsetResetPropertyName = "ksql.streams.auto.offset.reset";
 
+  /// <summary>
+  /// Sets the auto offset reset using <see cref="AutoOffsetReset"/>.
+  /// </summary>
   [JsonIgnore]
   public AutoOffsetReset AutoOffsetReset
   {

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryParametersExtensions.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryParametersExtensions.cs
@@ -4,7 +4,14 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
 
 internal static class QueryParametersExtensions
 {
-  internal static void FillFromInternal(this IQueryParameters destination, IQueryParameters source)
+  internal static void FillPushQueryParametersFrom(this IPushQueryParameters destination, IPushQueryParameters source)
+  {
+    destination.FillQueryParametersFrom(source);
+
+    destination.AutoOffsetReset = source.AutoOffsetReset;
+  }
+
+  internal static void FillQueryParametersFrom(this IQueryParameters destination, IQueryParameters source)
   {
     destination.Sql = source.Sql;
 

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryParametersExtensions.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryParametersExtensions.cs
@@ -1,9 +1,17 @@
-﻿using System.Text;
+using System.Text;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
 
 internal static class QueryParametersExtensions
 {
+  internal static void FillFromInternal(this IQueryParameters destination, IQueryParameters source)
+  {
+    destination.Sql = source.Sql;
+
+    foreach (var entry in source.Properties)
+      destination.Properties.Add(entry.Key, entry.Value);
+  }
+
   public static string ToLogInfo(this IQueryParameters queryParameters)
   {
     var sb = new StringBuilder();

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryParametersExtensions.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryParametersExtensions.cs
@@ -19,7 +19,7 @@ internal static class QueryParametersExtensions
       destination.Properties.Add(entry.Key, entry.Value);
   }
 
-  public static string ToLogInfo(this IQueryParameters queryParameters)
+  internal static string ToLogInfo(this IQueryParameters queryParameters)
   {
     var sb = new StringBuilder();
 

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryStreamEndpointParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryStreamEndpointParameters.cs
@@ -1,0 +1,43 @@
+using System.Text.Json.Serialization;
+
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters
+{
+  public class QueryStreamEndpointParameters<T> : IKSqlDbParameters
+    where T : QueryStreamEndpointParameters<T>, new()
+  {
+    [JsonPropertyName("sql")]
+    public string Sql { get; set; } = null!;
+
+    [JsonPropertyName("properties")]
+    public Dictionary<string, string> Properties { get; } = new();
+
+    public string this[string key]
+    {
+      get => Properties[key];
+      set => Properties[key] = value;
+    }
+
+    public void FillFrom(IKSqlDbParameters parameters)
+    {
+      this.FillFromInternal(parameters);
+    }
+
+    public IKSqlDbParameters Clone()
+    {
+      var queryParams = new T()
+      {
+        Sql = Sql
+      };
+
+      foreach (var entry in Properties)
+        queryParams.Properties.Add(entry.Key, entry.Value);
+
+      return queryParams;
+    }
+
+    public override string ToString()
+    {
+      return this.ToLogInfo();
+    }
+  }
+}

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryStreamEndpointParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryStreamEndpointParameters.cs
@@ -19,7 +19,7 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters
 
     public void FillFrom(IKSqlDbParameters parameters)
     {
-      this.FillFromInternal(parameters);
+      this.FillQueryParametersFrom(parameters);
     }
 
     public IKSqlDbParameters Clone()

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryStreamEndpointParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryStreamEndpointParameters.cs
@@ -1,43 +1,70 @@
 using System.Text.Json.Serialization;
 
-namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
+
+/// <summary>
+/// Represents parameters for a '/query-stream' endpoint.
+/// </summary>
+/// <typeparam name="T">The type of the query stream endpoint parameters.</typeparam>
+public class QueryStreamEndpointParameters<T> : IKSqlDbParameters
+  where T : QueryStreamEndpointParameters<T>, new()
 {
-  public class QueryStreamEndpointParameters<T> : IKSqlDbParameters
-    where T : QueryStreamEndpointParameters<T>, new()
+  /// <summary>
+  /// A semicolon-delimited sequence of SQL statements to run.
+  /// </summary>
+  [JsonPropertyName("sql")]
+  public string Sql { get; set; } = null!;
+
+  /// <summary>
+  /// Property overrides to run the statements with.
+  /// </summary>
+  [JsonPropertyName("properties")]
+  public Dictionary<string, string> Properties { get; } = new();
+
+  /// <summary>
+  /// Indexer to access properties by key.
+  /// </summary>
+  /// <param name="key">The key of the property.</param>
+  /// <returns>The value of the property.</returns>
+  public string this[string key]
   {
-    [JsonPropertyName("sql")]
-    public string Sql { get; set; } = null!;
+    get => Properties[key];
+    set => Properties[key] = value;
+  }
 
-    [JsonPropertyName("properties")]
-    public Dictionary<string, string> Properties { get; } = new();
+  /// <summary>
+  /// Fills the parameters from another set of parameters.
+  /// </summary>
+  /// <param name="parameters">The parameters to fill from.</param>
+  public void FillFrom(IKSqlDbParameters parameters)
+  {
+    this.FillQueryParametersFrom(parameters);
+  }
 
-    public string this[string key]
+
+  /// <summary>
+  /// Clones the current parameters.
+  /// </summary>
+  /// <returns>A new instance of the parameters with the same values.</returns>
+  public IKSqlDbParameters Clone()
+  {
+    var queryParams = new T()
     {
-      get => Properties[key];
-      set => Properties[key] = value;
-    }
+      Sql = Sql
+    };
 
-    public void FillFrom(IKSqlDbParameters parameters)
-    {
-      this.FillQueryParametersFrom(parameters);
-    }
+    foreach (var entry in Properties)
+      queryParams.Properties.Add(entry.Key, entry.Value);
 
-    public IKSqlDbParameters Clone()
-    {
-      var queryParams = new T()
-      {
-        Sql = Sql
-      };
+    return queryParams;
+  }
 
-      foreach (var entry in Properties)
-        queryParams.Properties.Add(entry.Key, entry.Value);
-
-      return queryParams;
-    }
-
-    public override string ToString()
-    {
-      return this.ToLogInfo();
-    }
+  /// <summary>
+  /// Returns a string representation of the object.
+  /// </summary>
+  /// <returns>A string representation of the object.</returns>
+  public override string ToString()
+  {
+    return this.ToLogInfo();
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryStreamParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryStreamParameters.cs
@@ -3,21 +3,9 @@ using ksqlDB.RestApi.Client.KSql.Query.Options;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
 
-public sealed class QueryStreamParameters : IKSqlDbParameters
+public sealed class QueryStreamParameters : QueryStreamEndpointParameters<QueryStreamParameters>, IPushQueryParameters
 {
-  [JsonPropertyName("sql")]
-  public string Sql { get; set; } = null!;
-
-  [JsonPropertyName("properties")]
-  public Dictionary<string, string> Properties { get; } = new();
-    
   public static readonly string AutoOffsetResetPropertyName = "auto.offset.reset";
-
-  public string this[string key]
-  {
-    get => Properties[key];
-    set => Properties[key] = value;
-  }
 
   [JsonIgnore]
   public AutoOffsetReset AutoOffsetReset
@@ -25,28 +13,10 @@ public sealed class QueryStreamParameters : IKSqlDbParameters
     get
     {
       var value = this[AutoOffsetResetPropertyName];
-        
+
       return value.ToAutoOffsetReset();
     }
 
     set => this[AutoOffsetResetPropertyName] = value.ToKSqlValue();
-  }
-
-  public IKSqlDbParameters Clone()
-  {
-    var queryParams = new QueryStreamParameters
-    {
-      Sql = Sql
-    };
-
-    foreach (var entry in Properties)
-      queryParams.Properties.Add(entry.Key, entry.Value);
-
-    return queryParams;
-  }
-
-  public override string ToString()
-  {
-    return this.ToLogInfo();
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryStreamParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryStreamParameters.cs
@@ -3,10 +3,16 @@ using ksqlDB.RestApi.Client.KSql.Query.Options;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
 
+/// <summary>
+/// Represents parameters for a query stream.
+/// </summary>
 public sealed class QueryStreamParameters : QueryStreamEndpointParameters<QueryStreamParameters>, IPushQueryParameters
 {
   public static readonly string AutoOffsetResetPropertyName = "auto.offset.reset";
 
+  /// <summary>
+  /// Sets the auto offset reset using <see cref="AutoOffsetReset"/>.
+  /// </summary>
   [JsonIgnore]
   public AutoOffsetReset AutoOffsetReset
   {

--- a/ksqlDb.RestApi.Client/KSql/RestApi/RowValueJsonSerializer.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/RowValueJsonSerializer.cs
@@ -40,7 +40,7 @@ internal class RowValueJsonSerializer
     if (queryStreamHeader.ColumnTypes.Length == 1 && !typeof(T).IsAnonymousType())
     {
       var type = typeof(T);
-      var isAllowedType = type.IsPrimitive || type.IsArray || type.IsEnum;
+      var isAllowedType = type.IsPrimitive || type == typeof(string) || type.IsArray || type.IsEnum;
 
       if (isSingleAnonymousColumn || isMapColumn || isAllowedType)
       {

--- a/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
+++ b/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
@@ -15,7 +15,7 @@
             Documentation for the library can be found at https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/README.md.
         </Description>
         <PackageTags>ksql ksqlDB LINQ .NET csharp push query</PackageTags>
-        <Version>6.0.0-rc.1</Version>
+        <Version>6.0.0-rc.2</Version>
         <AssemblyVersion>6.0.0.0</AssemblyVersion>
         <LangVersion>12.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
+++ b/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
@@ -15,7 +15,7 @@
             Documentation for the library can be found at https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/README.md.
         </Description>
         <PackageTags>ksql ksqlDB LINQ .NET csharp push query</PackageTags>
-        <Version>6.0.0-rc.2</Version>
+        <Version>6.0.0-rc.3</Version>
         <AssemblyVersion>6.0.0.0</AssemblyVersion>
         <LangVersion>12.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
+++ b/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
@@ -15,7 +15,7 @@
             Documentation for the library can be found at https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/README.md.
         </Description>
         <PackageTags>ksql ksqlDB LINQ .NET csharp push query</PackageTags>
-        <Version>6.0.0-rc.3</Version>
+        <Version>6.0.0</Version>
         <AssemblyVersion>6.0.0.0</AssemblyVersion>
         <LangVersion>12.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
- separated configuration for pull and push queries, added `SetupPullQuery` configuration option
- `SetupQuery` from `KSqlDbContextOptionsBuilder` was unified with `SetupQueryStream`

#77