### PR TITLE
90 specify ignorebyinserts using the model builder

### DIFF
--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/ModelBuilderTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/ModelBuilderTests.cs
@@ -9,7 +9,6 @@ using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
 using ksqlDB.RestApi.Client.KSql.RestApi.Http;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NUnit.Framework;
 
 namespace ksqlDb.RestApi.Client.IntegrationTests.KSql.Linq

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/Models/Record.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/Models/Record.cs
@@ -1,9 +1,10 @@
-﻿using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Annotations;
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Annotations;
 
 namespace ksqlDb.RestApi.Client.IntegrationTests.Models;
 
 public record Record
 {
-  [IgnoreByInserts]
+  [ksqlDB.RestApi.Client.KSql.RestApi.Statements.Annotations.Ignore]
+  [PseudoColumn]
   public long RowTime { get; set; }
 }

--- a/Tests/ksqlDB.RestApi.Client.Tests/FluentAPI/Builders/ModelBuilderTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/FluentAPI/Builders/ModelBuilderTests.cs
@@ -68,6 +68,23 @@ namespace ksqlDb.RestApi.Client.Tests.FluentAPI.Builders
     }
 
     [Test]
+    public void Property_IgnoreByInsertsField()
+    {
+      //Arrange
+
+      //Act
+      var fieldTypeBuilder = builder.Entity<Payment>()
+        .Property(b => b.Description)
+        .IgnoreInDML();
+
+      //Assert
+      fieldTypeBuilder.Should().NotBeNull();
+      var entityMetadata = ((IMetadataProvider)builder).GetEntities().FirstOrDefault(c => c.Type == typeof(Payment));
+      entityMetadata.Should().NotBeNull();
+      entityMetadata!.FieldsMetadata.First(c => c.MemberInfo.Name == nameof(Payment.Description)).IgnoreInDML.Should().BeTrue();
+    }
+
+    [Test]
     public void Property_HasColumnName()
     {
       //Arrange
@@ -233,6 +250,7 @@ namespace ksqlDb.RestApi.Client.Tests.FluentAPI.Builders
       var metadata = entityMetadata!.FieldsMetadata.First(c => c.MemberInfo.Name == nameof(Payment.Header));
 
       metadata.HasHeaders.Should().BeTrue();
+      metadata.IgnoreInDML.Should().BeTrue();
     }
 
     private record KeyValuePair

--- a/Tests/ksqlDB.RestApi.Client.Tests/FluentAPI/Builders/ModelBuilderTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/FluentAPI/Builders/ModelBuilderTests.cs
@@ -50,7 +50,7 @@ namespace ksqlDb.RestApi.Client.Tests.FluentAPI.Builders
     }
 
     [Test]
-    public void Property_IgnoreField()
+    public void Property_Ignore()
     {
       //Arrange
 
@@ -68,7 +68,7 @@ namespace ksqlDb.RestApi.Client.Tests.FluentAPI.Builders
     }
 
     [Test]
-    public void Property_IgnoreByInsertsField()
+    public void Property_IgnoreInDML()
     {
       //Arrange
 

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/CreateInsertTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/CreateInsertTests.cs
@@ -156,15 +156,15 @@ public class CreateInsertTests
     public string Name { get; set; } = null!;
   }
 
-  public static IEnumerable<(IdentifierEscaping, string)> GenerateIgnoreByInsertsTestCases()
+  public static IEnumerable<(IdentifierEscaping, string)> GenerateIgnoreInDMLTestCases()
   {
     yield return (Never, "INSERT INTO Actors (Id) VALUES (1);");
     yield return (Keywords, "INSERT INTO Actors (Id) VALUES (1);");
     yield return (Always, "INSERT INTO `Actors` (`Id`) VALUES (1);");
   }
 
