### PR TITLE
fix: check for ModelBuilder set PseudoColumns

### DIFF
--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -8,7 +8,12 @@
 ## 💥 Breaking changes
 - removed usupported .NET 6.0, and 7.0 target frameworks
 - upgraded Microsoft packages to v9.0.0: `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Http`, and `Microsoft.Extensions.Logging.Abstractions`
-- upgraded `System.Text.Json` to v9.0.0 
+- upgraded `System.Text.Json` to v9.0.0
+
+# 6.5.2
+
+## 🐛 Bug Fixes
+- fixed `IdentifierUtil.IsPseudoColumn` to handle PseudoColumns that are set using `ModelBuilder` correctly
 
 # 6.5.1
 

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parsers/IdentifierUtil.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parsers/IdentifierUtil.cs
@@ -96,7 +96,8 @@ namespace ksqlDb.RestApi.Client.KSql.RestApi.Parsers
       if (memberInfo.GetCustomAttribute<PseudoColumnAttribute>() != null)
         return true;
 
-      var entityMetadata = metadataProvider?.GetEntities().FirstOrDefault(c => c.Type == memberInfo.DeclaringType);
+      var entityMetadata = metadataProvider?.GetEntities().FirstOrDefault(c =>
+        c.FieldsMetadata.FirstOrDefault(fmd => fmd.Path == memberInfo.Name)?.IsPseudoColumn ?? false);
 
       var fieldMetadata =
         entityMetadata?.FieldsMetadata.FirstOrDefault(c => c.MemberInfo.Name == memberInfo.Name);


### PR DESCRIPTION
PseudoColumns must not be escaped but the check using modelbuilder provided information did not work.