### PR TITLE
89 specify types as struct using the modelbuilder

### DIFF
--- a/Samples/ksqlDB.RestApi.Client.Sample/ModelBuilders/PaymentModelBuilder.cs
+++ b/Samples/ksqlDB.RestApi.Client.Sample/ModelBuilders/PaymentModelBuilder.cs
@@ -34,6 +34,19 @@ public class PaymentModelBuilder
       .Property(c => c.Header)
       .WithHeader(header);
 
+    modelBuilder.Entity<Record>()
+      .Property(b => b.Headers)
+      .AsStruct()
+      .WithHeaders();
+
+    modelBuilder.Entity<KeyValuePair>()
+      .Property(c => c.Key)
+      .HasColumnName(nameof(KeyValuePair.Key).ToUpper());
+
+    modelBuilder.Entity<KeyValuePair>()
+      .Property(c => c.Value)
+      .HasColumnName(nameof(KeyValuePair.Value).ToUpper());
+
     var restApiProvider = ConfigureRestApiClientWithServicesCollection(new ServiceCollection(), modelBuilder);
 
     var entityCreationMetadata = new EntityCreationMetadata(kafkaTopic: nameof(Payment), partitions: 1);
@@ -93,4 +106,15 @@ record Account
 record PocoWithHeader
 {
   public byte[] Header { get; init; } = null!;
+}
+
+record KeyValuePair
+{
+  public string Key { get; set; } = null!;
+  public byte[] Value { get; set; } = null!;
+}
+
+record Record
+{
+  public KeyValuePair[] Headers { get; init; } = null!;
 }

--- a/Samples/ksqlDB.RestApi.Client.Sample/ksqlDB.RestApi.Client.Samples.csproj
+++ b/Samples/ksqlDB.RestApi.Client.Sample/ksqlDB.RestApi.Client.Samples.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="ksqlDb.RestApi.Client" Version="6.3.0-rc.1" />
+        <PackageReference Include="ksqlDb.RestApi.Client" Version="6.3.0" />
         <!-- <ProjectReference Include="..\..\ksqlDb.RestApi.Client\ksqlDb.RestApi.Client.csproj" /> -->
         <!-- <PackageReference Include="ksqlDb.RestApi.Client.ProtoBuf" Version="4.0.0" /> -->
         <ProjectReference Include="..\..\ksqlDb.RestApi.Client.ProtoBuf\ksqlDb.RestApi.Client.ProtoBuf.csproj" />

--- a/Samples/ksqlDB.RestApi.Client.Sample/ksqlDB.RestApi.Client.Samples.csproj
+++ b/Samples/ksqlDB.RestApi.Client.Sample/ksqlDB.RestApi.Client.Samples.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="ksqlDb.RestApi.Client" Version="6.2.0" />
+        <PackageReference Include="ksqlDb.RestApi.Client" Version="6.3.0-rc.1" />
         <!-- <ProjectReference Include="..\..\ksqlDb.RestApi.Client\ksqlDb.RestApi.Client.csproj" /> -->
         <!-- <PackageReference Include="ksqlDb.RestApi.Client.ProtoBuf" Version="4.0.0" /> -->
         <ProjectReference Include="..\..\ksqlDb.RestApi.Client.ProtoBuf\ksqlDb.RestApi.Client.ProtoBuf.csproj" />

--- a/Tests/ksqlDB.RestApi.Client.Tests/FluentAPI/Builders/ModelBuilderTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/FluentAPI/Builders/ModelBuilderTests.cs
@@ -234,6 +234,37 @@ namespace ksqlDb.RestApi.Client.Tests.FluentAPI.Builders
 
       metadata.HasHeaders.Should().BeTrue();
     }
