### PR TITLE
refactor: make BasicAuth(UsernName|Password) properties public

### DIFF
--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/KSqlDBContextOptionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/KSqlDBContextOptionsTests.cs
@@ -32,7 +32,7 @@ public class KSqlDBContextOptionsTests : TestBase<KSqlDBContextOptions>
     //Assert
     url.Should().Be(TestParameters.KsqlDbUrl);
   }
-    
+
   [Test]
   public void NotSetBasicAuthCredentials()
   {
@@ -45,7 +45,7 @@ public class KSqlDBContextOptionsTests : TestBase<KSqlDBContextOptions>
     ClassUnderTest.BasicAuthUserName.Should().BeEmpty();
     ClassUnderTest.BasicAuthPassword.Should().BeEmpty();
   }
-    
+
   [Test]
   public void SetBasicAuthCredentials()
   {
@@ -61,6 +61,20 @@ public class KSqlDBContextOptionsTests : TestBase<KSqlDBContextOptions>
     ClassUnderTest.UseBasicAuth.Should().BeTrue();
     ClassUnderTest.BasicAuthUserName.Should().Be(userName);
     ClassUnderTest.BasicAuthPassword.Should().Be(password);
+  }
+
+  [Test]
+  public void SetBasicAuthCredentialsDirectly()
+  {
+    //Arrange
+
+    //Act
+    ClassUnderTest.UseBasicAuth = true;
+
+    //Assert
+    ClassUnderTest.UseBasicAuth.Should().BeTrue();
+    ClassUnderTest.BasicAuthUserName.Should().BeEmpty();
+    ClassUnderTest.BasicAuthPassword.Should().BeEmpty();
   }
 
   [Test]

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/Options/KSqlDbContextOptionsBuilderTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/Options/KSqlDbContextOptionsBuilderTests.cs
@@ -80,6 +80,20 @@ public class KSqlDbContextOptionsBuilderTests : TestBase<KSqlDbContextOptionsBui
   }
 
   [Test]