-  [TestCaseSource(nameof(GenerateIgnoreByInsertsTestCases))]
-  public void Generate_UseModelBuilder_IgnoreByInserts((IdentifierEscaping escaping, string expected) testCase)
+  [TestCaseSource(nameof(GenerateIgnoreInDMLTestCases))]
+  public void Generate_UseModelBuilder_IgnoreInDML((IdentifierEscaping escaping, string expected) testCase)
   {
     //Arrange
     modelBuilder.Entity<Actor>()

--- a/Tests/ksqlDB.RestApi.Client.Tests/Models/Movies/Movie.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/Models/Movies/Movie.cs
@@ -4,14 +4,14 @@ namespace ksqlDb.RestApi.Client.Tests.Models.Movies;
 
 public class Movie
 { 
-  [IgnoreByInserts]
+  [ksqlDB.RestApi.Client.KSql.RestApi.Statements.Annotations.Ignore]
   public long RowTime { get; set; }
   public string Title { get; set; } = null!;
   [Key]
   public int Id { get; set; }
   public int Release_Year { get; set; }
 
-  [IgnoreByInserts]
+  [ksqlDB.RestApi.Client.KSql.RestApi.Statements.Annotations.Ignore]
   public int IgnoreMe { get; set; }
 
   public IEnumerable<int> ReadOnly { get; } = new[] { 1, 2 };

--- a/docs/ksqldbrestapiclient.md
+++ b/docs/ksqldbrestapiclient.md
@@ -1311,3 +1311,22 @@ var restApiClientOptions = new KSqlDBRestApiClientOptions
 };
 servicesCollection.AddSingleton(restApiClientOptions);
 ```
+
+
+## IgnoreAttribute
+**v6.4.0**
+
+Properties and fields decorated with the `IgnoreAttribute` are excluded from both DDL and DML statements.
+
+```C#
+public class Movie
+{
+  [ksqlDB.RestApi.Client.KSql.RestApi.Statements.Annotations.Key]
+  public int Id { get; set; }
+  public string Title { get; set; }
+  public int Release_Year { get; set; }
+	
+  [ksqlDB.RestApi.Client.KSql.RestApi.Statements.Annotations.Ignore]
+  public int IgnoredProperty { get; set; }
+}
+```

--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -1,5 +1,13 @@
 # ksqlDB.RestApi.Client
 
+# 6.4.0
+- added the `IgnoreInDML` function to the Fluent API to exclude fields from INSERT statements #90 (proposed by @mrt181)
+- added `IgnoreAttribute` to prevent properties or fields from being included in both DDL and DML statement
+- `Headers` property was marked as obsolete in the `Record` type
+
+## BugFix
+- `IgnoreByInsertsAttribute` no longer excludes fields or properties from DDL statements. For this purpose, a new `IgnoreAttribute` has been introduced.
+ 
 # 6.3.0
 - added `AsStruct` function to the Fluent API for marking fields as ksqldb `STRUCT` types #89 (proposed by @mrt181)
 

--- a/ksqlDb.RestApi.Client/FluentAPI/Builders/FieldTypeBuilder.cs
+++ b/ksqlDb.RestApi.Client/FluentAPI/Builders/FieldTypeBuilder.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using ksqlDb.RestApi.Client.Metadata;
 
 namespace ksqlDb.RestApi.Client.FluentAPI.Builders
@@ -9,10 +10,16 @@ namespace ksqlDb.RestApi.Client.FluentAPI.Builders
   public interface IFieldTypeBuilder<TProperty>
   {
     /// <summary>
-    /// Marks the field as ignored, excluding it from the entity's schema.
+    /// Marks the field as ignored, excluding it from the entity's schema, preventing it from being included in both DDL and DML statements. 
     /// </summary>
     /// <returns>The field type builder for chaining additional configuration.</returns>
     public IFieldTypeBuilder<TProperty> Ignore();
+
+    /// <summary>
+    /// Marks the field to be excluded from data manipulation operations, preventing it from being included in DML statements such as INSERT.
+    /// </summary>
+    /// <returns>The field type builder for chaining additional configuration.</returns>
+    public IFieldTypeBuilder<TProperty> IgnoreInDML();
 
     /// <summary>
     /// Marks the field as HEADERS.
@@ -55,9 +62,16 @@ namespace ksqlDb.RestApi.Client.FluentAPI.Builders
       return this;
     }
 
+    public IFieldTypeBuilder<TProperty> IgnoreInDML()
+    {
+      fieldMetadata.IgnoreInDML = true;
+      return this;
+    }
+
     public IFieldTypeBuilder<TProperty> WithHeaders()
     {
       fieldMetadata.HasHeaders = true;
+      IgnoreInDML();
       return this;
     }
   }

--- a/ksqlDb.RestApi.Client/KSql/Query/Record.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Record.cs
@@ -12,6 +12,7 @@ public class Record
   /// </summary>
   [IgnoreByInserts]
   [PseudoColumn]
+  [Obsolete("This property will be removed in the future. Headers need to be defined per use case and should have the type ARRAY<STRUCT<key STRING, value BYTES>>.")]
   public string? Headers { get; set; }
 
   /// <summary>

--- a/ksqlDb.RestApi.Client/KSql/Query/Record.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Record.cs
@@ -10,6 +10,7 @@ public class Record
   /// <summary>
   /// Columns that are populated by the Kafka record's header.
   /// </summary>
+  [Ignore]
   [IgnoreByInserts]
   [PseudoColumn]
   [Obsolete("This property will be removed in the future. Headers need to be defined per use case and should have the type ARRAY<STRUCT<key STRING, value BYTES>>.")]
@@ -18,6 +19,7 @@ public class Record
   /// <summary>
   /// The offset of the source record.
   /// </summary>
+  [Ignore]
   [IgnoreByInserts]
   [PseudoColumn]
   public long? RowOffset { get; set; }
@@ -25,6 +27,7 @@ public class Record
   /// <summary>
   /// The partition of the source record.
   /// </summary>
+  [Ignore]
   [IgnoreByInserts]
   [PseudoColumn]
   public short? RowPartition { get; set; }
@@ -32,6 +35,7 @@ public class Record
   /// <summary>
   /// Row timestamp, inferred from the underlying Kafka record if not overridden.
   /// </summary>
+  [Ignore]
   [IgnoreByInserts]
   [PseudoColumn]
   public long RowTime { get; set; }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Extensions/MemberInfoExtensions.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Extensions/MemberInfoExtensions.cs
@@ -12,8 +12,8 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi.Extensions
     /// </summary>
     /// <param name="memberInfo"></param>
     /// <param name="escaping"></param>
-    /// <param name="modelBuilder"></param>
+    /// <param name="metadataProvider"></param>
     /// <returns>the <c>memberInfo.Name</c> modified based on the provided <c>format</c></returns>
-    public static string Format(this MemberInfo memberInfo, IdentifierEscaping escaping, ModelBuilder modelBuilder) => IdentifierUtil.Format(memberInfo, escaping, modelBuilder);
+    public static string Format(this MemberInfo memberInfo, IdentifierEscaping escaping, IMetadataProvider metadataProvider) => IdentifierUtil.Format(memberInfo, escaping, metadataProvider);
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Annotations/IgnoreAttribute.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/Annotations/IgnoreAttribute.cs
@@ -1,0 +1,7 @@
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements.Annotations
+{
+  [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+  public sealed class IgnoreAttribute : Attribute
+  {
+  }
+}

--- a/ksqlDb.RestApi.Client/Metadata/BytesArrayFieldMetadata.cs
+++ b/ksqlDb.RestApi.Client/Metadata/BytesArrayFieldMetadata.cs
@@ -3,11 +3,8 @@ namespace ksqlDb.RestApi.Client.Metadata
   internal sealed record BytesArrayFieldMetadata : FieldMetadata
   {
     public BytesArrayFieldMetadata(FieldMetadata fieldMetadata)
+      : base(fieldMetadata)
     {
-      MemberInfo = fieldMetadata.MemberInfo;
-      Ignore = fieldMetadata.Ignore;
-      Path = fieldMetadata.Path;
-      FullPath = fieldMetadata.FullPath;
     }
 
     public string? Header { get; internal set; }

--- a/ksqlDb.RestApi.Client/Metadata/DecimalFieldMetadata.cs
+++ b/ksqlDb.RestApi.Client/Metadata/DecimalFieldMetadata.cs
@@ -3,11 +3,8 @@ namespace ksqlDb.RestApi.Client.Metadata
   internal sealed record DecimalFieldMetadata : FieldMetadata
   {
     public DecimalFieldMetadata(FieldMetadata fieldMetadata)
+     : base(fieldMetadata)
     {
-      MemberInfo = fieldMetadata.MemberInfo;
-      Ignore = fieldMetadata.Ignore;
-      Path = fieldMetadata.Path;
-      FullPath = fieldMetadata.FullPath;
     }
 
     public short Precision { get; internal set; }

--- a/ksqlDb.RestApi.Client/Metadata/FieldMetadata.cs
+++ b/ksqlDb.RestApi.Client/Metadata/FieldMetadata.cs
@@ -4,8 +4,21 @@ namespace ksqlDb.RestApi.Client.Metadata
 {
   internal record FieldMetadata
   {
+    public FieldMetadata(FieldMetadata fieldMetadata)
+    {
+      MemberInfo = fieldMetadata.MemberInfo;
+      Ignore = fieldMetadata.Ignore;
+      IgnoreInDML = fieldMetadata.IgnoreInDML;
+      HasHeaders = fieldMetadata.HasHeaders;
+      IsStruct = fieldMetadata.IsStruct;
+      Path = fieldMetadata.Path;
+      FullPath = fieldMetadata.FullPath;
+      ColumnName = fieldMetadata.ColumnName;
+    }
+
     internal MemberInfo MemberInfo { get; init; } = null!;
     public bool Ignore { get; internal set; }
+    public bool IgnoreInDML { get; internal set; }
     public bool HasHeaders { get; internal set; }
     internal bool IsStruct { get; set; }
     internal string Path { get; init; } = null!;

--- a/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
+++ b/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
@@ -15,8 +15,8 @@
             Documentation for the library can be found at https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/README.md.
         </Description>
         <PackageTags>ksql ksqlDB LINQ .NET csharp push query</PackageTags>
-        <Version>6.3.0</Version>
-        <AssemblyVersion>6.3.0.0</AssemblyVersion>
+        <Version>6.4.0</Version>
+        <AssemblyVersion>6.4.0.0</AssemblyVersion>
         <LangVersion>12.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <PackageReleaseNotes>https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/ksqlDb.RestApi.Client/ChangeLog.md</PackageReleaseNotes>


### PR DESCRIPTION
- added the `IgnoreInDML` function to the Fluent API to exclude fields from INSERT statements #90 (proposed by @mrt181)
- added `IgnoreAttribute` to prevent properties or fields from being included in both DDL and DML statement
- `Headers` property was marked as obsolete in the `Record` type

## BugFix
- `IgnoreByInsertsAttribute` no longer excludes fields or properties from DDL statements. For this purpose, a new `IgnoreAttribute` has been introduced. 

 #90 @mrt181