### PR TITLE
82 enhancing fluent API implementing the HasColumnName method

### DIFF
--- a/Samples/ksqlDB.RestApi.Client.Sample/ModelBuilders/PaymentModelBuilder.cs
+++ b/Samples/ksqlDB.RestApi.Client.Sample/ModelBuilders/PaymentModelBuilder.cs
@@ -25,6 +25,10 @@ public class PaymentModelBuilder
       .Property(b => b.Amount)
       .Decimal(precision: 10, scale: 2);
 
+    modelBuilder.Entity<Payment>()
+      .Property(b => b.Description)
+      .HasColumnName("desc");
+
     string header = "abc";
     modelBuilder.Entity<PocoWithHeader>()
       .Property(c => c.Header)
@@ -59,7 +63,7 @@ public class PaymentModelBuilder
       {
         c.UseKSqlDb(ksqlDbUrl);
 
-        c.ReplaceHttpClient<ksqlDB.RestApi.Client.KSql.RestApi.Http.IHttpClientFactory, ksqlDB.RestApi.Client.KSql.RestApi.Http.HttpClientFactory>(_ => { })
+        c.ReplaceHttpClient<KSql.RestApi.Http.IHttpClientFactory, KSql.RestApi.Http.HttpClientFactory>(_ => { })
         .AddHttpMessageHandler(_ => new Program.DebugHandler());
       })
       .AddSingleton(builder);

--- a/Samples/ksqlDB.RestApi.Client.Sample/ksqlDB.RestApi.Client.Samples.csproj
+++ b/Samples/ksqlDB.RestApi.Client.Sample/ksqlDB.RestApi.Client.Samples.csproj
@@ -9,8 +9,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="ksqlDb.RestApi.Client" Version="6.0.0" />
-        <!-- <ProjectReference Include="..\..\ksqlDb.RestApi.Client\ksqlDb.RestApi.Client.csproj" /> -->
+        <!-- <PackageReference Include="ksqlDb.RestApi.Client" Version="6.1.0" /> -->
+        <ProjectReference Include="..\..\ksqlDb.RestApi.Client\ksqlDb.RestApi.Client.csproj" />
         <!-- <PackageReference Include="ksqlDb.RestApi.Client.ProtoBuf" Version="4.0.0" /> -->
         <ProjectReference Include="..\..\ksqlDb.RestApi.Client.ProtoBuf\ksqlDb.RestApi.Client.ProtoBuf.csproj" />
 

--- a/Tests/ksqlDB.RestApi.Client.Tests/FluentAPI/Builders/ModelBuilderTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/FluentAPI/Builders/ModelBuilderTests.cs
@@ -62,7 +62,7 @@ namespace ksqlDb.RestApi.Client.Tests.FluentAPI.Builders
 
       //Assert
       fieldTypeBuilder.Should().NotBeNull();
-      var entityMetadata = builder.GetEntities().FirstOrDefault(c => c.Type == typeof(Payment));
+      var entityMetadata = ((IMetadataProvider)builder).GetEntities().FirstOrDefault(c => c.Type == typeof(Payment));
       entityMetadata.Should().NotBeNull();
       entityMetadata!.FieldsMetadata.First(c => c.MemberInfo.Name == nameof(Payment.Description)).Ignore.Should().BeTrue();
     }
@@ -80,7 +80,7 @@ namespace ksqlDb.RestApi.Client.Tests.FluentAPI.Builders
 
       //Assert
       fieldTypeBuilder.Should().NotBeNull();
-      var entityMetadata = builder.GetEntities().FirstOrDefault(c => c.Type == typeof(Payment));
+      var entityMetadata = ((IMetadataProvider)builder).GetEntities().FirstOrDefault(c => c.Type == typeof(Payment));
       entityMetadata.Should().NotBeNull();
       entityMetadata!.FieldsMetadata.First(c => c.MemberInfo.Name == nameof(Payment.Description)).ColumnName.Should().Be(columnName);
     }
@@ -101,7 +101,7 @@ namespace ksqlDb.RestApi.Client.Tests.FluentAPI.Builders
 
       //Assert
       fieldTypeBuilder.Should().NotBeNull();
-      var entityMetadata = builder.GetEntities().FirstOrDefault(c => c.Type == typeof(Payment));
+      var entityMetadata = ((IMetadataProvider)builder).GetEntities().FirstOrDefault(c => c.Type == typeof(Payment));
       entityMetadata.Should().NotBeNull();
       entityMetadata!.FieldsMetadata.First(c => c.MemberInfo.Name == nameof(Payment.Description)).Ignore.Should().BeTrue();
       entityMetadata.FieldsMetadata.First(c => c.MemberInfo.Name == nameof(Payment.Amount)).Ignore.Should().BeTrue();
@@ -123,7 +123,7 @@ namespace ksqlDb.RestApi.Client.Tests.FluentAPI.Builders
 
       //Assert
       fieldTypeBuilder.Should().NotBeNull();
-      var entityMetadata = builder.GetEntities().FirstOrDefault(c => c.Type == typeof(Composite));
+      var entityMetadata = ((IMetadataProvider)builder).GetEntities().FirstOrDefault(c => c.Type == typeof(Composite));
       entityMetadata.Should().NotBeNull();
       var memberInfo = GetTitleMemberInfo();
       entityMetadata!.FieldsMetadata.First(c => c.MemberInfo == memberInfo).Ignore.Should().BeTrue();
@@ -139,7 +139,7 @@ namespace ksqlDb.RestApi.Client.Tests.FluentAPI.Builders
       builder.AddConvention(decimalTypeConvention);
 
       //Assert
-      builder.Conventions[typeof(decimal)].Should().BeEquivalentTo(decimalTypeConvention);
+      ((IMetadataProvider)builder).Conventions[typeof(decimal)].Should().BeEquivalentTo(decimalTypeConvention);
     }
 
     private class PaymentConfiguration : IFromItemTypeConfiguration<Payment>
@@ -161,7 +161,7 @@ namespace ksqlDb.RestApi.Client.Tests.FluentAPI.Builders
       builder.Apply(configuration);
 
       //Assert
-      var entityMetadata = builder.GetEntities().FirstOrDefault(c => c.Type == typeof(Payment));
+      var entityMetadata = ((IMetadataProvider)builder).GetEntities().FirstOrDefault(c => c.Type == typeof(Payment));
       entityMetadata.Should().NotBeNull();
       entityMetadata!.FieldsMetadata.First(c => c.MemberInfo.Name == nameof(Payment.Description)).Ignore.Should().BeTrue();
     }
@@ -188,7 +188,7 @@ namespace ksqlDb.RestApi.Client.Tests.FluentAPI.Builders
 
       //Assert
       fieldTypeBuilder.Should().NotBeNull();
-      var entityMetadata = builder.GetEntities().FirstOrDefault(c => c.Type == typeof(Payment));
+      var entityMetadata = ((IMetadataProvider)builder).GetEntities().FirstOrDefault(c => c.Type == typeof(Payment));
       entityMetadata.Should().NotBeNull();
       var metadata = (DecimalFieldMetadata)entityMetadata!.FieldsMetadata.First(c => c.MemberInfo.Name == nameof(Payment.Amount));
 
@@ -209,7 +209,7 @@ namespace ksqlDb.RestApi.Client.Tests.FluentAPI.Builders
 
       //Assert
       fieldTypeBuilder.Should().NotBeNull();
-      var entityMetadata = builder.GetEntities().FirstOrDefault(c => c.Type == typeof(Payment));
+      var entityMetadata = ((IMetadataProvider)builder).GetEntities().FirstOrDefault(c => c.Type == typeof(Payment));
       entityMetadata.Should().NotBeNull();
       var metadata = (BytesArrayFieldMetadata)entityMetadata!.FieldsMetadata.First(c => c.MemberInfo.Name == nameof(Payment.Header));
 