+  public void SetBasicAuth()
+  {
+    //Arrange
+
+    //Act
+    var options = ClassUnderTest.UseKSqlDb(TestParameters.KsqlDbUrl).SetBasicAuth().Options;
+
+    //Assert
+    options.UseBasicAuth.Should().BeTrue();
+    options.BasicAuthUserName.Should().BeEmpty();
+    options.BasicAuthPassword.Should().BeEmpty();
+  }
+
+  [Test]
   public void SetProcessingGuarantee()
   {
     //Arrange

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Http/BasicAuthCredentialsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Http/BasicAuthCredentialsTests.cs
@@ -29,7 +29,7 @@ public class BasicAuthCredentialsTests : TestBase
     var credentials = new BasicAuthCredentials("fred", "letmein");
 
     //Act
-    var token = credentials.Schema;
+    var token = BasicAuthCredentials.Schema;
 
     //Assert
     token.Should().Be("basic");

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Http/BasicAuthHandlerTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Http/BasicAuthHandlerTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using ksqlDB.RestApi.Client.KSql.Query.Context;
 using ksqlDB.RestApi.Client.KSql.RestApi.Http;
 using NUnit.Framework;
 using UnitTests;
@@ -11,9 +12,10 @@ public class BasicAuthHandlerTests : TestBase
   public async Task SendAsync()
   {
     //Arrange
-    var credentials = new BasicAuthCredentials("fred", "letmein");
+    var options = new KSqlDBContextOptions("https://tests.com/");
+    options.SetBasicAuthCredentials("fred", "letmein");
 
-    var handler = new BasicAuthHandler(credentials);
+    var handler = new BasicAuthHandler(options);
     handler.InnerHandler = new HttpClientHandler();
     var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://tests.com/");
     var invoker = new HttpMessageInvoker(handler);

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Http/HttpClientFactoryWithBasicAuthTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Http/HttpClientFactoryWithBasicAuthTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using ksqlDB.RestApi.Client.KSql.Query.Context;
 using ksqlDB.RestApi.Client.KSql.RestApi.Http;
 using NUnit.Framework;
 using UnitTests;
@@ -12,9 +13,13 @@ public class HttpClientFactoryWithBasicAuthTests : TestBase
   public void CreateClient_BaseAddressWasSet()
   {
     //Arrange
-    var credentials = new BasicAuthCredentials("fred", "letmein");
+    var options = new KSqlDBContextOptions(TestParameters.KsqlDbUrl);
+    options.SetBasicAuthCredentials("fred", "letmein");
 
-    var httpClientFactory = new HttpClientFactoryWithBasicAuth(new Uri(TestParameters.KsqlDbUrl), credentials);
+    var httpClientFactory = new HttpClientFactoryWithBasicAuth(
+      new Uri(TestParameters.KsqlDbUrl),
+      options
+    );
 
     //Act
     var httpClient = httpClientFactory.CreateClient();

--- a/docs/ksqldbcontext.md
+++ b/docs/ksqldbcontext.md
@@ -105,6 +105,28 @@ var options = new KSqlDbContextOptionsBuilder()
 await using var context = new KSqlDBContext(options);
 ```
 
+**v7.1.0**
+
+You can also just activate the usage of the [Http-Basic authentication](https://docs.ksqldb.io/en/latest/operate-and-deploy/installation/server-config/security/#configuring-listener-for-http-basic-authenticationauthorization) mechanism but need to provide the credentials to the `KSqlDbContextOptions` directly. This allows to update the credentials at runtime by setting them on the `KSqlDbContextOptions` singleton instance.
+
+```C#
+using ksqlDB.RestApi.Client.KSql.Query.Context.Options;
+
+string ksqlDbUrl = @"http://localhost:8088";
+
+string userName = "fred";
+string password = "letmein";
+
+var options = new KSqlDbContextOptionsBuilder()
+  .UseKSqlDb(ksqlDbUrl)
+  .SetBasicAuth()
+  .Options;
+
+options.SetBasicAuthCredentials(userName, password);
+
+await using var context = new KSqlDBContext(options);
+```
+
 See also how to [intercept http requests](https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/wiki/Interception-of-HTTP-requests-in--ksqlDB.RestApi.Client-DotNet---Authentication)
 
 ### KSqlDbServiceCollectionExtensions - AddDbContext and AddDbContextFactory

--- a/ksqlDb.RestApi.Client/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/ksqlDb.RestApi.Client/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -37,12 +37,9 @@ internal static class ServiceCollectionExtensions
         httpClient.BaseAddress = uri;
       });
 
-      if (contextOptions.UseBasicAuth && !string.IsNullOrEmpty(contextOptions.BasicAuthUserName) && !string.IsNullOrEmpty(contextOptions.BasicAuthPassword))
+      if (contextOptions.UseBasicAuth)
       {
-        var basicAuthCredentials =
-          new BasicAuthCredentials(contextOptions.BasicAuthUserName!, contextOptions.BasicAuthPassword!);
-
-        httpClientV1Builder.AddHttpMessageHandler(_ => new BasicAuthHandler(basicAuthCredentials));
+        httpClientV1Builder.AddHttpMessageHandler(_ => new BasicAuthHandler(contextOptions));
       }
     }
 
@@ -56,12 +53,9 @@ internal static class ServiceCollectionExtensions
 #endif
       });
 
-      if (contextOptions.UseBasicAuth && !string.IsNullOrEmpty(contextOptions.BasicAuthUserName) && !string.IsNullOrEmpty(contextOptions.BasicAuthPassword))
+      if (contextOptions.UseBasicAuth)
       {
-        var basicAuthCredentials =
-          new BasicAuthCredentials(contextOptions.BasicAuthUserName!, contextOptions.BasicAuthPassword!);
-
-        httpClientBuilder.AddHttpMessageHandler(_ => new BasicAuthHandler(basicAuthCredentials));
+        httpClientBuilder.AddHttpMessageHandler(_ => new BasicAuthHandler(contextOptions));
       }
     }
 

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContextOptions.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContextOptions.cs
@@ -92,12 +92,18 @@ public sealed class KSqlDBContextOptions : KSqlDbProviderOptions
     optionsAction.Invoke(JsonSerializerOptions);
   }
 
-  public bool UseBasicAuth => userName != null || password != null;
+  public bool UseBasicAuth
+  {
+    get { return (userName != null || password != null) || _useBasicAuth; }
+    set { _useBasicAuth = value; }
+  }
 
   private string? userName;
   public string BasicAuthUserName => string.IsNullOrEmpty(userName) ? string.Empty : userName;
 
   private string? password;
+  private bool _useBasicAuth;
+
   public string BasicAuthPassword => string.IsNullOrEmpty(password) ? string.Empty : password;
 
   /// <summary>
@@ -110,7 +116,7 @@ public sealed class KSqlDBContextOptions : KSqlDbProviderOptions
 
   /// <summary>
   /// Sets the basic authentication credentials.
-  /// Note: Credentials are stored only when using <see cref="UseBasicAuth"/>.
+  /// Note: Credentials are used when using <see cref="UseBasicAuth"/>.
   /// </summary>
   /// <param name="userName">The username.</param>
   /// <param name="password">The password.</param>

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/Options/ISetupParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/Options/ISetupParameters.cs
@@ -15,7 +15,7 @@ public interface ISetupParameters : ICreateOptions
   ISetupParameters SetProcessingGuarantee(ProcessingGuarantee processingGuarantee);
 
   /// <summary>
-  /// Allows you to configure the auto.offset.reset streams property. 
+  /// Allows you to configure the auto.offset.reset streams property.
   /// </summary>
   /// <param name="autoOffsetReset">The auto offset reset value to set.</param>
   /// <returns>Returns this instance.</returns>
@@ -37,7 +37,7 @@ public interface ISetupParameters : ICreateOptions
   ISetupParameters SetupPullQuery(Action<IPullQueryParameters> configure);
 
   /// <summary>
-  /// Allows you to set basic authentication credentials for an HTTP client. 
+  /// Allows you to set basic authentication credentials for an HTTP client.
   /// </summary>
   /// <param name="username">User name</param>
   /// <param name="password">Password</param>
@@ -61,4 +61,10 @@ public interface ISetupParameters : ICreateOptions
   /// As ksqlDB automatically converts all identifiers to uppercase by default, it's crucial to enclose them within backticks to maintain the desired casing.
   /// </summary>
   ISetupParameters SetIdentifierEscaping(IdentifierEscaping escaping);
+
+  /// <summary>
+  /// Allows you to set basic authentication usage through a DelegatingHandler
+  /// </summary>
+  /// <returns>Returns this instance.</returns>
+  ISetupParameters SetBasicAuth();
 }

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/Options/KSqlDbContextOptionsBuilder.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/Options/KSqlDbContextOptionsBuilder.cs
@@ -89,7 +89,7 @@ public class KSqlDbContextOptionsBuilder : ISetupParameters
   }
 
   /// <summary>
-  /// Allows you to set basic authentication credentials for an HTTP client. 
+  /// Allows you to set basic authentication credentials for an HTTP client.
   /// </summary>
   /// <param name="username">User name</param>
   /// <param name="password">Password</param>
@@ -141,13 +141,24 @@ public class KSqlDbContextOptionsBuilder : ISetupParameters
   }
 
   /// <summary>
-  /// Allows you to configure the auto.offset.reset streams property. 
+  /// Allows you to configure the auto.offset.reset streams property.
   /// </summary>
   /// <param name="autoOffsetReset">The auto offset reset value to set.</param>
   /// <returns>Returns this instance.</returns>
   ISetupParameters ISetupParameters.SetAutoOffsetReset(AutoOffsetReset autoOffsetReset)
   {
     InternalOptions.SetAutoOffsetReset(autoOffsetReset);
+
+    return this;
+  }
+
+  /// <summary>
+  /// Allows you to set basic authentication usage through an DelegatingHandler
+  /// </summary>
+  /// <returns>Returns this instance.</returns>
+  public ISetupParameters SetBasicAuth()
+  {
+    InternalOptions.UseBasicAuth = true;
 
     return this;
   }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Http/BasicAuthCredentials.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Http/BasicAuthCredentials.cs
@@ -6,6 +6,11 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi.Http;
 public record BasicAuthCredentials
 {
   /// <summary>
+  /// Gets the schema for basic authentication.
+  /// </summary>
+  public const string Schema = "basic";
+
+  /// <summary>
   /// Initializes a new instance of the <see cref="BasicAuthCredentials"/> class.
   /// </summary>
   /// <param name="userName">The username.</param>
@@ -27,11 +32,6 @@ public record BasicAuthCredentials
   public string Password { get; internal set; }
 
   /// <summary>
-  /// Gets the schema for basic authentication.
-  /// </summary>
-  public string Schema => "basic";
-
-  /// <summary>
   /// Creates a token for basic authentication.
   /// </summary>
   /// <returns>A base64 encoded string representing the username and password.</returns>
@@ -42,7 +42,7 @@ public record BasicAuthCredentials
     var bytes = System.Text.Encoding.UTF8.GetBytes(credentials);
 
     string base64Credentials = Convert.ToBase64String(bytes, 0, bytes.Length);
-      
+
     return base64Credentials;
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Http/BasicAuthHandler.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Http/BasicAuthHandler.cs
@@ -1,22 +1,31 @@
-﻿using System.Net.Http.Headers;
+using System.Net.Http.Headers;
+using ksqlDB.RestApi.Client.KSql.Query.Context;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Http;
 
 internal class BasicAuthHandler : DelegatingHandler
 {
-  private readonly BasicAuthCredentials basicAuthCredentials;
+  private readonly KSqlDBContextOptions options;
 
-  public BasicAuthHandler(BasicAuthCredentials basicAuthCredentials)
+  public BasicAuthHandler(KSqlDBContextOptions options)
   {
-    this.basicAuthCredentials = basicAuthCredentials ?? throw new ArgumentNullException(nameof(basicAuthCredentials));
+    this.options = options ?? throw new ArgumentNullException(nameof(options));
   }
-	
-  protected override Task<HttpResponseMessage> SendAsync(
-    HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
-  {
-    var token = basicAuthCredentials.CreateToken();
 
-    request.Headers.Authorization = new AuthenticationHeaderValue(basicAuthCredentials.Schema, token);
+  protected override Task<HttpResponseMessage> SendAsync(
+    HttpRequestMessage request,
+    CancellationToken cancellationToken
+  )
+  {
+    var token = new BasicAuthCredentials(
+      options.BasicAuthUserName,
+      options.BasicAuthPassword
+    ).CreateToken();
+
+    request.Headers.Authorization = new AuthenticationHeaderValue(
+      BasicAuthCredentials.Schema,
+      token
+    );
 
     return base.SendAsync(request, cancellationToken);
   }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Http/HttpClientFactoryWithBasicAuth.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Http/HttpClientFactoryWithBasicAuth.cs
@@ -1,21 +1,20 @@
-﻿namespace ksqlDB.RestApi.Client.KSql.RestApi.Http;
+using ksqlDB.RestApi.Client.KSql.Query.Context;
+
+namespace ksqlDB.RestApi.Client.KSql.RestApi.Http;
 
 internal class HttpClientFactoryWithBasicAuth : IHttpClientFactory
 {
   private readonly Uri uri;
-  private readonly BasicAuthCredentials basicAuthCredentials;
+  private readonly KSqlDBContextOptions options;
 
-  public HttpClientFactoryWithBasicAuth(Uri uri, BasicAuthCredentials basicAuthCredentials)
+  public HttpClientFactoryWithBasicAuth(Uri uri, KSqlDBContextOptions options)
   {
     this.uri = uri ?? throw new ArgumentNullException(nameof(uri));
-    this.basicAuthCredentials = basicAuthCredentials ?? throw new ArgumentNullException(nameof(basicAuthCredentials));
+    this.options = options ?? throw new ArgumentNullException(nameof(options));
   }
 
   public HttpClient CreateClient()
   {
-    return new HttpClient(new BasicAuthHandler(basicAuthCredentials))
-    {
-      BaseAddress = uri
-    };
+    return new HttpClient(new BasicAuthHandler(options)) { BaseAddress = uri };
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/KSqlDbRestApiClient.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/KSqlDbRestApiClient.cs
@@ -3,12 +3,13 @@ using System.Text;
 using System.Text.Json;
 using ksqlDb.RestApi.Client.FluentAPI.Builders;
 using ksqlDb.RestApi.Client.Infrastructure.Logging;
-using ksqlDb.RestApi.Client.KSql.RestApi.Generators.Asserts;
-using ksqlDb.RestApi.Client.KSql.RestApi.Responses.Asserts;
+using ksqlDB.RestApi.Client.KSql.Query.Context;
 using ksqlDB.RestApi.Client.KSql.RestApi.Extensions;
 using ksqlDB.RestApi.Client.KSql.RestApi.Generators;
+using ksqlDb.RestApi.Client.KSql.RestApi.Generators.Asserts;
 using ksqlDB.RestApi.Client.KSql.RestApi.Http;
 using ksqlDB.RestApi.Client.KSql.RestApi.Query;
+using ksqlDb.RestApi.Client.KSql.RestApi.Responses.Asserts;
 using ksqlDB.RestApi.Client.KSql.RestApi.Responses.Connectors;
 using ksqlDB.RestApi.Client.KSql.RestApi.Responses.Queries;
 using ksqlDB.RestApi.Client.KSql.RestApi.Responses.Query.Descriptors;
@@ -19,10 +20,9 @@ using ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Connectors;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Inserts;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
+using ksqlDb.RestApi.Client.KSql.RestApi.Statements.Providers;
 using Microsoft.Extensions.Logging;
 using IHttpClientFactory = ksqlDB.RestApi.Client.KSql.RestApi.Http.IHttpClientFactory;
-using ksqlDb.RestApi.Client.KSql.RestApi.Statements.Providers;
-using ksqlDB.RestApi.Client.KSql.Query.Context;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi;
 
@@ -177,7 +177,10 @@ public class KSqlDbRestApiClient : IKSqlDbRestApiClient
     {
       string basicAuthHeader = basicAuthCredentials.CreateToken();
 
-      httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue(basicAuthCredentials.Schema, basicAuthHeader);
+      httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue(
+        BasicAuthCredentials.Schema,
+        basicAuthHeader
+      );
     }
 
     return httpRequestMessage;


### PR DESCRIPTION
The context-options properties can be set but are not accessible. Currently the credentials are set during configuration of the library which triggers their usage. Although they can be set later at runtime when needed (e.g. fetching new credentials from key-vault), they are not updated on all use sides like `BasicAuthHandler`. The BasicAuth properties should be available to handle cases where credentials need to be updated at runtime.