+
+    private record KeyValuePair
+    {
+      public string Key { get; set; } = null!;
+      public byte[] Value { get; set; } = null!;
+    }
+
+    private record Record
+    {
+      public KeyValuePair[] Headers { get; init; } = null!;
+    }
+
+    [Test]
+    public void AsStruct()
+    {
+      //Arrange
+
+      //Act
+      var fieldTypeBuilder = builder.Entity<Record>()
+        .Property(b => b.Headers)
+        .AsStruct();
+
+      //Assert
+      fieldTypeBuilder.Should().NotBeNull();
+
+      var entityMetadata = ((IMetadataProvider)builder).GetEntities().FirstOrDefault(c => c.Type == typeof(Record));
+      entityMetadata.Should().NotBeNull();
+
+      var metadata = entityMetadata!.FieldsMetadata.First(c => c.IsStruct && c.Path == "Headers");
+      metadata.IsStruct.Should().BeTrue();
+    }
   }
 
   internal record Payment

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/KSqlTypeTranslatorTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/KSqlTypeTranslatorTests.cs
@@ -12,7 +12,7 @@ namespace ksqlDb.RestApi.Client.Tests.KSql.RestApi.Statements
   public class KSqlTypeTranslatorTests
   {
     private ModelBuilder modelBuilder = null!;
-    private KSqlTypeTranslator kSqlTypeTranslator = null!;
+    private KSqlTypeTranslator<Poco> kSqlTypeTranslator = null!;
 
     [SetUp]
     public void Init()
@@ -396,7 +396,7 @@ namespace ksqlDb.RestApi.Client.Tests.KSql.RestApi.Statements
         .Decimal(10, 2);
 
       //Act
-      string ksqlType = kSqlTypeTranslator.Translate(type);
+      string ksqlType = kSqlTypeTranslator.Translate(type, type.GetMember(nameof(Poco.Amount))[0]);
 
       //Assert
       ksqlType.Should().Be($"{KSqlTypes.Struct}<{nameof(Poco.Amount)} {KSqlTypes.Decimal}(10,2)>");

--- a/docs/modelbuilder.md
+++ b/docs/modelbuilder.md
@@ -278,7 +278,7 @@ VALUES ('1', 33, 'Purchase');
 ```
 
 ### AsSource
-**v6.2.0**
+**v6.3.0**
 
 The `AsSource` function designates fields in entity types as ksqlDB struct types.
 

--- a/docs/modelbuilder.md
+++ b/docs/modelbuilder.md
@@ -277,12 +277,12 @@ INSERT INTO Payments (Id, Amount, Desc)
 VALUES ('1', 33, 'Purchase');
 ```
 
-### AsSource
+### AsStruct
 **v6.3.0**
 
-The `AsSource` function designates fields in entity types as ksqlDB struct types.
+The `AsStruct` function designates fields in entity types as ksqlDB struct types.
 
-The following code showcases how to use the `AsSource` method in the fluent API to infer the underlying `ksqlDB` type as a struct during code generation:
+The following code showcases how to use the `AsStruct` method in the fluent API to infer the underlying `ksqlDB` type as a struct during code generation:
 
 ```C#
 private record KeyValuePair

--- a/docs/modelbuilder.md
+++ b/docs/modelbuilder.md
@@ -96,6 +96,34 @@ CREATE TABLE IF NOT EXISTS Accounts (
 ) WITH ( KAFKA_TOPIC='Account', VALUE_FORMAT='Json', PARTITIONS='1', REPLICAS='3' );
 ```
 
+## Dependency injection
+This setup ensures that the `ksqlDB` client, context, and model configuration are properly injected throughout your application.
+
+```C#
+using ksqlDb.RestApi.Client.DependencyInjection;
+using ksqlDb.RestApi.Client.FluentAPI.Builders;
+using ksqlDB.RestApi.Client.KSql.Query.Options;
+using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
+
+var builder = WebApplication.CreateBuilder(args);
+
+ModelBuilder modelBuilder = new();
+
+builder.Services.ConfigureKSqlDb(
+  builder.Configuration.GetConnectionString("KafkaConnection")!,
+  parameters =>
+  {
+    parameters
+      .SetAutoOffsetReset(AutoOffsetReset.Latest)
+      .SetIdentifierEscaping(IdentifierEscaping.Always)
+      .SetJsonSerializerOptions(options =>
+      {
+        options.PropertyNameCaseInsensitive = true;
+      });
+  }
+).AddSingleton(modelBuilder);
+```
+
 ## IFromItemTypeConfiguration
 **v5.0.0**
 
@@ -247,4 +275,45 @@ The KSQL snippet illustrates an example INSERT statement with the overridden col
 ```SQL
 INSERT INTO Payments (Id, Amount, Desc)
 VALUES ('1', 33, 'Purchase');
+```
+
+### AsSource
+**v6.2.0**
+
+The `AsSource` function designates fields in entity types as ksqlDB struct types.
+
+The following code showcases how to use the `AsSource` method in the fluent API to infer the underlying `ksqlDB` type as a struct during code generation:
+
+```C#
+private record KeyValuePair
+{
+  public string Key { get; set; } = null!;
+  public byte[] Value { get; set; } = null!;
+}
+
+private record Record
+{
+  public KeyValuePair[] Headers { get; init; } = null!;
+}
+```
+
+```C#
+ModelBuilder builder = new();
+ 
+builder.Entity<Record>()
+        .Property(b => b.Headers)
+        .AsStruct();
+        
+var creationMetadata = new EntityCreationMetadata("my_topic", partitions: 3);
+
+var ksql = new StatementGenerator(builder).CreateTable<Record>(creationMetadata, ifNotExists: true);
+```
+
+The KSQL snippet illustrates an example CREATE TABLE statement with the injected `STRUCT` type,
+showing how it corresponds to the fluent API configuration:
+
+```SQL
+CREATE TABLE IF NOT EXISTS Records (
+	  Headers ARRAY<STRUCT<Key VARCHAR, Value BYTES>>
+) WITH ( KAFKA_TOPIC='my_topic', VALUE_FORMAT='Json', PARTITIONS='3' );
 ```

--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -1,9 +1,12 @@
 # ksqlDB.RestApi.Client
 
+# 6.3.0-rc.1
+- added `AsStruct` function to the Fluent API for marking fields as ksqldb `STRUCT` types
+
 # 6.2.1
 
 ## BugFix
-- Source table can't be queried #87 - fixed `KSqlDbRestApiClient.CreateSourceTableAsync` and `KSqlDbRestApiClient.CreateSourceStreamAsync`
+- source table can't be queried #87 - fixed `KSqlDbRestApiClient.CreateSourceTableAsync` and `KSqlDbRestApiClient.CreateSourceStreamAsync`
 
 # 6.2.0
 

--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -1,6 +1,6 @@
 # ksqlDB.RestApi.Client
 
-# 6.3.0-rc.1
+# 6.3.0
 - added `AsStruct` function to the Fluent API for marking fields as ksqldb `STRUCT` types #89 (proposed by @mrt181)
 
 # 6.2.1

--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -1,7 +1,7 @@
 # ksqlDB.RestApi.Client
 
 # 6.3.0-rc.1
-- added `AsStruct` function to the Fluent API for marking fields as ksqldb `STRUCT` types
+- added `AsStruct` function to the Fluent API for marking fields as ksqldb `STRUCT` types #89 (proposed by @mrt181)
 
 # 6.2.1
 

--- a/ksqlDb.RestApi.Client/FluentAPI/Builders/FieldTypeBuilder.cs
+++ b/ksqlDb.RestApi.Client/FluentAPI/Builders/FieldTypeBuilder.cs
@@ -26,6 +26,12 @@ namespace ksqlDb.RestApi.Client.FluentAPI.Builders
     /// <param name="columnName">The name of the column in the record schema.</param>
     /// <returns>The same <see cref="IFieldTypeBuilder{TProperty}"/> instance so that multiple calls can be chained.</returns>
     IFieldTypeBuilder<TProperty> HasColumnName(string columnName);
+
+    /// <summary>
+    /// Marks the field as a ksqldb STRUCT type.
+    /// </summary>
+    /// <returns>The field type builder for chaining additional configuration.</returns>
+    IFieldTypeBuilder<TProperty> AsStruct();
   }
 
   internal class FieldTypeBuilder<TProperty>(FieldMetadata fieldMetadata)