@@ -228,7 +228,7 @@ namespace ksqlDb.RestApi.Client.Tests.FluentAPI.Builders
 
       //Assert
       fieldTypeBuilder.Should().NotBeNull();
-      var entityMetadata = builder.GetEntities().FirstOrDefault(c => c.Type == typeof(Payment));
+      var entityMetadata = ((IMetadataProvider)builder).GetEntities().FirstOrDefault(c => c.Type == typeof(Payment));
       entityMetadata.Should().NotBeNull();
       var metadata = entityMetadata!.FieldsMetadata.First(c => c.MemberInfo.Name == nameof(Payment.Header));
 

--- a/Tests/ksqlDB.RestApi.Client.Tests/FluentAPI/Builders/ModelBuilderTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/FluentAPI/Builders/ModelBuilderTests.cs
@@ -68,6 +68,24 @@ namespace ksqlDb.RestApi.Client.Tests.FluentAPI.Builders
     }
 
     [Test]
+    public void Property_HasColumnName()
+    {
+      //Arrange
+      var columnName = "desc";
+
+      //Act
+      var fieldTypeBuilder = builder.Entity<Payment>()
+        .Property(b => b.Description)
+        .HasColumnName(columnName);
+
+      //Assert
+      fieldTypeBuilder.Should().NotBeNull();
+      var entityMetadata = builder.GetEntities().FirstOrDefault(c => c.Type == typeof(Payment));
+      entityMetadata.Should().NotBeNull();
+      entityMetadata!.FieldsMetadata.First(c => c.MemberInfo.Name == nameof(Payment.Description)).ColumnName.Should().Be(columnName);
+    }
+
+    [Test]
     public void MultiplePropertiesForSameType()
     {
       //Arrange

--- a/Tests/ksqlDB.RestApi.Client.Tests/Infrastructure/Extensions/TypeExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/Infrastructure/Extensions/TypeExtensionsTests.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Text;
 using System.Text.Json.Serialization;
 using FluentAssertions;
+using ksqlDb.RestApi.Client.FluentAPI.Builders;
 using ksqlDB.RestApi.Client.Infrastructure.Extensions;
 using ksqlDB.RestApi.Client.KSql.Linq;
 using ksqlDB.RestApi.Client.KSql.Query;
@@ -373,7 +374,7 @@ public class TypeExtensionsTests
     var member = type.GetProperty(nameof(MySensor.Title));
 
     //Act
-    var memberName = member!.GetMemberName();
+    var memberName = member!.GetMemberName(new ModelBuilder());
 
     //Assert
     memberName.Should().Be(nameof(MySensor.Title));
@@ -388,9 +389,31 @@ public class TypeExtensionsTests
     //Act
     var member = type.GetProperty(nameof(MySensor.SensorId2));
 
-    var memberName = member!.GetMemberName();
+    var memberName = member!.GetMemberName(new ModelBuilder());
 
     //Assert
     memberName.Should().Be("SensorId");
+  }
+
+  [Test]
+  public void GetMemberName_ModelBuilderHasColumnName()
+  {
+    //Arrange
+    var columnName = "Id";
+
+    var modelBuilder = new ModelBuilder();
+    modelBuilder.Entity<MySensor>()
+      .Property(c => c.SensorId2)
+      .HasColumnName(columnName);
+
+    var type = typeof(MySensor);
+
+    //Act
+    var member = type.GetProperty(nameof(MySensor.SensorId2));
+
+    var memberName = member!.GetMemberName(modelBuilder);
+
+    //Assert
+    memberName.Should().Be(columnName);
   }
 }

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/QbservableGroupByExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/QbservableGroupByExtensionsTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using ksqlDb.RestApi.Client.FluentAPI.Builders;
 using ksqlDB.RestApi.Client.KSql.Linq;
 using ksqlDB.RestApi.Client.KSql.Query.Context;
 using ksqlDB.RestApi.Client.KSql.Query.Windows;
@@ -505,6 +506,12 @@ class TestableDbProvider : TestableDbProvider<QbservableGroupByExtensionsTests.C
       sc.AddHttpClient<IHttpClientFactory, HttpClientFactory>(c => c.BaseAddress = new Uri(ksqlDbUrl))
         .AddHttpMessageHandler(_ => FakeHttpClient.CreateDelegatingHandler(httpResponse).Object);
     });
+  }
+
+  public TestableDbProvider(KSqlDBContextOptions contextOptions, ModelBuilder modelBuilder) 
+    : base(contextOptions, modelBuilder)
+  {
+    RegisterKSqlQueryGenerator = false;
   }
 
   public TestableDbProvider(KSqlDBContextOptions contextOptions) 

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/TestableDbProvider.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/TestableDbProvider.cs
@@ -1,3 +1,4 @@
+using ksqlDb.RestApi.Client.FluentAPI.Builders;
 using ksqlDB.RestApi.Client.KSql.Query;
 using ksqlDB.RestApi.Client.KSql.Query.Context;
 using ksqlDB.RestApi.Client.KSql.RestApi;
