### PR TITLE
fix: nested ignored struct fields are ignored in statements

### DIFF
--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -1,5 +1,10 @@
 # ksqlDB.RestApi.Client
 
+# 7.1.1
+
+## 🐛 Bug Fixes
+- fixed `EntityInfo.Members` to handle nested metadata definitions and `CreateEntity.PrintProperties` to ignore empty and invalid STRUCT columns. (contributed by @mrt181)
+
 # 7.1.0
 
 ## 🚀 New Features

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Generators/TypeGenerator.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Generators/TypeGenerator.cs
@@ -63,12 +63,12 @@ internal sealed class TypeGenerator : EntityInfo
       _ => throw new ArgumentOutOfRangeException(nameof(escaping), escaping, "Non-exhaustive match")
     };
 
-  protected override bool IncludeMemberInfo(EntityMetadata? entityMetadata, MemberInfo memberInfo)
+  protected override bool IncludeMemberInfo(Type type, EntityMetadata? entityMetadata, MemberInfo memberInfo, bool? includeReadOnly = null)
   {
     var fieldMetadata = entityMetadata?.GetFieldMetadataBy(memberInfo);
     if (fieldMetadata is { IgnoreInDDL: true })
       return false;
 
-    return base.IncludeMemberInfo(entityMetadata, memberInfo) && !memberInfo.GetCustomAttributes().OfType<IgnoreInDDLAttribute>().Any();
+    return base.IncludeMemberInfo(type, entityMetadata, memberInfo) && !memberInfo.GetCustomAttributes().OfType<IgnoreInDDLAttribute>().Any();
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntity.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntity.cs
@@ -108,12 +108,12 @@ internal sealed class CreateEntity : EntityInfo
     return $" {key}";
   }
 
-  protected override bool IncludeMemberInfo(EntityMetadata? entityMetadata, MemberInfo memberInfo)
+  protected override bool IncludeMemberInfo(Type type, EntityMetadata? entityMetadata, MemberInfo memberInfo, bool? includeReadOnly = null)
   {
     var fieldMetadata = entityMetadata?.GetFieldMetadataBy(memberInfo);
     if (fieldMetadata is { IgnoreInDDL: true })
       return false;
 
-    return base.IncludeMemberInfo(entityMetadata, memberInfo) && !memberInfo.GetCustomAttributes().OfType<IgnoreInDDLAttribute>().Any();
+    return base.IncludeMemberInfo(type, entityMetadata, memberInfo) && !memberInfo.GetCustomAttributes().OfType<IgnoreInDDLAttribute>().Any();
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
@@ -73,7 +73,7 @@ internal sealed class CreateInsert : EntityInfo
     var hasValue = insertValues.PropertyValues.ContainsKey(memberInfo.Format(insertProperties.IdentifierEscaping, metadataProvider));
 
     object value;
-    
+
     if (hasValue)
       value = insertValues.PropertyValues[memberInfo.Format(insertProperties.IdentifierEscaping, metadataProvider)];
     else
@@ -82,12 +82,12 @@ internal sealed class CreateInsert : EntityInfo
     return value;
   }
 
-  protected override bool IncludeMemberInfo(EntityMetadata? entityMetadata, MemberInfo memberInfo)
+  protected override bool IncludeMemberInfo(Type type, EntityMetadata? entityMetadata, MemberInfo memberInfo, bool? includeReadOnly = null)
   {
     var fieldMetadata = entityMetadata?.GetFieldMetadataBy(memberInfo);
     if (fieldMetadata is {IgnoreInDML: true})
       return false;
 
-    return base.IncludeMemberInfo(entityMetadata, memberInfo) && !memberInfo.GetCustomAttributes().OfType<IgnoreByInsertsAttribute>().Any();
+    return base.IncludeMemberInfo(type, entityMetadata, memberInfo) && !memberInfo.GetCustomAttributes().OfType<IgnoreByInsertsAttribute>().Any();
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/EntityInfo.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/EntityInfo.cs
@@ -3,6 +3,7 @@ using ksqlDb.RestApi.Client.FluentAPI.Builders;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Annotations;
 using ksqlDb.RestApi.Client.KSql.RestApi.Statements.Providers;
 using ksqlDb.RestApi.Client.Metadata;
+using ksqlDB.RestApi.Client.Infrastructure.Extensions;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 
@@ -26,15 +27,46 @@ internal class EntityInfo(IMetadataProvider metadataProvider)
 
     var members = properties.Concat(fields);
 
-    var entityMetadata = metadataProvider.GetEntities().FirstOrDefault(c => c.Type == type);
+    var entityMetadata = metadataProvider.GetEntities().FirstOrDefault(c => c.Type == type)
+                         ?? metadataProvider.GetEntities().FirstOrDefault(c => c.FieldsMetadata.Any(fm => fm.MemberInfo.DeclaringType == type));
 
-    return members.Where(memberInfo => IncludeMemberInfo(entityMetadata, memberInfo));
+    return members.Where(memberInfo => IncludeMemberInfo(type, entityMetadata, memberInfo, includeReadOnly));
   }
 
-  protected virtual bool IncludeMemberInfo(EntityMetadata? entityMetadata, MemberInfo memberInfo)
+  protected virtual bool IncludeMemberInfo(Type type, EntityMetadata? entityMetadata, MemberInfo memberInfo, bool? includeReadOnly = null)
   {
     var fieldMetadata = entityMetadata?.GetFieldMetadataBy(memberInfo);
+
+    var subType = GetMemberType(memberInfo);
+    if (!type.IsGenericType && IsStructType(subType, memberInfo))
+    {
+      var subMembers = Members(subType, includeReadOnly);
+
+      if(!subMembers.Any())
+        return false;
+    }
+
     return fieldMetadata is not {Ignore: true} && !memberInfo.GetCustomAttributes().OfType<IgnoreAttribute>().Any();
+  }
+
+  protected bool IsStructType(Type type, MemberInfo? memberInfo)
+  {
+    if (type.TryGetAttribute<StructAttribute>() != null)
+      return true;
+
+    if (memberInfo == null)
+      return false;
+
+    var entityMetadata =
+      metadataProvider.GetEntities().FirstOrDefault(c => c.Type == type)
+      ?? metadataProvider
+        .GetEntities()
+        .FirstOrDefault(c => c.FieldsMetadata.Any(fm => fm.MemberInfo.DeclaringType == type));
+    var fieldMetadata = entityMetadata?.GetFieldMetadataBy(memberInfo);
+    return fieldMetadata is
+    {
+      IsStruct: true
+    };
   }
 
   protected static Type GetMemberType(MemberInfo memberInfo)


### PR DESCRIPTION
Struct fields that are ignored are no longer added to create statements. A struct that has all its fields ignored is also ignored. It would otherwise create an empty `STRUCT<>` type which is an invalid ksql statement.