@@ -34,6 +40,12 @@ namespace ksqlDb.RestApi.Client.FluentAPI.Builders
     public IFieldTypeBuilder<TProperty> HasColumnName(string columnName)
     {
       fieldMetadata.ColumnName = columnName;
+      return this;
+    }
+
+    public IFieldTypeBuilder<TProperty> AsStruct()
+    {
+      fieldMetadata.IsStruct = true;
       return this;
     }
 

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Generators/TypeGenerator.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Generators/TypeGenerator.cs
@@ -11,8 +11,6 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi.Generators;
 
 internal sealed class TypeGenerator(IMetadataProvider metadataProvider) : EntityInfo(metadataProvider)
 {
-  private readonly KSqlTypeTranslator typeTranslator = new(metadataProvider);
-
   internal string Print<T>(TypeProperties properties)
   {
     StringBuilder stringBuilder = new();
@@ -30,11 +28,13 @@ internal sealed class TypeGenerator(IMetadataProvider metadataProvider) : Entity
   {
     var ksqlProperties = new List<string>();
 
+    KSqlTypeTranslator<T> typeTranslator = new(metadataProvider);
+
     foreach (var memberInfo in Members<T>())
     {
       var type = GetMemberType(memberInfo);
 
-      var ksqlType = typeTranslator.Translate(type, escaping);
+      var ksqlType = typeTranslator.Translate(type, memberInfo, escaping);
 
       var memberName = memberInfo.GetMemberName(metadataProvider);
       var columnDefinition = $"{EscapeName(memberName, escaping)} {ksqlType}{typeTranslator.ExploreAttributes(typeof(T), memberInfo, type)}";

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntity.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntity.cs
@@ -13,8 +13,6 @@ internal sealed class CreateEntity(IMetadataProvider metadataProvider) : EntityI
 {
   private readonly StringBuilder stringBuilder = new();
 
-  private readonly KSqlTypeTranslator typeTranslator = new(metadataProvider);
-
   internal string Print<T>(StatementContext statementContext, EntityCreationMetadata metadata, bool? ifNotExists)
   {
     stringBuilder.Clear();
@@ -42,12 +40,13 @@ internal sealed class CreateEntity(IMetadataProvider metadataProvider) : EntityI
   private void PrintProperties<T>(StatementContext statementContext, EntityCreationMetadata metadata)
   {
     var ksqlProperties = new List<string>();
+    KSqlTypeTranslator<T> typeTranslator = new(metadataProvider);
 
     foreach (var memberInfo in Members<T>(metadata.IncludeReadOnlyProperties))
     {
       var type = GetMemberType(memberInfo);
 
-      var ksqlType = typeTranslator.Translate(type, metadata.IdentifierEscaping);
+      var ksqlType = typeTranslator.Translate(type, memberInfo, metadata.IdentifierEscaping);
 
       var columnName = IdentifierUtil.Format(memberInfo, metadata.IdentifierEscaping, metadataProvider);
       string columnDefinition = $"\t{columnName} {ksqlType}{typeTranslator.ExploreAttributes(typeof(T), memberInfo, type)}";

--- a/ksqlDb.RestApi.Client/Metadata/FieldMetadata.cs
+++ b/ksqlDb.RestApi.Client/Metadata/FieldMetadata.cs
@@ -7,6 +7,7 @@ namespace ksqlDb.RestApi.Client.Metadata
     internal MemberInfo MemberInfo { get; init; } = null!;
     public bool Ignore { get; internal set; }
     public bool HasHeaders { get; internal set; }
+    internal bool IsStruct { get; set; }
     internal string Path { get; init; } = null!;
     internal string FullPath { get; init; } = null!;
     public string? ColumnName { get; set; }

--- a/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
+++ b/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
@@ -15,7 +15,7 @@
             Documentation for the library can be found at https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/README.md.
         </Description>
         <PackageTags>ksql ksqlDB LINQ .NET csharp push query</PackageTags>
-        <Version>6.3.0-rc.1</Version>
+        <Version>6.3.0</Version>
         <AssemblyVersion>6.3.0.0</AssemblyVersion>
         <LangVersion>12.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
+++ b/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
@@ -15,8 +15,8 @@
             Documentation for the library can be found at https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/README.md.
         </Description>
         <PackageTags>ksql ksqlDB LINQ .NET csharp push query</PackageTags>
-        <Version>6.2.1</Version>
-        <AssemblyVersion>6.2.0.0</AssemblyVersion>
+        <Version>6.3.0-rc.1</Version>
+        <AssemblyVersion>6.3.0.0</AssemblyVersion>
         <LangVersion>12.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <PackageReleaseNotes>https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/ksqlDb.RestApi.Client/ChangeLog.md</PackageReleaseNotes>


### PR DESCRIPTION
Added `AsStruct` function to the Fluent API for marking fields as `ksqldb` `STRUCT` types #89 @mrt181