@@ -8,12 +9,20 @@ namespace ksqlDb.RestApi.Client.Tests.KSql.Query.Context;
 
 public class TestableDbProvider<TValue> : KSqlDBContext
 {
-  public TestableDbProvider(string ksqlDbUrl) : base(ksqlDbUrl)
+  public TestableDbProvider(string ksqlDbUrl)
+    : base(ksqlDbUrl)
   {
     InitMocks();
   }
 
-  public TestableDbProvider(KSqlDBContextOptions contextOptions) : base(contextOptions)
+  public TestableDbProvider(KSqlDBContextOptions contextOptions)
+    : base(contextOptions)
+  {
+    InitMocks();
+  }
+
+  public TestableDbProvider(KSqlDBContextOptions contextOptions, ModelBuilder modelBuilder)
+    : base(contextOptions, modelBuilder)
   {
     InitMocks();
   }

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/KSqlQueryGeneratorTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/KSqlQueryGeneratorTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using FluentAssertions;
+using ksqlDb.RestApi.Client.FluentAPI.Builders;
 using ksqlDB.RestApi.Client.KSql.Linq;
 using ksqlDB.RestApi.Client.KSql.Query;
 using ksqlDB.RestApi.Client.KSql.Query.Context;
@@ -19,7 +20,7 @@ namespace ksqlDb.RestApi.Client.Tests.KSql.Query;
 
 #pragma warning disable CA1861
 
-public class KSqlQueryLanguageVisitorTests : TestBase
+public class KSqlQueryGeneratorTests : TestBase
 {
   private KSqlQueryGenerator ClassUnderTest { get; set; } = null!;
 
@@ -83,6 +84,77 @@ public class KSqlQueryLanguageVisitorTests : TestBase
     string expectedKsql =
       @$"SELECT SensorId FROM {nameof(MySensor)}s
 WHERE SensorId = '1' EMIT CHANGES;";
+
+    ksql.Should().BeEquivalentTo(expectedKsql.ReplaceLineEndings());
+  }
+
+  [Test]
+  public void BuildKSql_ModelBuilder_HasColumnNameOverride()
+  {
+    //Arrange
+    string idColumnName = "Id";
+    ModelBuilder modelBuilder = new ModelBuilder();
+    modelBuilder.Entity<MySensor>()
+      .Property(c => c.SensorId2)
+      .HasColumnName(idColumnName);
+
+    var query = new TestableDbProvider(contextOptions, modelBuilder)
+      .CreatePushQuery<MySensor>()
+      .Where(c => c.SensorId2 == "1")
+      .Select(c => c.SensorId2);
+
+    queryContext = new QueryContext()
+    {
+      ModelBuilder = modelBuilder
+    };
+
+    //Act
+    var ksql = ClassUnderTest.BuildKSql(query.Expression, queryContext);
+
+    //Assert
+    string expectedKsql =
+      @$"SELECT {idColumnName} FROM {nameof(MySensor)}s
+WHERE {idColumnName} = '1' EMIT CHANGES;";
+
+    ksql.Should().BeEquivalentTo(expectedKsql.ReplaceLineEndings());
+  }
+
+  private class Base
+  {
+    public int Id { get; set; }
+  }
+  private class Derived : Base
+  {
+    public string Description { get; set; }
+  }
+  
+  [Test]
+  public void BuildKSql_ModelBuilder_HasColumnNameOverride_ForPropertyInBaseClass()
+  {
+    //Arrange
+    string idColumnName = "SensorId";
+    ModelBuilder modelBuilder = new ModelBuilder();
+    modelBuilder.Entity<Derived>()
+      .Property(c => c.Id)
+      .HasColumnName(idColumnName);
+
+    var query = new TestableDbProvider(contextOptions, modelBuilder)
+      .CreatePushQuery<Derived>()
+      .Where(c => c.Id == 1)
+      .Select(c => c.Id);
+
+    queryContext = new QueryContext()
+    {
+      ModelBuilder = modelBuilder
+    };
+
+    //Act
+    var ksql = ClassUnderTest.BuildKSql(query.Expression, queryContext);
+
+    //Assert
+    string expectedKsql =
+      @$"SELECT {idColumnName} FROM {nameof(Derived)}s
+WHERE {idColumnName} = 1 EMIT CHANGES;";
 
     ksql.Should().BeEquivalentTo(expectedKsql.ReplaceLineEndings());
   }

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/KSqlVisitorTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/KSqlVisitorTests.cs
@@ -333,13 +333,13 @@ public class KSqlVisitorTests : TestBase
   public void Predicate_BuildKSql_PrintsOperatorAndOperands()
   {
     //Arrange
-    Expression<Func<Location, bool>> predicate = l => l.Latitude != "ahoj svet";
+    Expression<Func<Location, bool>> predicate = l => l.Latitude != "40.71427000";
 
     //Act
     var query = ClassUnderTest.BuildKSql(predicate);
 
     //Assert
-    query.Should().BeEquivalentTo($"{nameof(Location.Latitude)} != 'ahoj svet'");
+    query.Should().BeEquivalentTo($"{nameof(Location.Latitude)} != '40.71427000'");
   }
 
   private record Update
@@ -364,7 +364,7 @@ public class KSqlVisitorTests : TestBase
   public void PredicateCompareWithVariable_BuildKSql_PrintsOperatorAndOperands()
   {
     //Arrange
-    string value = "ahoj svet";
+    string value = "40.71427000";
 
     Expression<Func<Location, bool>> predicate = l => l.Latitude != value;
 
@@ -448,6 +448,37 @@ public class KSqlVisitorTests : TestBase
 
     //Assert
     query.Should().BeEquivalentTo("ARRAY_LENGTH(After->Model->Capabilities) > 0");
+  }
+
+  [Test]
+  public void MemberAccess_BuildKSql_JsonPropertyName()
+  {
+    //Arrange
+    Expression<Func<Tweet, string>> predicate = l => l.Message;
+
+    //Act
+    var query = ClassUnderTest.BuildKSql(predicate);
+
+    //Assert
+    query.Should().BeEquivalentTo($"{nameof(Tweet.Message).ToUpper()}");
+  }
+
+  [Test]
+  public void MemberAccess_BuildKSql_ModelBuilderHasColumnName()
+  {
+    //Arrange
+    var amountColumnName = "amount";
+    modelBuilder.Entity<Tweet>()
+      .Property(c => c.Amount)
+      .HasColumnName(amountColumnName);
+
+    Expression<Func<Tweet, double>> predicate = l => l.Amount;
+
+    //Act
+    var query = ClassUnderTest.BuildKSql(predicate);
+
+    //Assert
+    query.Should().BeEquivalentTo(amountColumnName);
   }
 
   #endregion

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Visitors/JoinVisitorTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Visitors/JoinVisitorTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using ksqlDb.RestApi.Client.FluentAPI.Builders;
 using ksqlDB.RestApi.Client.KSql.Linq;
 using ksqlDB.RestApi.Client.KSql.Query.Context;
 using ksqlDB.RestApi.Client.KSql.Query.Functions;
@@ -24,7 +25,7 @@ public class JoinVisitorTests : TestBase
     base.TestInitialize();
 
     var contextOptions = new KSqlDBContextOptions(TestParameters.KsqlDbUrl);
-    KSqlDbContext = new KSqlDBContext(contextOptions);
+    KSqlDbContext = new KSqlDBContext(contextOptions, new ModelBuilder());
   }
 
   private static string MovieAlias => "movie";

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Generators/StatementGeneratorTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Generators/StatementGeneratorTests.cs
@@ -36,7 +36,7 @@ public class StatementGeneratorTests
     return @$" MyMovies (
 	Id INT{keyClause} KEY,
 	Title VARCHAR,
-	Release_Year INT,
+	ReleaseYear INT,
 	NumberOfDays ARRAY<INT>,
 	Dictionary MAP<VARCHAR, INT>,
 	Dictionary2 MAP<VARCHAR, INT>,

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/CreateEntityTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/CreateEntityTests.cs
@@ -18,6 +18,8 @@ public class CreateEntityTests
   private EntityCreationMetadata creationMetadata = null!;
   private readonly ModelBuilder modelBuilder = new();
 
+  private const string MovieIdColumnName = "MovieId";
+
   [SetUp]
   public void Init()
   {
@@ -27,6 +29,10 @@ public class CreateEntityTests
       Partitions = 1,
       Replicas = 1
     };
+
+    modelBuilder.Entity<MyMovie>()
+      .Property(c => c.Id)
+      .HasColumnName(MovieIdColumnName);
   }
 
   private static readonly Pluralizer EnglishPluralizationService = new();
@@ -41,27 +47,27 @@ public class CreateEntityTests
     return escaping switch
     {
       Never => @$"{creationClause} {entityName} (
-	Id INT {key},
+	{MovieIdColumnName} INT {key},
 	Title VARCHAR,
-	Release_Year INT,
+	ReleaseYear INT,
 	NumberOfDays ARRAY<INT>,
 	Dictionary MAP<VARCHAR, INT>,
 	Dictionary2 MAP<VARCHAR, INT>,
 	Field DOUBLE
 ) WITH ( KAFKA_TOPIC='{nameof(MyMovie)}', VALUE_FORMAT='Json', PARTITIONS='1', REPLICAS='1' );".ReplaceLineEndings(),
       Keywords => @$"{creationClause} {entityName} (
-	Id INT {key},
+	{MovieIdColumnName} INT {key},
 	Title VARCHAR,
-	Release_Year INT,
+	ReleaseYear INT,
 	NumberOfDays ARRAY<INT>,
 	Dictionary MAP<VARCHAR, INT>,
 	Dictionary2 MAP<VARCHAR, INT>,
 	Field DOUBLE
 ) WITH ( KAFKA_TOPIC='{nameof(MyMovie)}', VALUE_FORMAT='Json', PARTITIONS='1', REPLICAS='1' );".ReplaceLineEndings(),
       Always => @$"{creationClause} `{entityName}` (
-	`Id` INT {key},
+	`{MovieIdColumnName}` INT {key},
 	`Title` VARCHAR,
-	`Release_Year` INT,
+	`ReleaseYear` INT,
 	`NumberOfDays` ARRAY<INT>,
 	`Dictionary` MAP<VARCHAR, INT>,
 	`Dictionary2` MAP<VARCHAR, INT>,
@@ -542,6 +548,7 @@ public class CreateEntityTests
 
     public string Title { get; set; } = null!;
 
+    [JsonPropertyName("ReleaseYear")]
     public int Release_Year { get; set; }
 
     public int[] NumberOfDays { get; init; } = null!;

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/TestableKSqlDbQueryStreamProvider.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/TestableKSqlDbQueryStreamProvider.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using ksqlDb.RestApi.Client.FluentAPI.Builders;
 using ksqlDB.RestApi.Client.KSql.RestApi;
 using ksqlDb.RestApi.Client.Tests.Helpers;
 using ksqlDb.RestApi.Client.Tests.Helpers.Http;
@@ -12,7 +13,7 @@ namespace ksqlDb.RestApi.Client.Tests.KSql.RestApi;
 internal class TestableKSqlDbQueryStreamProvider : KSqlDbQueryStreamProvider
 {
   public TestableKSqlDbQueryStreamProvider(IHttpClientFactory httpClientFactory, ILogger? logger = null)
-    : base(httpClientFactory, TestKSqlDBContextOptions.Instance, logger)
+    : base(httpClientFactory, new ModelBuilder(), TestKSqlDBContextOptions.Instance, logger)
   {
   }
 

--- a/Tests/ksqlDB.RestApi.Client.Tests/Metadata/EntityMetadataTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/Metadata/EntityMetadataTests.cs
@@ -21,61 +21,60 @@ namespace ksqlDb.RestApi.Client.Tests.Metadata
     public void Add_MemberWasStored()
     {
       //Arrange
-      var memberInfo = GetTitleMemberInfo();
+      var memberExpression = GetTitleMemberExpression();
 
       //Act
-      var added = entityMetadata.Add(memberInfo);
+      var added = entityMetadata.Add(memberExpression);
 
       //Assert
       added.Should().BeTrue();
     }
 
-    private static MemberInfo GetTitleMemberInfo()
+    private static MemberExpression GetTitleMemberExpression()
     {
       Expression<Func<Foo, object>> expression = foo => new { foo.Title };
       var argument = ((NewExpression)expression.Body).Arguments[0];
-      var memberInfo = ((MemberExpression)argument).Member;
-      return memberInfo;
+      return (MemberExpression)argument;
     }
 
     [Test]
     public void Add_MemberWasNotStoredSecondTime()
     {
       //Arrange
-      var memberInfo = GetTitleMemberInfo();
-      entityMetadata.Add(memberInfo);
+      var memberExpression = GetTitleMemberExpression();
+      entityMetadata.Add(memberExpression);
 
       //Act
-      var added = entityMetadata.Add(GetTitleMemberInfo());
+      var added = entityMetadata.Add(GetTitleMemberExpression());
 
       //Assert
       added.Should().BeFalse();
     }
 
     [Test]
-    public void TryGetMemberInfo_UnknownMemberName_NullIsReturned()
+    public void TryGetMemberExpression_UnknownMemberName_NullIsReturned()
     {
       //Arrange
-      var memberInfo = GetTitleMemberInfo();
-      entityMetadata.Add(memberInfo);
+      var memberExpression = GetTitleMemberExpression();
+      entityMetadata.Add(memberExpression);
 
       //Act
-      var result = entityMetadata.TryGetMemberInfo(nameof(Foo.Title));
+      var result = entityMetadata.TryGetMemberExpression(nameof(Foo.Title));
 
       //Assert
       result.Should().NotBeNull();
-      result!.GetCustomAttribute<JsonPropertyNameAttribute>().Should().NotBeNull();
+      result!.Member.GetCustomAttribute<JsonPropertyNameAttribute>().Should().NotBeNull();
     }
 
     [Test]
-    public void TryGetMemberInfo_KnownMemberName_MemberInfoIsReturned()
+    public void TryGetMemberExpression_KnownMemberName_MemberExpressionIsReturned()
     {
       //Arrange
-      var memberInfo = GetTitleMemberInfo();
-      entityMetadata.Add(memberInfo);
+      var memberExpression = GetTitleMemberExpression();
+      entityMetadata.Add(memberExpression);
 
       //Act
-      var result = entityMetadata.TryGetMemberInfo(nameof(Foo.Id));
+      var result = entityMetadata.TryGetMemberExpression(nameof(Foo.Id));
 
       //Assert
       result.Should().BeNull();

--- a/docs/modelbuilder.md
+++ b/docs/modelbuilder.md
@@ -223,3 +223,25 @@ CREATE STREAM Movie (
 ```
 
 The `WithHeaders` function within the FLUENT API takes precedence over the `HeadersAttribute`.
+
+### HasColumnName
+**v6.1.0**
+The `HasColumnName` function is employed during JSON deserialization and code generation, particularly in tasks like crafting CREATE STREAM or INSERT INTO statements.
+
+The below code demonstrates how to use the `HasColumnName` method in the Fluent API to override the property name `Description` to `Desc` during code generation:
+
+```C#
+using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
+
+modelBuilder.Entity<Payment>()
+  .Property(b => b.Description)
+  .HasColumnName("Desc");
+
+var statement = new CreateInsert(modelBuilder).Generate(movie, new InsertProperties { IdentifierEscaping = IdentifierEscaping.Keywords });
+```
+
+The KSQL snippet illustrates an example INSERT statement with the overridden column names, showing how it corresponds to the Fluent API configuration:
+
+```SQL
+INSERT INTO Payments (Id, Amount, Desc) VALUES ('1', 33, 'Purchase');
+```

--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -1,13 +1,19 @@
 # ksqlDB.RestApi.Client
 
+# 6.1.0-rc.1
+- added `HasColumnName` to the Fluent API to allow overriding property names during JSON deserialization and code generation.
+
+## BugFix
+- fixed missing usage/evaluation of the `JsonPropertyNameAttribute` during the creation of types.
+
 # 6.0.2
 
 # BugFix
-- C# decimal is mapped to STRUCT type. #81
+- C# decimal is mapped to STRUCT type #81
 
 # 6.0.1
 
-# BugFix
+## BugFix
 - requests with `KSqlDbRestApiClient` can result in 431 error codes #80
 
 # 6.0.0
@@ -17,7 +23,7 @@
 - introduced distinct parameters specifically tailored for pull queries. This modification results in a breaking change. Before this update, the parameters sent to both the 'query' and 'query-stream' endpoints were shared between pull and push queries. #77
 - see also [breakingchanges.md](https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/docs/breaking_changes.md#v600)
 
-# BugFix
+## BugFix
 - CreateQueryStream doesn't always use configured parameters. The PullQuery functionality was overriding the options configured for the PushQuery. #75 reported by @jbkuczma 
 
 # 5.1.0

--- a/ksqlDb.RestApi.Client/FluentAPI/Builders/FieldTypeBuilder.cs
+++ b/ksqlDb.RestApi.Client/FluentAPI/Builders/FieldTypeBuilder.cs
@@ -19,11 +19,24 @@ namespace ksqlDb.RestApi.Client.FluentAPI.Builders
     /// </summary>
     /// <returns>The field type builder for chaining additional configuration.</returns>
     public IFieldTypeBuilder<TProperty> WithHeaders();
+
+    /// <summary>
+    /// Configures the column name that the property will be mapped to in the record schema.
+    /// </summary>
+    /// <param name="columnName">The name of the column in the record schema.</param>
+    /// <returns>The same <see cref="IFieldTypeBuilder{TProperty}"/> instance so that multiple calls can be chained.</returns>
+    IFieldTypeBuilder<TProperty> HasColumnName(string columnName);
   }
 
   internal class FieldTypeBuilder<TProperty>(FieldMetadata fieldMetadata)
     : IFieldTypeBuilder<TProperty>
   {
+    public IFieldTypeBuilder<TProperty> HasColumnName(string columnName)
+    {
+      fieldMetadata.ColumnName = columnName;
+      return this;
+    }
+
     public IFieldTypeBuilder<TProperty> Ignore()
     {
       fieldMetadata.Ignore = true;

--- a/ksqlDb.RestApi.Client/FluentAPI/Builders/IMetadataProvider.cs
+++ b/ksqlDb.RestApi.Client/FluentAPI/Builders/IMetadataProvider.cs
@@ -1,0 +1,11 @@
+using ksqlDb.RestApi.Client.FluentAPI.Builders.Configuration;
+using ksqlDb.RestApi.Client.Metadata;
+
+namespace ksqlDb.RestApi.Client.FluentAPI.Builders
+{
+  internal interface IMetadataProvider
+  {
+    internal IEnumerable<EntityMetadata> GetEntities();
+    IDictionary<Type, IConventionConfiguration> Conventions { get; }
+  }
+}

--- a/ksqlDb.RestApi.Client/FluentAPI/Builders/ModelBuilder.cs
+++ b/ksqlDb.RestApi.Client/FluentAPI/Builders/ModelBuilder.cs
@@ -6,12 +6,20 @@ namespace ksqlDb.RestApi.Client.FluentAPI.Builders
   /// <summary>
   /// Represents a builder for configuring the model.
   /// </summary>
-  public class ModelBuilder
+  public class ModelBuilder : IMetadataProvider
   {
     private readonly IDictionary<Type, EntityTypeBuilder> builders = new Dictionary<Type, EntityTypeBuilder>();
-    internal readonly IDictionary<Type, IConventionConfiguration> Conventions = new Dictionary<Type, IConventionConfiguration>();
+    private readonly IDictionary<Type, IConventionConfiguration> conventions = new Dictionary<Type, IConventionConfiguration>();
 
-    internal IEnumerable<EntityMetadata> GetEntities()
+    IDictionary<Type, IConventionConfiguration> IMetadataProvider.Conventions
+    {
+      get
+      {
+        return conventions;
+      }
+    }
+
+    IEnumerable<EntityMetadata> IMetadataProvider.GetEntities()
     {
       return builders.Values.Select(c => c.Metadata);
     }
@@ -37,7 +45,7 @@ namespace ksqlDb.RestApi.Client.FluentAPI.Builders
     /// <returns>The current <see cref="ModelBuilder"/> instance.</returns>
     public ModelBuilder AddConvention(IConventionConfiguration configuration)
     {
-      Conventions.Add(configuration.Type, configuration);
+      conventions.Add(configuration.Type, configuration);
 
       return this;
     }

--- a/ksqlDb.RestApi.Client/Infrastructure/Extensions/TypeExtensions.cs
+++ b/ksqlDb.RestApi.Client/Infrastructure/Extensions/TypeExtensions.cs
@@ -1,10 +1,13 @@
 using System.Collections;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
+using ksqlDb.RestApi.Client.FluentAPI.Builders;
 using ksqlDB.RestApi.Client.KSql.Linq;
 using ksqlDB.RestApi.Client.KSql.Query;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Annotations;
+using ksqlDb.RestApi.Client.Metadata;
 
 namespace ksqlDB.RestApi.Client.Infrastructure.Extensions;
 
@@ -101,9 +104,29 @@ internal static class TypeExtensions
 
     return attribute;
   }
-  
-  internal static string GetMemberName(this MemberInfo memberInfo)
+
+  internal static string GetMemberName(this MemberExpression memberExpression, ModelBuilder? modelBuilder)
   {
+    var entityMetadata = modelBuilder?.GetEntities().FirstOrDefault(c => c.Type == memberExpression.Expression?.Type);
+
+    return memberExpression.Member.GetMemberName(entityMetadata);
+  }
+
+  internal static string GetMemberName(this MemberInfo memberInfo, ModelBuilder? modelBuilder)
+  {
+    var entityMetadata = modelBuilder?.GetEntities().FirstOrDefault(c => c.Type == memberInfo.DeclaringType);
+
+    return memberInfo.GetMemberName(entityMetadata);
+  }
+
+  internal static string GetMemberName(this MemberInfo memberInfo, EntityMetadata? entityMetadata)
+  {
+    var fieldMetadata =
+      entityMetadata?.FieldsMetadata.FirstOrDefault(c => c.MemberInfo.Name == memberInfo.Name);
+
+    if (fieldMetadata != null && !string.IsNullOrEmpty(fieldMetadata.ColumnName))
+      return fieldMetadata.ColumnName;
+
     var jsonPropertyNameAttribute = memberInfo.GetCustomAttribute<JsonPropertyNameAttribute>();
 
     var memberName = jsonPropertyNameAttribute?.Name ?? memberInfo.Name;

--- a/ksqlDb.RestApi.Client/Infrastructure/Extensions/TypeExtensions.cs
+++ b/ksqlDb.RestApi.Client/Infrastructure/Extensions/TypeExtensions.cs
@@ -105,16 +105,16 @@ internal static class TypeExtensions
     return attribute;
   }
 
-  internal static string GetMemberName(this MemberExpression memberExpression, ModelBuilder? modelBuilder)
+  internal static string GetMemberName(this MemberExpression memberExpression, IMetadataProvider? metadataProvider)
   {
-    var entityMetadata = modelBuilder?.GetEntities().FirstOrDefault(c => c.Type == memberExpression.Expression?.Type);
+    var entityMetadata = metadataProvider?.GetEntities().FirstOrDefault(c => c.Type == memberExpression.Expression?.Type);
 
     return memberExpression.Member.GetMemberName(entityMetadata);
   }
 
-  internal static string GetMemberName(this MemberInfo memberInfo, ModelBuilder? modelBuilder)
+  internal static string GetMemberName(this MemberInfo memberInfo, IMetadataProvider? metadataProvider)
   {
-    var entityMetadata = modelBuilder?.GetEntities().FirstOrDefault(c => c.Type == memberInfo.DeclaringType);
+    var entityMetadata = metadataProvider?.GetEntities().FirstOrDefault(c => c.Type == memberInfo.DeclaringType);
 
     return memberInfo.GetMemberName(entityMetadata);
   }

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContext.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContext.cs
@@ -74,6 +74,7 @@ public class KSqlDBContext : KSqlDBContextDependenciesProvider, IKSqlDBContext
     base.OnConfigureServices(serviceCollection, contextOptions);
 
     serviceCollection.TryAddSingleton(modelBuilder);
+    serviceCollection.TryAddSingleton<IMetadataProvider>(modelBuilder);
     serviceCollection.RegisterEndpointDependencies(contextOptions);
   }
 

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContext.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContext.cs
@@ -11,6 +11,7 @@ using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Clauses;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Inserts;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
 namespace ksqlDB.RestApi.Client.KSql.Query.Context;
@@ -72,6 +73,7 @@ public class KSqlDBContext : KSqlDBContextDependenciesProvider, IKSqlDBContext
   {
     base.OnConfigureServices(serviceCollection, contextOptions);
 
+    serviceCollection.TryAddSingleton(modelBuilder);
     serviceCollection.RegisterEndpointDependencies(contextOptions);
   }
 

--- a/ksqlDb.RestApi.Client/KSql/Query/Visitors/ConstantVisitor.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Visitors/ConstantVisitor.cs
@@ -51,7 +51,7 @@ namespace ksqlDB.RestApi.Client.KSql.Query.Visitors
       }
       else if (value != null && type != null && (type.IsClass || type.IsStruct() || type.IsDictionary()))
       {
-        var ksqlValue = new CreateKSqlValue(QueryMetadata.ModelBuilder).ExtractValue(value, null, null, type, str => IdentifierUtil.Format(str, QueryMetadata.IdentifierEscaping));
+        var ksqlValue = new CreateKSqlValue(QueryMetadata.ModelBuilder).ExtractValue(value, null, null, type, memberInfo => IdentifierUtil.Format(memberInfo, QueryMetadata.IdentifierEscaping, QueryMetadata.ModelBuilder));
 
         StringBuilder.Append(ksqlValue);
       }

--- a/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlJoinsVisitor.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlJoinsVisitor.cs
@@ -191,7 +191,7 @@ internal class KSqlJoinsVisitor : KSqlVisitor
 
     if (memberExpression.Expression?.NodeType == ExpressionType.Parameter)
     {
-      var memberName = IdentifierUtil.Format(memberExpression.Member, QueryMetadata.IdentifierEscaping);
+      var memberName = IdentifierUtil.Format(memberExpression, QueryMetadata.IdentifierEscaping, QueryMetadata.ModelBuilder);
 
       Append(memberName);
 
@@ -200,7 +200,7 @@ internal class KSqlJoinsVisitor : KSqlVisitor
 
     if (QueryMetadata.Joins != null && memberExpression.Expression?.NodeType == ExpressionType.MemberAccess)
     {
-      Append(memberExpression.Member.Format(QueryMetadata.IdentifierEscaping));
+      Append(memberExpression.Member.Format(QueryMetadata.IdentifierEscaping, QueryMetadata.ModelBuilder));
     }
     else
       base.VisitMember(memberExpression);

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Extensions/MemberInfoExtensions.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Extensions/MemberInfoExtensions.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using ksqlDb.RestApi.Client.FluentAPI.Builders;
 using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
 using ksqlDb.RestApi.Client.KSql.RestApi.Parsers;
 
@@ -11,7 +12,8 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi.Extensions
     /// </summary>
     /// <param name="memberInfo"></param>
     /// <param name="escaping"></param>
+    /// <param name="modelBuilder"></param>
     /// <returns>the <c>memberInfo.Name</c> modified based on the provided <c>format</c></returns>
-    public static string Format(this MemberInfo memberInfo, IdentifierEscaping escaping) => IdentifierUtil.Format(memberInfo, escaping);
+    public static string Format(this MemberInfo memberInfo, IdentifierEscaping escaping, ModelBuilder modelBuilder) => IdentifierUtil.Format(memberInfo, escaping, modelBuilder);
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Generators/TypeGenerator.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Generators/TypeGenerator.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using ksqlDb.RestApi.Client.FluentAPI.Builders;
+using ksqlDB.RestApi.Client.Infrastructure.Extensions;
 using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
 using ksqlDb.RestApi.Client.KSql.RestApi.Parsers;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements;
@@ -35,7 +36,8 @@ internal sealed class TypeGenerator(ModelBuilder modelBuilder) : EntityInfo(mode
 
       var ksqlType = typeTranslator.Translate(type, escaping);
 
-      var columnDefinition = $"{EscapeName(memberInfo.Name, escaping)} {ksqlType}{typeTranslator.ExploreAttributes(typeof(T), memberInfo, type)}";
+      var memberName = memberInfo.GetMemberName(modelBuilder);
+      var columnDefinition = $"{EscapeName(memberName, escaping)} {ksqlType}{typeTranslator.ExploreAttributes(typeof(T), memberInfo, type)}";
       ksqlProperties.Add(columnDefinition);
     }
 

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Generators/TypeGenerator.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Generators/TypeGenerator.cs
@@ -9,9 +9,9 @@ using static ksqlDB.RestApi.Client.KSql.RestApi.Enums.IdentifierEscaping;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Generators;
 
-internal sealed class TypeGenerator(ModelBuilder modelBuilder) : EntityInfo(modelBuilder)
+internal sealed class TypeGenerator(ModelBuilder metadataProvider) : EntityInfo(metadataProvider)
 {
-  private readonly KSqlTypeTranslator typeTranslator = new(modelBuilder);
+  private readonly KSqlTypeTranslator typeTranslator = new(metadataProvider);
 
   internal string Print<T>(TypeProperties properties)
   {
@@ -36,7 +36,7 @@ internal sealed class TypeGenerator(ModelBuilder modelBuilder) : EntityInfo(mode
 
       var ksqlType = typeTranslator.Translate(type, escaping);
 
-      var memberName = memberInfo.GetMemberName(modelBuilder);
+      var memberName = memberInfo.GetMemberName(metadataProvider);
       var columnDefinition = $"{EscapeName(memberName, escaping)} {ksqlType}{typeTranslator.ExploreAttributes(typeof(T), memberInfo, type)}";
       ksqlProperties.Add(columnDefinition);
     }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Json/JsonTypeInfoResolver.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Json/JsonTypeInfoResolver.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace ksqlDb.RestApi.Client.KSql.RestApi.Json
+{
+  internal class JsonTypeInfoResolver(IJsonTypeInfoResolver typeInfoResolver) : IJsonTypeInfoResolver
+  {
+    private readonly IJsonTypeInfoResolver typeInfoResolver = typeInfoResolver ?? throw new ArgumentNullException(nameof(typeInfoResolver));
+
+    public IList<Action<JsonTypeInfo>> Modifiers => modifiers ??= new List<Action<JsonTypeInfo>>();
+    private IList<Action<JsonTypeInfo>>? modifiers;
+
+    public virtual JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options)
+    {
+      var typeInfo = typeInfoResolver.GetTypeInfo(type, options);
+
+      if (modifiers != null)
+      {
+        foreach (Action<JsonTypeInfo> modifier in modifiers)
+        {
+          modifier(typeInfo);
+        }
+      }
+
+      return typeInfo;
+    }
+  }
+}

--- a/ksqlDb.RestApi.Client/KSql/RestApi/KSqlDbQueryStreamProvider.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/KSqlDbQueryStreamProvider.cs
@@ -85,9 +85,9 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi
       JsonPropertyNameModifier(jsonTypeInfo, modelBuilder);
     }
 
-    internal static void JsonPropertyNameModifier(JsonTypeInfo jsonTypeInfo, ModelBuilder modelBuilder)
+    internal static void JsonPropertyNameModifier(JsonTypeInfo jsonTypeInfo, IMetadataProvider metadataProvider)
     {
-      var entityMetadata = modelBuilder.GetEntities().FirstOrDefault(c => c.Type == jsonTypeInfo.Type);
+      var entityMetadata = metadataProvider.GetEntities().FirstOrDefault(c => c.Type == jsonTypeInfo.Type);
 
       foreach (var typeInfoProperty in jsonTypeInfo.Properties)
       {

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parsers/IdentifierUtil.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parsers/IdentifierUtil.cs
@@ -51,25 +51,23 @@ namespace ksqlDb.RestApi.Client.KSql.RestApi.Parsers
       };
     }
 
-    /// <summary>
-    /// Format the <c>identifier</c>, except when it is a <c>PseudoColumn</c>.
-    /// </summary>
-    /// <param name="memberExpression">the memberExpression with the identifier</param>
-    /// <param name="escaping">the format</param>
-    /// <param name="modelBuilder">the model builder</param>
-    /// <returns>the identifier modified based on the provided <c>format</c></returns>
-    public static string Format(MemberExpression memberExpression, IdentifierEscaping escaping, ModelBuilder? modelBuilder = null)
+    internal static string Format(MemberExpression memberExpression, IdentifierEscaping escaping, IMetadataProvider? metadataProvider = null)
     {
       return escaping switch
       {
-        Never => memberExpression.GetMemberName(modelBuilder),
+        Never => memberExpression.GetMemberName(metadataProvider),
         Keywords when memberExpression.Member.GetCustomAttribute<PseudoColumnAttribute>() != null => memberExpression.Member.Name,
-        Keywords when IsValid(memberExpression.GetMemberName(modelBuilder)) && SystemColumns.IsValid(memberExpression.GetMemberName(modelBuilder)) => memberExpression.GetMemberName(modelBuilder),
-        Keywords => string.Concat("`", memberExpression.GetMemberName(modelBuilder), "`"),
+        Keywords when IsValid(memberExpression.GetMemberName(metadataProvider)) && SystemColumns.IsValid(memberExpression.GetMemberName(metadataProvider)) => memberExpression.GetMemberName(metadataProvider),
+        Keywords => string.Concat("`", memberExpression.GetMemberName(metadataProvider), "`"),
         Always when memberExpression.Member.GetCustomAttribute<PseudoColumnAttribute>() != null => memberExpression.Member.Name,
-        Always => string.Concat("`", memberExpression.GetMemberName(modelBuilder), "`"),
+        Always => string.Concat("`", memberExpression.GetMemberName(metadataProvider), "`"),
         _ => throw new ArgumentOutOfRangeException(nameof(escaping), escaping, "Non-exhaustive match.")
       };
+    }
+
+    internal static string Format(MemberInfo memberInfo, IdentifierEscaping escaping, IMetadataProvider? modelBuilder = null)
+    {
+      return Format(memberInfo, escaping, modelBuilder as ModelBuilder);
     }
 
     /// <summary>

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntity.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntity.cs
@@ -49,7 +49,7 @@ internal sealed class CreateEntity(ModelBuilder modelBuilder) : EntityInfo(model
 
       var ksqlType = typeTranslator.Translate(type, metadata.IdentifierEscaping);
 
-      var columnName = IdentifierUtil.Format(memberInfo, metadata.IdentifierEscaping);
+      var columnName = IdentifierUtil.Format(memberInfo, metadata.IdentifierEscaping, modelBuilder);
       string columnDefinition = $"\t{columnName} {ksqlType}{typeTranslator.ExploreAttributes(typeof(T), memberInfo, type)}";
 
       columnDefinition += TryAttachKey<T>(statementContext.KSqlEntityType, memberInfo);

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntity.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntity.cs
@@ -9,11 +9,11 @@ using static System.String;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 
-internal sealed class CreateEntity(ModelBuilder modelBuilder) : EntityInfo(modelBuilder)
+internal sealed class CreateEntity(IMetadataProvider metadataProvider) : EntityInfo(metadataProvider)
 {
   private readonly StringBuilder stringBuilder = new();
 
-  private readonly KSqlTypeTranslator typeTranslator = new(modelBuilder);
+  private readonly KSqlTypeTranslator typeTranslator = new(metadataProvider);
 
   internal string Print<T>(StatementContext statementContext, EntityCreationMetadata metadata, bool? ifNotExists)
   {
@@ -49,7 +49,7 @@ internal sealed class CreateEntity(ModelBuilder modelBuilder) : EntityInfo(model
 
       var ksqlType = typeTranslator.Translate(type, metadata.IdentifierEscaping);
 
-      var columnName = IdentifierUtil.Format(memberInfo, metadata.IdentifierEscaping, modelBuilder);
+      var columnName = IdentifierUtil.Format(memberInfo, metadata.IdentifierEscaping, metadataProvider);
       string columnDefinition = $"\t{columnName} {ksqlType}{typeTranslator.ExploreAttributes(typeof(T), memberInfo, type)}";
 
       columnDefinition += TryAttachKey<T>(statementContext.KSqlEntityType, memberInfo);
@@ -85,7 +85,7 @@ internal sealed class CreateEntity(ModelBuilder modelBuilder) : EntityInfo(model
 
   private string TryAttachKey<T>(KSqlEntityType entityType, MemberInfo memberInfo)
   {
-    var entityMetadata = modelBuilder.GetEntities().FirstOrDefault(c => c.Type == typeof(T));
+    var entityMetadata = metadataProvider.GetEntities().FirstOrDefault(c => c.Type == typeof(T));
 
     var primaryKey = entityMetadata?.PrimaryKeyMemberInfo;
 

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
@@ -51,11 +51,11 @@ internal sealed class CreateInsert : EntityInfo
         valuesStringBuilder.Append(", ");
       }
 
-      columnsStringBuilder.Append(memberInfo.Format(insertProperties.IdentifierEscaping));
+      columnsStringBuilder.Append(memberInfo.Format(insertProperties.IdentifierEscaping, modelBuilder));
 
       var type = GetMemberType(memberInfo);
 
-      var value = GetValue(insertValues, insertProperties, memberInfo, type, mi => IdentifierUtil.Format(mi, insertProperties.IdentifierEscaping));
+      var value = GetValue(insertValues, insertProperties, memberInfo, type, mi => IdentifierUtil.Format(mi, insertProperties.IdentifierEscaping, modelBuilder));
 
       valuesStringBuilder.Append(value);
     }
@@ -69,12 +69,12 @@ internal sealed class CreateInsert : EntityInfo
   private object GetValue<T>(InsertValues<T> insertValues, InsertProperties insertProperties,
     MemberInfo memberInfo, Type type, Func<MemberInfo, string> formatter)
   {
-    var hasValue = insertValues.PropertyValues.ContainsKey(memberInfo.Format(insertProperties.IdentifierEscaping));
+    var hasValue = insertValues.PropertyValues.ContainsKey(memberInfo.Format(insertProperties.IdentifierEscaping, modelBuilder));
 
     object value;
     
     if (hasValue)
-      value = insertValues.PropertyValues[memberInfo.Format(insertProperties.IdentifierEscaping)];
+      value = insertValues.PropertyValues[memberInfo.Format(insertProperties.IdentifierEscaping, modelBuilder)];
     else
       value = new CreateKSqlValue(modelBuilder).ExtractValue(insertValues.Entity, insertProperties, memberInfo, type, formatter);
 

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
@@ -10,12 +10,12 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 
 internal sealed class CreateInsert : EntityInfo
 {
-  private readonly ModelBuilder modelBuilder;
+  private readonly ModelBuilder metadataProvider;
 
-  public CreateInsert(ModelBuilder modelBuilder)
-    : base(modelBuilder)
+  public CreateInsert(ModelBuilder metadataProvider)
+    : base(metadataProvider)
   {
-    this.modelBuilder = modelBuilder;
+    this.metadataProvider = metadataProvider;
   }
 
   internal string Generate<T>(T entity, InsertProperties? insertProperties = null)
@@ -51,11 +51,11 @@ internal sealed class CreateInsert : EntityInfo
         valuesStringBuilder.Append(", ");
       }
 
-      columnsStringBuilder.Append(memberInfo.Format(insertProperties.IdentifierEscaping, modelBuilder));
+      columnsStringBuilder.Append(memberInfo.Format(insertProperties.IdentifierEscaping, metadataProvider));
 
       var type = GetMemberType(memberInfo);
 
-      var value = GetValue(insertValues, insertProperties, memberInfo, type, mi => IdentifierUtil.Format(mi, insertProperties.IdentifierEscaping, modelBuilder));
+      var value = GetValue(insertValues, insertProperties, memberInfo, type, mi => IdentifierUtil.Format(mi, insertProperties.IdentifierEscaping, metadataProvider));
 
       valuesStringBuilder.Append(value);
     }
@@ -69,14 +69,14 @@ internal sealed class CreateInsert : EntityInfo
   private object GetValue<T>(InsertValues<T> insertValues, InsertProperties insertProperties,
     MemberInfo memberInfo, Type type, Func<MemberInfo, string> formatter)
   {
-    var hasValue = insertValues.PropertyValues.ContainsKey(memberInfo.Format(insertProperties.IdentifierEscaping, modelBuilder));
+    var hasValue = insertValues.PropertyValues.ContainsKey(memberInfo.Format(insertProperties.IdentifierEscaping, metadataProvider));
 
     object value;
     
     if (hasValue)
-      value = insertValues.PropertyValues[memberInfo.Format(insertProperties.IdentifierEscaping, modelBuilder)];
+      value = insertValues.PropertyValues[memberInfo.Format(insertProperties.IdentifierEscaping, metadataProvider)];
     else
-      value = new CreateKSqlValue(modelBuilder).ExtractValue(insertValues.Entity, insertProperties, memberInfo, type, formatter);
+      value = new CreateKSqlValue(metadataProvider).ExtractValue(insertValues.Entity, insertProperties, memberInfo, type, formatter);
 
     return value;
   }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateKSqlValue.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateKSqlValue.cs
@@ -11,7 +11,7 @@ using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 
 #nullable disable
-internal sealed class CreateKSqlValue(ModelBuilder modelBuilder) : EntityInfo(modelBuilder)
+internal sealed class CreateKSqlValue(ModelBuilder metadataProvider) : EntityInfo(metadataProvider)
 {
   public object ExtractValue<T>(T inputValue, IValueFormatters valueFormatters, MemberInfo memberInfo, Type type, Func<MemberInfo, string> formatter)
   {

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/EntityInfo.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/EntityInfo.cs
@@ -5,7 +5,7 @@ using ksqlDb.RestApi.Client.KSql.RestApi.Statements.Providers;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 
-internal class EntityInfo(ModelBuilder modelBuilder)
+internal class EntityInfo(IMetadataProvider metadataProvider)
 {
   protected static readonly EntityProvider EntityProvider = new();
 
@@ -24,7 +24,7 @@ internal class EntityInfo(ModelBuilder modelBuilder)
       .OfType<MemberInfo>()
       .Concat(fields);
 
-    var entityMetadata = modelBuilder.GetEntities().FirstOrDefault(c => c.Type == type);
+    var entityMetadata = metadataProvider.GetEntities().FirstOrDefault(c => c.Type == type);
     
     return properties.Where(c =>
     {

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/KSqlTypeTranslator.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/KSqlTypeTranslator.cs
@@ -9,10 +9,10 @@ using ksqlDb.RestApi.Client.Metadata;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements
 {
-  internal sealed class KSqlTypeTranslator(ModelBuilder modelBuilder) : EntityInfo(modelBuilder)
+  internal sealed class KSqlTypeTranslator(IMetadataProvider metadataProvider) : EntityInfo(metadataProvider)
   {
-    private readonly ModelBuilder modelBuilder = modelBuilder;
-    private readonly DecimalTypeTranslator decimalTypeTranslator = new(modelBuilder);
+    private readonly IMetadataProvider metadataProvider = metadataProvider;
+    private readonly DecimalTypeTranslator decimalTypeTranslator = new(metadataProvider);
 
     internal string Translate(Type type, IdentifierEscaping escaping = IdentifierEscaping.Never)
     {
@@ -107,7 +107,7 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements
 
         var ksqlType = Translate(memberType, escaping);
 
-        string columnDefinition = $"{memberInfo.Format(escaping, modelBuilder)} {ksqlType}{ExploreAttributes(type, memberInfo, memberType)}";
+        string columnDefinition = $"{memberInfo.Format(escaping, metadataProvider as ModelBuilder)} {ksqlType}{ExploreAttributes(type, memberInfo, memberType)}";
 
         ksqlProperties.Add(columnDefinition);
       }
@@ -132,7 +132,7 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements
 
     private string TryGetHeaderMarker(Type? parentType, MemberInfo memberInfo)
     {
-      var entityMetadata = modelBuilder.GetEntities().FirstOrDefault(c => c.Type == parentType);
+      var entityMetadata = metadataProvider.GetEntities().FirstOrDefault(c => c.Type == parentType);
       var fieldMetadata = entityMetadata?.GetFieldMetadataBy(memberInfo);
 
       if (fieldMetadata?.HasHeaders ?? false)

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/KSqlTypeTranslator.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/KSqlTypeTranslator.cs
@@ -107,7 +107,7 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements
 
         var ksqlType = Translate(memberType, escaping);
 
-        string columnDefinition = $"{memberInfo.Format(escaping)} {ksqlType}{ExploreAttributes(type, memberInfo, memberType)}";
+        string columnDefinition = $"{memberInfo.Format(escaping, modelBuilder)} {ksqlType}{ExploreAttributes(type, memberInfo, memberType)}";
 
         ksqlProperties.Add(columnDefinition);
       }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Translators/DecimalTypeTranslator.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Translators/DecimalTypeTranslator.cs
@@ -7,7 +7,7 @@ using ksqlDb.RestApi.Client.Metadata;
 
 namespace ksqlDb.RestApi.Client.KSql.RestApi.Statements.Translators
 {
-  internal class DecimalTypeTranslator(ModelBuilder modelBuilder)
+  internal class DecimalTypeTranslator(IMetadataProvider modelBuilder)
   {
     internal bool TryGetDecimal(Type? parentType, MemberInfo memberInfo, out string? @decimal)
     {

--- a/ksqlDb.RestApi.Client/Metadata/EntityMetadata.cs
+++ b/ksqlDb.RestApi.Client/Metadata/EntityMetadata.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace ksqlDb.RestApi.Client.Metadata
@@ -12,15 +13,14 @@ namespace ksqlDb.RestApi.Client.Metadata
 
     public IEnumerable<FieldMetadata> FieldsMetadata => FieldsMetadataDict.Values;
 
-    internal bool Add(MemberInfo memberInfo)
+
+    private readonly IList<MemberExpression> fieldMemberExpressions = new List<MemberExpression>();
+
+    internal bool Add(MemberExpression memberExpression)
     {
-      if (!FieldsMetadataDict.ContainsKey(memberInfo))
+      if (fieldMemberExpressions.All(c => c.Type != memberExpression.Type && c.Member != memberExpression.Member))
       {
-        var fieldMetadata = new FieldMetadata
-        {
-          MemberInfo = memberInfo
-        };
-        FieldsMetadataDict[memberInfo] = fieldMetadata;
+        fieldMemberExpressions.Add(memberExpression);
         return true;
       }
 
@@ -33,9 +33,9 @@ namespace ksqlDb.RestApi.Client.Metadata
         c.MemberInfo.DeclaringType == memberInfo.DeclaringType && c.MemberInfo.Name == memberInfo.Name);
     }
 
-    internal MemberInfo? TryGetMemberInfo(string memberInfoName)
+    internal MemberExpression? TryGetMemberExpression(string memberInfoName)
     {
-      return FieldsMetadata.Where(c => c.MemberInfo.Name == memberInfoName).Select(c => c.MemberInfo).FirstOrDefault();
+      return fieldMemberExpressions.Where(c => c.Member.Name == memberInfoName).Select(c => c).FirstOrDefault();
     }
   }
 }

--- a/ksqlDb.RestApi.Client/Metadata/FieldMetadata.cs
+++ b/ksqlDb.RestApi.Client/Metadata/FieldMetadata.cs
@@ -9,5 +9,6 @@ namespace ksqlDb.RestApi.Client.Metadata
     public bool HasHeaders { get; internal set; }
     internal string Path { get; init; } = null!;
     internal string FullPath { get; init; } = null!;
+    public string? ColumnName { get; set; }
   }
 }

--- a/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
+++ b/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
@@ -15,8 +15,8 @@
             Documentation for the library can be found at https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/README.md.
         </Description>
         <PackageTags>ksql ksqlDB LINQ .NET csharp push query</PackageTags>
-        <Version>6.0.2</Version>
-        <AssemblyVersion>6.0.2.0</AssemblyVersion>
+        <Version>6.1.0-rc.1</Version>
+        <AssemblyVersion>6.1.0.0</AssemblyVersion>
         <LangVersion>12.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <PackageReleaseNotes>https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/ksqlDb.RestApi.Client/ChangeLog.md</PackageReleaseNotes>


### PR DESCRIPTION
The Fluent API should enable the definition of how properties and fields are mapped to the record schema. The `HasColumnName` method can be used to specify custom column names for these properties.
Proposed API:
```C#
  public interface IFieldTypeBuilder<TProperty>
  {
    IFieldTypeBuilder<TProperty> HasColumnName(string columnName);
  }
```

This approach serves as an alternative to using the `JsonPropertyName` attribute for marking properties.

```cmd
dotnet add package ksqlDb.RestApi.Client --version 6.1.0-rc.1
```

#82