### PR TITLE
refactor: switch to Microsoft.NET.Test.Sdk and NUnit

### DIFF
--- a/Samples/Aggregations/Aggregations.csproj
+++ b/Samples/Aggregations/Aggregations.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-        <PackageReference Include="ksqlDb.RestApi.Client" Version="7.0.0" />
+        <PackageReference Include="ksqlDb.RestApi.Client" Version="7.1.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
 	</ItemGroup>
 

--- a/Samples/Avro/Avro.Samples.csproj
+++ b/Samples/Avro/Avro.Samples.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="ksqlDb.RestApi.Client" Version="7.0.0" />
+        <PackageReference Include="ksqlDb.RestApi.Client" Version="7.1.0" />
 	<PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.6.0" />
     </ItemGroup>
 </Project>

--- a/Samples/DataTypes/DataTypes.csproj
+++ b/Samples/DataTypes/DataTypes.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-        <PackageReference Include="ksqlDb.RestApi.Client" Version="7.0.0" />
+        <PackageReference Include="ksqlDb.RestApi.Client" Version="7.1.0" />
 	</ItemGroup>
 
 </Project>

--- a/Samples/GraphQL/GraphQL.csproj
+++ b/Samples/GraphQL/GraphQL.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="HotChocolate.AspNetCore" Version="14.1.0" />
     <PackageReference Include="HotChocolate.Data" Version="14.1.0" />
-    <PackageReference Include="ksqlDb.RestApi.Client" Version="7.0.0" />
+    <PackageReference Include="ksqlDb.RestApi.Client" Version="7.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
   </ItemGroup>
 </Project>

--- a/Samples/Joins/Joins.csproj
+++ b/Samples/Joins/Joins.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-        <PackageReference Include="ksqlDb.RestApi.Client" Version="7.0.0" />
+        <PackageReference Include="ksqlDb.RestApi.Client" Version="7.1.0" />
 	</ItemGroup>
 
 </Project>

--- a/Samples/Statements/Statements.csproj
+++ b/Samples/Statements/Statements.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-        <PackageReference Include="ksqlDb.RestApi.Client" Version="7.0.0" />
+        <PackageReference Include="ksqlDb.RestApi.Client" Version="7.1.0" />
 	</ItemGroup>
 
 </Project>

--- a/Samples/ksqlDB.RestApi.Client.Sample/ksqlDB.RestApi.Client.Samples.csproj
+++ b/Samples/ksqlDB.RestApi.Client.Sample/ksqlDB.RestApi.Client.Samples.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="ksqlDb.RestApi.Client" Version="7.0.0" />
+        <PackageReference Include="ksqlDb.RestApi.Client" Version="7.1.0" />
         <!-- <ProjectReference Include="..\..\ksqlDb.RestApi.Client\ksqlDb.RestApi.Client.csproj" /> -->
         <!-- <PackageReference Include="ksqlDb.RestApi.Client.ProtoBuf" Version="4.0.0" /> -->
         <ProjectReference Include="..\..\ksqlDb.RestApi.Client.ProtoBuf\ksqlDb.RestApi.Client.ProtoBuf.csproj" />

--- a/Samples/ksqldB.RestApi.Client.WorkerService/ksqlDB.RestApi.Client.WorkerService/ksqlDB.RestApi.Client.WorkerService.csproj
+++ b/Samples/ksqldB.RestApi.Client.WorkerService/ksqlDB.RestApi.Client.WorkerService/ksqlDB.RestApi.Client.WorkerService.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="ksqlDb.RestApi.Client" Version="7.0.0" />
+        <PackageReference Include="ksqlDb.RestApi.Client" Version="7.1.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
         <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     </ItemGroup>

--- a/Tests/Directory.Packages.props
+++ b/Tests/Directory.Packages.props
@@ -12,15 +12,17 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup Label="Unit testing Nugets">
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.0.0" />
-    <PackageVersion Include="Moq" Version="4.20.70" />
-    <PackageVersion Include="NUnit" Version="4.1.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageVersion Include="FluentAssertions" Version="7.2.0" />
+    <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.0.1" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="NUnit" Version="4.3.2" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.7.0" />
     <PackageVersion Include="Ninject.MockingKernel.Moq" Version="3.3.0" />
     <PackageVersion Include="Joker" Version="2.0.0" />
   </ItemGroup>

--- a/Tests/SqlServer.Connector.Tests/Cdc/Connectors/ConnectorExtensionsTests.cs
+++ b/Tests/SqlServer.Connector.Tests/Cdc/Connectors/ConnectorExtensionsTests.cs
@@ -1,11 +1,11 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using FluentAssertions;
 using SqlServer.Connector.Cdc.Connectors;
+using NUnit.Framework;
 using UnitTests;
 
 namespace SqlServer.Connector.Tests.Cdc.Connectors;
 
-[TestClass]
+[TestFixture]
 public class ConnectorExtensionsTests : TestBase
 {
   private SqlServerConnectorMetadata CreateConnector()
@@ -15,10 +15,10 @@ public class ConnectorExtensionsTests : TestBase
 
     return new SqlServerConnectorMetadata(connectionString);
   }
-    
+
   string connectorName = "myConnector";
 
-  [TestMethod]
+  [Test]
   public void ToCreateSourceConnectorStatement()
   {
     //Arrange
@@ -31,7 +31,7 @@ public class ConnectorExtensionsTests : TestBase
     statement.Should().Be(ExpectedStatement("CREATE SOURCE CONNECTOR"));
   }
 
-  [TestMethod]
+  [Test]
   public void ToCreateSourceConnectorStatement_IfNotExists()
   {
     //Arrange
@@ -44,7 +44,7 @@ public class ConnectorExtensionsTests : TestBase
     statement.Should().Be(ExpectedStatement("CREATE SOURCE CONNECTOR IF NOT EXISTS"));
   }
 
-  [TestMethod]
+  [Test]
   public void ToCreateSinkConnectorStatement()
   {
     //Arrange
@@ -53,7 +53,7 @@ public class ConnectorExtensionsTests : TestBase
 
     //Act
     var statement = connector.ToCreateConnectorStatement(connectorName);
-      
+
     //Assert
     statement.Should().Be(ExpectedStatement("CREATE SINK CONNECTOR"));
   }

--- a/Tests/SqlServer.Connector.Tests/Cdc/Connectors/ConnectorMetadataTests.cs
+++ b/Tests/SqlServer.Connector.Tests/Cdc/Connectors/ConnectorMetadataTests.cs
@@ -1,14 +1,14 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using FluentAssertions;
 using SqlServer.Connector.Cdc.Connectors;
+using NUnit.Framework;
 using UnitTests;
 
 namespace SqlServer.Connector.Tests.Cdc.Connectors;
 
-[TestClass]
+[TestFixture]
 public class ConnectorMetadataTests : TestBase<ConnectorMetadata>
-{    
-  [TestInitialize]
+{
+  [SetUp]
   public override void TestInitialize()
   {
     base.TestInitialize();
@@ -16,7 +16,7 @@ public class ConnectorMetadataTests : TestBase<ConnectorMetadata>
     ClassUnderTest = new ConnectorMetadata();
   }
 
-  [TestMethod]
+  [Test]
   public void JsonKeyConverter()
   {
     //Arrange
@@ -28,7 +28,7 @@ public class ConnectorMetadataTests : TestBase<ConnectorMetadata>
     ClassUnderTest.KeyConverter.Should().Be("org.apache.kafka.connect.json.JsonConverter");
   }
 
-  [TestMethod]
+  [Test]
   public void ValueConverter()
   {
     //Arrange
@@ -40,7 +40,7 @@ public class ConnectorMetadataTests : TestBase<ConnectorMetadata>
     ClassUnderTest.ValueConverter.Should().Be("org.apache.kafka.connect.json.JsonConverter");
   }
 
-  [TestMethod]
+  [Test]
   public void SetProperty()
   {
     //Arrange

--- a/Tests/SqlServer.Connector.Tests/Cdc/Connectors/SqlServerConnectorMetadataTests.cs
+++ b/Tests/SqlServer.Connector.Tests/Cdc/Connectors/SqlServerConnectorMetadataTests.cs
@@ -1,14 +1,14 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using FluentAssertions;
+using NUnit.Framework;
 using SqlServer.Connector.Cdc.Connectors;
 using UnitTests;
 
 namespace SqlServer.Connector.Tests.Cdc.Connectors;
 
-[TestClass]
+[TestFixture]
 public class SqlServerConnectorMetadataTests : TestBase<SqlServerConnectorMetadata>
 {
-  [TestInitialize]
+  [SetUp]
   public override void TestInitialize()
   {
     base.TestInitialize();
@@ -19,7 +19,7 @@ public class SqlServerConnectorMetadataTests : TestBase<SqlServerConnectorMetada
     ClassUnderTest = new SqlServerConnectorMetadata(connectionString);
   }
 
-  [TestMethod]
+  [Test]
   public void ConnectorClass()
   {
     //Arrange
@@ -30,7 +30,7 @@ public class SqlServerConnectorMetadataTests : TestBase<SqlServerConnectorMetada
     ClassUnderTest.ConnectorClass.Should().Be("io.debezium.connector.sqlserver.SqlServerConnector");
   }
 
-  [TestMethod]
+  [Test]
   public void DatabaseHostnameName()
   {
     //Arrange
@@ -41,7 +41,7 @@ public class SqlServerConnectorMetadataTests : TestBase<SqlServerConnectorMetada
     ClassUnderTest.DatabaseHostname.Should().Be("127.0.0.1");
   }
 
-  [TestMethod]
+  [Test]
   public void DatabaseUser()
   {
     //Arrange
@@ -52,7 +52,7 @@ public class SqlServerConnectorMetadataTests : TestBase<SqlServerConnectorMetada
     ClassUnderTest.DatabaseUser.Should().Be("SA");
   }
 
-  [TestMethod]
+  [Test]
   public void DefaultCtor_Port()
   {
     //Arrange
@@ -64,7 +64,7 @@ public class SqlServerConnectorMetadataTests : TestBase<SqlServerConnectorMetada
     ClassUnderTest.DatabasePort.Should().Be("1433");
   }
 
-  [TestMethod]
+  [Test]
   public void Port()
   {
     //Arrange
@@ -75,7 +75,7 @@ public class SqlServerConnectorMetadataTests : TestBase<SqlServerConnectorMetada
     ClassUnderTest.DatabasePort.Should().Be("1433");
   }
 
-  [TestMethod]
+  [Test]
   public void DatabasePassword()
   {
     //Arrange
@@ -86,7 +86,7 @@ public class SqlServerConnectorMetadataTests : TestBase<SqlServerConnectorMetada
     ClassUnderTest.DatabasePassword.Should().Be("<YourNewStrong@Passw0rd>");
   }
 
-  [TestMethod]
+  [Test]
   public void DatabaseDbname()
   {
     //Arrange
@@ -97,7 +97,7 @@ public class SqlServerConnectorMetadataTests : TestBase<SqlServerConnectorMetada
     ClassUnderTest.DatabaseDbname.Should().Be("Sensors");
   }
 
-  [TestMethod]
+  [Test]
   public void TrySetDatabaseHistoryKafkaTopic()
   {
     //Arrange
@@ -110,7 +110,7 @@ public class SqlServerConnectorMetadataTests : TestBase<SqlServerConnectorMetada
     ClassUnderTest.DatabaseHistoryKafkaTopic.Should().Be($"dbhistory.{ClassUnderTest.DatabaseServerName}");
   }
 
-  [TestMethod]
+  [Test]
   public void TrySetConnectorName()
   {
     //Arrange
@@ -122,7 +122,7 @@ public class SqlServerConnectorMetadataTests : TestBase<SqlServerConnectorMetada
     ClassUnderTest.Name.Should().Be($"{ClassUnderTest.DatabaseDbname}-connector");
   }
 
-  [TestMethod]
+  [Test]
   public void KafkaBootstrapServers()
   {
     //Arrange

--- a/Tests/SqlServer.Connector.Tests/Cdc/Extensions/OperationTypeExtensionsTests.cs
+++ b/Tests/SqlServer.Connector.Tests/Cdc/Extensions/OperationTypeExtensionsTests.cs
@@ -1,15 +1,15 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using FluentAssertions;
+using NUnit.Framework;
 using SqlServer.Connector.Cdc;
 using SqlServer.Connector.Cdc.Extensions;
 using UnitTests;
 
 namespace SqlServer.Connector.Tests.Cdc.Extensions;
 
-[TestClass]
+[TestFixture]
 public class OperationTypeExtensionsTests : TestBase
 {
-  [TestMethod]
+  [Test]
   public void ToChangeDataCaptureType_r_Read()
   {
     //Arrange
@@ -22,7 +22,7 @@ public class OperationTypeExtensionsTests : TestBase
     cdcTpe.Should().Be(ChangeDataCaptureType.Read);
   }
 
-  [TestMethod]
+  [Test]
   public void ToChangeDataCaptureType_c_Created()
   {
     //Arrange
@@ -35,7 +35,7 @@ public class OperationTypeExtensionsTests : TestBase
     cdcTpe.Should().Be(ChangeDataCaptureType.Created);
   }
 
-  [TestMethod]
+  [Test]
   public void ToChangeDataCaptureType_u_Updated()
   {
     //Arrange
@@ -48,7 +48,7 @@ public class OperationTypeExtensionsTests : TestBase
     cdcTpe.Should().Be(ChangeDataCaptureType.Updated);
   }
 
-  [TestMethod]
+  [Test]
   public void ToChangeDataCaptureType_d_Deleted()
   {
     //Arrange

--- a/Tests/SqlServer.Connector.Tests/SqlServer.Connector.Tests.csproj
+++ b/Tests/SqlServer.Connector.Tests/SqlServer.Connector.Tests.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="MSTest.Sdk/3.6.2">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
+<PropertyGroup>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
@@ -16,11 +16,9 @@
 		<PackageReference Include="Microsoft.Extensions.Caching.Memory" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<PackageReference Include="FluentAssertions" />
 		<PackageReference Include="Microsoft.Reactive.Testing" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="Moq" />
 		<PackageReference Include="System.Formats.Asn1" />
 		<PackageReference Include="System.Text.Json" />

--- a/Tests/UnitTests/TestBase.cs
+++ b/Tests/UnitTests/TestBase.cs
@@ -32,6 +32,7 @@ public abstract class TestBase
   [TearDown]
   public virtual void TestCleanup()
   {
+    MockingKernel.Dispose();
   }
 
   #region RunSchedulers
@@ -39,7 +40,7 @@ public abstract class TestBase
   public void RunSchedulers()
   {
     TestScheduler.Start();
-      
+
     SchedulersFactory.ThreadPool.Start();
     SchedulersFactory.TaskPool.Start();
     SchedulersFactory.Dispatcher.Start();
@@ -52,24 +53,24 @@ public abstract class TestBase
   public void AdvanceSchedulers(long time)
   {
     TestScheduler.AdvanceBy(time);
-      
+
     SchedulersFactory.ThreadPool.AdvanceBy(time);
     SchedulersFactory.TaskPool.AdvanceBy(time);
     SchedulersFactory.Dispatcher.AdvanceBy(time);
   }
 
-  #endregion    
-    
+  #endregion
+
   protected void Schedule(TestScheduler testScheduler, TimeSpan timeSpan, Action action)
   {
     testScheduler.Schedule(timeSpan, action);
   }
-    
+
   protected void ScheduleOnTaskPool(TimeSpan timeSpan, Action action)
   {
     Schedule(SchedulersFactory.TaskPool, timeSpan, action);
   }
-    
+
   protected void ScheduleOnThreadPool(TimeSpan timeSpan, Action action)
   {
     Schedule(SchedulersFactory.ThreadPool, timeSpan, action);

--- a/Tests/UnitTests/UnitTests.csproj
+++ b/Tests/UnitTests/UnitTests.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="MSTest.Sdk/3.6.2">
+<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
+<PropertyGroup>
 	  <LangVersion>12.0</LangVersion>
 	  <ImplicitUsings>enable</ImplicitUsings>
 	  <IsPackable>false</IsPackable>
@@ -12,11 +12,13 @@
 
   <ItemGroup>
 	  <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
 	  <PackageReference Include="Microsoft.Reactive.Testing" />
 	  <PackageReference Include="Moq" />
 	  <PackageReference Include="Ninject.MockingKernel.Moq" />
 	  <PackageReference Include="NUnit" />
 	  <PackageReference Include="NUnit3TestAdapter" />
+	  <PackageReference Include="NUnit.Analyzers" />
 	  <PackageReference Include="Microsoft.Extensions.Logging" />
 	  <PackageReference Include="Joker" />
   </ItemGroup>

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/Infrastructure/IntegrationTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/Infrastructure/IntegrationTests.cs
@@ -2,12 +2,12 @@ using ksqlDb.RestApi.Client.FluentAPI.Builders;
 using ksqlDb.RestApi.Client.IntegrationTests.KSql.RestApi;
 using ksqlDB.RestApi.Client.KSql.Query.Context;
 using ksqlDB.RestApi.Client.KSql.Query.Options;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 using UnitTests;
 
 namespace ksqlDb.RestApi.Client.IntegrationTests.Infrastructure;
 
-[TestClass]
+[TestFixture]
 public abstract class IntegrationTests : TestBase
 {
   protected static KSqlDbRestApiProvider RestApiProvider = null!;
@@ -25,7 +25,7 @@ public abstract class IntegrationTests : TestBase
     }
   }
 
-  [TestInitialize]
+  [SetUp]
   public override void TestInitialize()
   {
     base.TestInitialize();
@@ -45,10 +45,11 @@ public abstract class IntegrationTests : TestBase
     return new KSqlDBContext(ContextOptions, modelBuilder);
   }
 
-  [TestCleanup]
+  [TearDown]
   public override void TestCleanup()
   {
     Context.DisposeAsync().GetAwaiter().GetResult();
+    Context.Dispose();
 
     base.TestCleanup();
   }
@@ -62,7 +63,7 @@ public abstract class IntegrationTests : TestBase
 
     if (expectedItemsCount.HasValue)
       source = source.Take(expectedItemsCount.Value);
-      
+
     await foreach (var item in source.WithCancellation(cts.Token))
     {
       actualValues.Add(item);

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/AggregationTimeTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/AggregationTimeTests.cs
@@ -4,7 +4,6 @@ using ksqlDb.RestApi.Client.IntegrationTests.Models;
 using ksqlDB.RestApi.Client.KSql.Linq;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NUnit.Framework;
 
 namespace ksqlDb.RestApi.Client.IntegrationTests.KSql.Linq;
@@ -50,7 +49,7 @@ public class AggregationTimeTests : Infrastructure.IntegrationTests
     await RestApiProvider.InsertIntoAsync(Times2, insertProperties);
   }
 
-  [ClassCleanup]
+  [OneTimeTearDown]
   public static async Task ClassCleanup()
   {
 

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/ComplexTypesTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/ComplexTypesTests.cs
@@ -35,6 +35,12 @@ public class ComplexTypesTests
     Context = new KSqlDBContext(contextOptions);
   }
 
+  [TearDown]
+  public void TearDown()
+  {
+    Context.Dispose();
+  }
+
   [Test]
   public async Task ReceiveArrayWithComplexElements()
   {

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/JoinsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/JoinsTests.cs
@@ -11,8 +11,6 @@ using ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Annotations;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
 using NUnit.Framework;
-using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
-
 
 namespace ksqlDb.RestApi.Client.IntegrationTests.KSql.Linq;
 
@@ -83,12 +81,12 @@ public class JoinsTests : Infrastructure.IntegrationTests
     var actualValues = await CollectActualValues(source, expectedItemsCount);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
-    
-    Assert.AreEqual(MoviesProvider.Movie1.Title, actualValues[0].Title);
-    Assert.AreEqual(MoviesProvider.LeadActor1.Title, actualValues[0].Title);
-    Assert.AreEqual("lien", actualValues[0].Substr);
-    Assert.AreEqual(MoviesProvider.Movie1.Release_Year, actualValues[0].Release_Year);
+    actualValues.Count.Should().Be(expectedItemsCount);
+
+    actualValues[0].Title.Should().Be(MoviesProvider.Movie1.Title);
+    actualValues[0].Title.Should().Be(MoviesProvider.LeadActor1.Title);
+    actualValues[0].Substr.Should().Be("lien");
+    actualValues[0].Release_Year.Should().Be(MoviesProvider.Movie1.Release_Year);
   }
 
   [Test]
@@ -117,11 +115,10 @@ public class JoinsTests : Infrastructure.IntegrationTests
     var actualValues = await CollectActualValues(source, expectedItemsCount);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
 
-    Assert.AreEqual(MoviesProvider.Movie1.Title, actualValues[0].Title);
-    Assert.AreEqual(MoviesProvider.LeadActor1.Title, actualValues[0].Title);
-
+    actualValues[0].Title.Should().Be(MoviesProvider.Movie1.Title);
+    actualValues[0].Title.Should().Be(MoviesProvider.LeadActor1.Title);
     actualValues[0].Substr.Length.Should().Be(4);
     actualValues[0].Release_Year.Should().BeOneOf(MoviesProvider.Movie1.Release_Year, MoviesProvider.Movie2.Release_Year);
     actualValues[0].ActorTitle.Should().BeOneOf(null, MoviesProvider.Movie1.Title, MoviesProvider.Movie2.Title);
@@ -151,7 +148,7 @@ public class JoinsTests : Infrastructure.IntegrationTests
   {
     //Arrange
     int expectedItemsCount = 3;
-        
+
     await moviesProvider.InsertLeadAsync(MoviesProvider.LeadActor2);
 
     var source = querySource
@@ -171,9 +168,9 @@ public class JoinsTests : Infrastructure.IntegrationTests
 
     //Act
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-        
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
 
     actualValues[2].Title.Should().BeOneOf(MoviesProvider.Movie1.Title, MoviesProvider.Movie2.Title, null);
   }
@@ -213,10 +210,10 @@ public class JoinsTests : Infrastructure.IntegrationTests
     var actualValues = await CollectActualValues(source, expectedItemsCount);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
 
-    Assert.AreEqual(MoviesProvider.Movie1.Title, actualValues[0].Title);
-    Assert.AreEqual(MoviesProvider.LeadActor1.Title, actualValues[0].Title);
+    actualValues[0].Title.Should().Be(MoviesProvider.Movie1.Title);
+    actualValues[0].Title.Should().Be(MoviesProvider.LeadActor1.Title);
 
     actualValues[0].Substr.Length.Should().Be(4);
     actualValues[0].Release_Year.Should().BeOneOf(MoviesProvider.Movie1.Release_Year, MoviesProvider.Movie2.Release_Year);
@@ -285,7 +282,7 @@ public class JoinsTests : Infrastructure.IntegrationTests
     var actualValues = await CollectActualValues(query.ToAsyncEnumerable(), expectedItemsCount);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
 
     actualValues[0].orderId.Should().Be(1);
     actualValues[0].paymentId.Should().Be(1);
@@ -329,7 +326,7 @@ public class JoinsTests : Infrastructure.IntegrationTests
     var actualValues = await CollectActualValues(query.ToAsyncEnumerable(), expectedItemsCount);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
 
     actualValues[0].orderId.Should().Be(1);
   }

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/ModelBuilderTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/ModelBuilderTests.cs
@@ -29,6 +29,7 @@ namespace ksqlDb.RestApi.Client.IntegrationTests.KSql.Linq
     public record Tweet : Record
     {
       public int Id { get; set; }
+
       [JsonPropertyName("MESSAGE")]
       public string Message { get; set; } = null!;
       public bool IsRobot { get; set; }
@@ -140,7 +141,7 @@ namespace ksqlDb.RestApi.Client.IntegrationTests.KSql.Linq
       };
       
       expectedItemsCount.Should().Be(actualValues.Count);
-      CollectionAssert.AreEqual(expectedValues, actualValues);
+      actualValues.Should().BeEquivalentTo(expectedValues);
     }
 
     [Test]

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/PullQueries/PullQueryExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/PullQueries/PullQueryExtensionsTests.cs
@@ -44,6 +44,7 @@ public class PullQueryExtensionsTests
   public static async Task ClassCleanup()
   {
     await pullQueryProvider.DropEntitiesAsync();
+    context.Dispose();
   }
 
   [Test]
@@ -56,7 +57,7 @@ public class PullQueryExtensionsTests
     var result = await context.CreatePullQuery<IoTSensorStats>(SensorsPullQueryProvider.MaterializedViewName)
       .Where(c => c.SensorId == sensorId)
       .FirstOrDefaultAsync();
-      
+
     //Assert
     result.Should().NotBeNull();
     result!.SensorId.Should().Be(sensorId);
@@ -95,7 +96,7 @@ public class PullQueryExtensionsTests
       .Where(c => c.SensorId == sensorId)
       .Select(c => c.SensorId)
       .FirstOrDefaultAsync();
-      
+
     //Assert
     result.Should().NotBeNull();
     result.Should().Be(sensorId);
@@ -131,7 +132,7 @@ public class PullQueryExtensionsTests
       .Where(c => c.SensorId == sensorId)
       .Where(c => Bounds.WindowStart > windowStart && Bounds.WindowEnd <= windowEnd)
       .FirstOrDefaultAsync();
-      
+
     //Assert
     result.Should().NotBeNull();
     result!.SensorId.Should().Be(sensorId);
@@ -148,7 +149,7 @@ public class PullQueryExtensionsTests
 
     //Act
     var result = await context.ExecutePullQuery<IoTSensorStats>(ksql);
-      
+
     //Assert
     result.Should().NotBeNull();
     result!.SensorId.Should().Be(sensorId);

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/QbservableExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/QbservableExtensionsTests.cs
@@ -12,9 +12,7 @@ using ksqlDB.RestApi.Client.KSql.RestApi.Exceptions;
 using ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NUnit.Framework;
-using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 namespace ksqlDb.RestApi.Client.IntegrationTests.KSql.Linq;
 
@@ -86,8 +84,8 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
       Tweet1, Tweet2
     };
 
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
-    CollectionAssert.AreEqual(expectedValues, actualValues);
+    actualValues.Count.Should().Be(expectedItemsCount);
+    actualValues.Should().BeEquivalentTo(expectedValues);
   }
 
   [Test]
@@ -109,8 +107,8 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
       Tweet1
     };
 
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
-    CollectionAssert.AreEqual(expectedValues, actualValues);
+    actualValues.Count.Should().Be(expectedItemsCount);
+    actualValues.Should().BeEquivalentTo(expectedValues);
   }
 
   [Test]
@@ -127,8 +125,8 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
     var actualValues = await CollectActualValues(source, expectedItemsCount);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
-    Assert.AreEqual(actualValues[0].Message, Tweet2.Message);
+    actualValues.Count.Should().Be(expectedItemsCount);
+    actualValues[0].Message.Should().Be(Tweet2.Message);
   }
 
   [Test]
@@ -145,8 +143,8 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
     var actualValues = await CollectActualValues(source, expectedItemsCount);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
-    Assert.AreEqual(actualValues[0].Amount, Tweet2.Amount);
+    actualValues.Count.Should().Be(expectedItemsCount);
+    actualValues[0].Amount.Should().Be(Tweet2.Amount);
   }
 
   [Test]
@@ -166,7 +164,7 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
     await semaphore.WaitAsync(timeOut);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
   }
 
   [Test]
@@ -185,7 +183,7 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
     await semaphore.WaitAsync(timeOut);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     subscription.QueryId.Should().NotBeNullOrEmpty();
   }
 
@@ -242,12 +240,12 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
     await cts.CancelAsync();
 
     //Assert
-    Assert.AreEqual(0, actualValues.Count);
+    actualValues.Count.Should().Be(0);
     subscription.QueryId.Should().NotBeNullOrEmpty();
   }
 
   [Test]
-  [NUnit.Framework.Ignore("TODO")]
+  [Ignore("TODO")]
   public async Task SubscribeOn_Blocks()
   {
     //Arrange
@@ -264,7 +262,7 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
 
     //Assert
     subscription.QueryId.Should().NotBeNullOrEmpty();
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
   }
 
   [Test]
@@ -287,7 +285,7 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
     //Assert
     observeOnThread.Should().NotBeNull();
     subscription.QueryId.Should().NotBeNullOrEmpty();
-    Assert.AreNotEqual(currentThread, observeOnThread!.Value);
+    observeOnThread!.Value.Should().NotBe(currentThread);
   }
 
   [Test]
@@ -331,7 +329,7 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
     await semaphore.WaitAsync(timeOut);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
   }
 
   [Test]
@@ -349,13 +347,13 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
     var actualValues = await CollectActualValues(source, expectedItemsCount);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
 
-    Assert.AreEqual(1, actualValues[0].Count);
-    Assert.AreEqual(Tweet1.Id, actualValues[0].Id);
+    actualValues[0].Count.Should().Be(1);
+    actualValues[0].Id.Should().Be(Tweet1.Id);
 
-    Assert.AreEqual(1, actualValues[1].Count);
-    Assert.AreEqual(Tweet2.Id, actualValues[1].Id);
+    actualValues[1].Count.Should().Be(1);
+    actualValues[1].Id.Should().Be(Tweet2.Id);
   }
 
   [Test]
@@ -374,13 +372,13 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
     var actualValues = await CollectActualValues(source, expectedItemsCount);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
 
-    Assert.AreEqual(1, actualValues[0].Count);
-    Assert.AreEqual(Tweet1.Id, actualValues[0].Id);
+    actualValues[0].Count.Should().Be(1);
+    actualValues[0].Id.Should().Be(Tweet1.Id);
 
-    Assert.AreEqual(1, actualValues[1].Count);
-    Assert.AreEqual(Tweet2.Id, actualValues[1].Id);
+    actualValues[1].Count.Should().Be(1);
+    actualValues[1].Id.Should().Be(Tweet2.Id);
   }
 
   [Test]
@@ -399,17 +397,17 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
     var actualValues = await CollectActualValues(source, expectedItemsCount);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
 
-    Assert.AreEqual(1, actualValues[0].Count);
-    Assert.AreEqual(Tweet1.Id, actualValues[0].Id);
+    actualValues[0].Count.Should().Be(1);
+    actualValues[0].Id.Should().Be(Tweet1.Id);
 
-    Assert.AreEqual(1, actualValues[1].Count);
-    Assert.AreEqual(Tweet2.Id, actualValues[1].Id);
+    actualValues[1].Count.Should().Be(1);
+    actualValues[1].Id.Should().Be(Tweet2.Id);
   }
 
   [Test]
-  [NUnit.Framework.Ignore("fix test")]
+  [Ignore("fix test")]
   public async Task WindowedBy_WithFinalOutputRefinement()
   {
     //Arrange
@@ -454,7 +452,7 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
     var actualValues = await CollectActualValues(source, expectedItemsCount);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
   }
 
   [Test]
@@ -477,7 +475,7 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
     var actualValues = await CollectActualValues(source, expectedItemsCount);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
   }
 
   [Test]
@@ -496,8 +494,8 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
     var actualValues = await CollectActualValues(source, expectedItemsCount);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
-    Assert.AreEqual(actualValues[0].Id, 1);
+    actualValues.Count.Should().Be(expectedItemsCount);
+    actualValues[0].Id.Should().Be(1);
   }
 
   [Test]
@@ -516,7 +514,7 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
     var actualValues = await CollectActualValues(source, expectedItemsCount);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues[0].Should().BeTrue();
   }
 
@@ -554,7 +552,7 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
       tweet3
     };
 
-    CollectionAssert.AreEqual(expectedValues, actualValues);
+    actualValues.Should().BeEquivalentTo(expectedValues);
   }
 
   [Test]
@@ -600,7 +598,7 @@ WHERE MESSAGE = 'ET' EMIT CHANGES;");
     var actualValues = await CollectActualValues(source, expectedItemsCount);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues[0].Should().Be(name);
   }
 
@@ -622,7 +620,7 @@ WHERE MESSAGE = 'ET' EMIT CHANGES;");
     var actualValues = await CollectActualValues(source, expectedItemsCount);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues[0].Name.Should().Be("E.T.");
   }
 
@@ -641,7 +639,7 @@ WHERE MESSAGE = 'ET' EMIT CHANGES;");
     var actualValues = await CollectActualValues(source, expectedItemsCount);
 
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues[0].Year.Should().Be(year);
   }
 
@@ -690,7 +688,7 @@ WHERE MESSAGE = 'ET' EMIT CHANGES;");
     var actualValues = await CollectActualValues(source, expectedItemsCount);
 
     //Assert
-    CollectionAssert.AreEqual(new[] { 1, 2 }, actualValues[0]);
+    actualValues[0].Should().BeEquivalentTo(new[] { 1, 2 });
   }
 
   private record MyStruct

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/QbservableExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Linq/QbservableExtensionsTests.cs
@@ -565,8 +565,7 @@ public class QbservableExtensionsTests : Infrastructure.IntegrationTests
     var description = await query.ExplainAsync();
 
     //Assert
-    description[0].StatementText.Should().Be(@"EXPLAIN SELECT * FROM tweetsTest
-WHERE MESSAGE = 'ET' EMIT CHANGES;");
+    description[0].StatementText.Should().Be(@"EXPLAIN SELECT * FROM tweetsTest WHERE MESSAGE = 'ET' EMIT CHANGES;");
     description[0].QueryDescription!.QueryType.Should().Be("PUSH");
     description[0].QueryDescription!.ExecutionPlan.Should().NotBeNullOrEmpty();
   }

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Query/Functions/KSqlFunctionsExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Query/Functions/KSqlFunctionsExtensionsTests.cs
@@ -8,9 +8,7 @@ using ksqlDb.RestApi.Client.IntegrationTests.Models.Movies;
 using ksqlDB.RestApi.Client.KSql.Linq;
 using ksqlDB.RestApi.Client.KSql.Query.Functions;
 using ksqlDB.RestApi.Client.KSql.Query.Options;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NUnit.Framework;
-using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 namespace ksqlDb.RestApi.Client.IntegrationTests.KSql.Query.Functions;
 
@@ -22,7 +20,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
   public static async Task ClassInitialize()
   {
     RestApiProvider = KSqlDbRestApiProvider.Create();
-      
+
     moviesProvider = new MoviesProvider(RestApiProvider);
     await moviesProvider.CreateTablesAsync();
 
@@ -54,7 +52,7 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
   {
     //Arrange
     int expectedItemsCount = 1;
-      
+
     int epochDays = 18672;
     string format = "yyyy-MM-dd";
     Expression<Func<Movie, string>> expression = _ => KSqlFunctions.Instance.DateToString(epochDays, format);
@@ -65,9 +63,9 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
       //.Select(c => new { DTS = KSqlFunctions.Instance.DateToString(epochDays, format) })
       .ToAsyncEnumerable();
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues[0].Should().BeEquivalentTo("2021-02-14");
   }
 
@@ -83,14 +81,14 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     Context = CreateKSqlDbContext(EndpointType.Query);
     await EntriesTest(Context.CreatePushQuery<Movie>(MoviesTableName));
   }
-    
+
   public async Task EntriesTest(IQbservable<Movie> querySource)
   {
     //Arrange
     int expectedItemsCount = 1;
-      
+
     bool sorted = true;
-      
+
     //Act
     var source = querySource
       .Select(c => new { Col = KSqlFunctions.Instance.Entries(new Dictionary<string, string>()
@@ -98,11 +96,11 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
         { "a", "value" }
       }, sorted)})
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues[0].Col[0].K.Should().BeEquivalentTo("a");
     actualValues[0].Col[0].V.Should().BeEquivalentTo("value");
   }
@@ -112,16 +110,16 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
   {
     //Arrange
     int expectedItemsCount = 1;
-      
+
     //Act
     var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = KSqlFunctions.Instance.ArrayIntersect(new [] { 1, 2 }, new []{ 1 } )})
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues[0].Col.Length.Should().Be(1);
     actualValues[0].Col[0].Should().Be(1);
   }
@@ -131,16 +129,16 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
   {
     //Arrange
     int expectedItemsCount = 1;
-      
+
     //Act
     var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = KSqlFunctions.Instance.ArrayJoin(new [] { 1, 2 }, ";" )})
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues.Count.Should().Be(1);
     actualValues[0].Col.Should().Be("1;2");
   }
@@ -150,112 +148,112 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
   {
     //Arrange
     int expectedItemsCount = 1;
-      
+
     //Act
     var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = KSqlFunctions.Instance.ArrayLength(new [] { 1, 2 } )})
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues.Count.Should().Be(1);
     actualValues[0].Col.Should().Be(2);
   }
-    
+
   [Test]
   public async Task ArrayMin()
   {
     //Arrange
     int expectedItemsCount = 1;
-      
+
     //Act
     var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = KSqlFunctions.Instance.ArrayMin(new [] { 1, 2 } )})
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues.Count.Should().Be(1);
     actualValues[0].Col.Should().Be(1);
   }
 
   [Test]
-  [NUnit.Framework.Ignore("Cannot construct an array with all NULL elements")]
+  [Ignore("Cannot construct an array with all NULL elements")]
   public async Task ArrayMin_Null()
   {
     //Arrange
     int expectedItemsCount = 1;
-      
+
     //Act
     var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = KSqlFunctions.Instance.ArrayMin(new string [] { })})
       .ToAsyncEnumerable();
 
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues.Count.Should().Be(1);
     actualValues[0].Col.Should().BeNull();
   }
-    
+
   [Test]
   public async Task ArrayRemove()
   {
     //Arrange
     int expectedItemsCount = 1;
-      
+
     //Act
     var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = KSqlFunctions.Instance.ArrayRemove(new [] { 1, 2 }, 2)})
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues.Count.Should().Be(1);
     actualValues[0].Col.Length.Should().Be(1);
   }
-    
+
   [Test]
   public async Task ArraySort()
   {
     //Arrange
     int expectedItemsCount = 1;
-      
+
     //Act
     var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = K.Functions.ArraySort(new int?[]{ 3, null, 1}, ListSortDirection.Ascending)})
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    CollectionAssert.AreEquivalent(new int?[] { 1, 3, null}, actualValues[0].Col);
+    actualValues[0].Col.Should().BeEquivalentTo(new int?[] { 1, 3, null });
   }
-    
+
   [Test]
   public async Task ArrayUnion()
   {
     //Arrange
     int expectedItemsCount = 1;
-      
+
     //Act
     var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = K.Functions.ArrayUnion(new int?[]{ 3, null, 1}, new int?[]{ 4, null})})
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    CollectionAssert.AreEquivalent(new int?[] { 3, null, 1, 4}, actualValues[0].Col);
+    actualValues[0].Col.Should().BeEquivalentTo(new int?[] { 3, null, 1, 4 });
   }
-    
+
   [Test]
   public async Task Concat()
   {
@@ -267,15 +265,15 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = K.Functions.Concat(c.Title, message), ColWS = K.Functions.ConcatWS(" - ", c.Title, message) })
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues[0].Col.Should().Be($"{MoviesProvider.Movie1.Title}{message}");
     actualValues[0].ColWS.Should().Be($"{MoviesProvider.Movie1.Title} - {message}");
   }
-    
+
   [Test]
   public async Task ToBytes()
   {
@@ -283,19 +281,20 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;
 
     //Act
-    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
+    var source = Context
+      .CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = K.Functions.ToBytes(c.Title, "utf8") })
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
 
     string result = Encoding.UTF8.GetString(actualValues[0].Col);
     result.Should().Be(MoviesProvider.Movie1.Title);
   }
-    
+
   [Test]
   public async Task FromBytes()
   {
@@ -306,17 +305,17 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = K.Functions.FromBytes(K.Functions.ToBytes(c.Title, "utf8"), "utf8") })
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
 
     actualValues[0].Col.Should().BeEquivalentTo(MoviesProvider.Movie1.Title);
   }
-    
+
   [Test]
-  [NUnit.Framework.Ignore("TODO")]
+  [Ignore("TODO")]
   public async Task FromBytes_CapturedVariable()
   {
     //Arrange
@@ -328,11 +327,11 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = K.Functions.FromBytes(bytes, "utf8") })
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
 
     actualValues[0].Col.Should().BeEquivalentTo(MoviesProvider.Movie1.Title);
   }
@@ -347,14 +346,14 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = K.Functions.AsMap(new []{ "1", "2" }, new []{ 11, 22 }) })
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues[0].Col["1"].Should().Be(11);
   }
-    
+
   [Test]
   public async Task JsonArrayContains()
   {
@@ -362,17 +361,18 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     int expectedItemsCount = 1;
 
     //Act
-    var source = Context.CreatePushQuery<Movie>(MoviesTableName)
+    var source = Context
+      .CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Col = K.Functions.JsonArrayContains("[1, 2, 3]", 2) })
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues[0].Col.Should().BeTrue();
   }
-    
+
   [Test]
   public async Task MapKeys()
   {
@@ -387,11 +387,11 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
         {"banana", 20}
       }) })
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues[0].Col[0].Should().Be("banana");
     actualValues[0].Col[1].Should().Be("apple");
   }
@@ -410,11 +410,11 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(expression)
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues[0].Should().Be(MoviesProvider.Movie1.Title);
   }
 
@@ -433,11 +433,11 @@ public class KSqlFunctionsExtensionsTests : Infrastructure.IntegrationTests
     var source = Context.CreatePushQuery<Movie>(MoviesTableName)
       .Select(c => new { Extracted = K.Functions.ExtractJsonField(json, jsonPath) })
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues[0].Extracted.Should().Be("gcp836Csd");
   }
 }

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Query/Functions/KSqlInvocationFunctionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/KSql/Query/Functions/KSqlInvocationFunctionsTests.cs
@@ -5,7 +5,6 @@ using ksqlDB.RestApi.Client.KSql.Linq;
 using ksqlDB.RestApi.Client.KSql.Query.Functions;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 using NUnit.Framework;
-using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 namespace ksqlDb.RestApi.Client.IntegrationTests.KSql.Query.Functions;
 
@@ -66,12 +65,12 @@ public class KSqlInvocationFunctionsTests : Infrastructure.IntegrationTests
     var source = Context.CreatePushQuery<Lambda>(StreamName)
       .Select(c => new { Col = KSqlFunctions.Instance.Transform(c.Arr, x => x + 1) })
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
-    actualValues[0].Col.Should().BeEquivalentTo(new[] {2,3,4});
+    actualValues.Count.Should().Be(expectedItemsCount);
+    actualValues[0].Col.Should().BeEquivalentTo(new[] { 2, 3, 4 });
   }
 
   private class LambdaMap
@@ -80,27 +79,27 @@ public class KSqlInvocationFunctionsTests : Infrastructure.IntegrationTests
     public IDictionary<string, int[]> Map { get; set; } = null!;
     public IDictionary<string, int> Dictionary2 { get; set; } = null!;
   }
-    
+
   private readonly string streamNameWithMap = "stream4";
 
   [Test]
   public async Task TransformMap()
   {
     //Arrange
-    int expectedItemsCount = 1;      
-      
+    int expectedItemsCount = 1;
+
     //Act
     var source = Context.CreatePushQuery<LambdaMap>(streamNameWithMap)
       .Select(c => new { Col = K.Functions.Transform(c.Map, (k, v) => K.Functions.Concat(k, "_new"), (k, v) => K.Functions.Transform(v, x => x * x)) })
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues[0].Col.Keys.First().Should().Be("goodbye_new");
     actualValues[0].Col.Values.Count.Should().Be(2);
-    actualValues[0].Col.Values.First().Should().BeEquivalentTo(new [] {1,4,9});
+    actualValues[0].Col.Values.First().Should().BeEquivalentTo(new[] { 1, 4, 9 });
   }
 
   [Test]
@@ -113,31 +112,31 @@ public class KSqlInvocationFunctionsTests : Infrastructure.IntegrationTests
     var source = Context.CreatePushQuery<Lambda>(StreamName)
       .Select(c => new { Col = KSqlFunctions.Instance.Filter(c.Arr, x => x > 1) })
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues[0].Col.Should().BeEquivalentTo(new[] { 2, 3 });
   }
-    
+
   [Test]
   public async Task FilterMap()
   {
     //Arrange
-    int expectedItemsCount = 1;      
-      
+    int expectedItemsCount = 1;
+
     //Act
     var source = Context.CreatePushQuery<LambdaMap>(streamNameWithMap)
       .Select(c => new { Col = K.Functions.Filter(c.Map, (k, v) => k != "E.T" && v[1] > 0) })
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues[0].Col.Values.Count.Should().Be(1);
-    actualValues[0].Col.Values.First().Should().BeEquivalentTo(new [] {1,2,3});
+    actualValues[0].Col.Values.First().Should().BeEquivalentTo(new[] { 1, 2, 3 });
   }
 
   [Test]
@@ -150,29 +149,29 @@ public class KSqlInvocationFunctionsTests : Infrastructure.IntegrationTests
     var source = Context.CreatePushQuery<Lambda>(StreamName)
       .Select(c => new { Acc = K.Functions.Reduce(c.Arr, 0, (x,y) => x + y) })
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues[0].Acc.Should().Be(6);
   }
-    
+
   [Test]
   public async Task ReduceMap()
   {
     //Arrange
-    int expectedItemsCount = 1;      
-      
+    int expectedItemsCount = 1;
+
     //Act
     var source = Context.CreatePushQuery<LambdaMap>(streamNameWithMap)
       .Select(c => new { Col = K.Functions.Reduce(c.Map, 2, (s, k, v) => K.Functions.Ceil(s / v[1])) })
       .ToAsyncEnumerable();
-      
+
     var actualValues = await CollectActualValues(source, expectedItemsCount);
-      
+
     //Assert
-    Assert.AreEqual(expectedItemsCount, actualValues.Count);
+    actualValues.Count.Should().Be(expectedItemsCount);
     actualValues[0].Col.Should().Be(-2);
   }
 }

--- a/Tests/ksqlDB.RestApi.Client.IntegrationTests/ksqlDb.RestApi.Client.IntegrationTests.csproj
+++ b/Tests/ksqlDB.RestApi.Client.IntegrationTests/ksqlDb.RestApi.Client.IntegrationTests.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="MSTest.Sdk/3.6.2">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
+<PropertyGroup>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>12.0</LangVersion>
 		<IsPackable>false</IsPackable>
@@ -13,6 +13,7 @@
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" />
 		<PackageReference Include="Microsoft.Reactive.Testing" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="Moq" />
 		<PackageReference Include="NUnit" />
 		<PackageReference Include="NUnit3TestAdapter" />

--- a/Tests/ksqlDB.RestApi.Client.Tests/Disposables/AsyncDisposableObjectTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/Disposables/AsyncDisposableObjectTests.cs
@@ -2,12 +2,12 @@ using FluentAssertions;
 using ksqlDB.RestApi.Client.KSql.Disposables;
 using NUnit.Framework;
 using UnitTests;
-using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 namespace ksqlDb.RestApi.Client.Tests.Disposables;
 
 public class AsyncDisposableObjectTests : TestBase<AsyncDisposableObjectTests.TestableAsyncDisposableObject>
 {
+  [SetUp]
   public override void TestInitialize()
   {
     base.TestInitialize();
@@ -33,11 +33,10 @@ public class AsyncDisposableObjectTests : TestBase<AsyncDisposableObjectTests.Te
     //Arrange
     await ClassUnderTest.DisposeAsync().ConfigureAwait(false);
 
-
     //Assert
-    await Assert.ThrowsExceptionAsync<ObjectDisposedException>(() => ClassUnderTest.InitializeAsync());
+    Assert.ThrowsAsync<ObjectDisposedException>(async () => await ClassUnderTest.InitializeAsync());
   }
-    
+
   [Test]
   public async Task InitializeAsyncDisposed_IsCancellationRequested()
   {
@@ -89,10 +88,10 @@ public class AsyncDisposableObjectTests : TestBase<AsyncDisposableObjectTests.Te
       InitializationCounter++;
 
       CancellationToken = cancellationToken;
-        
-      if(ShouldDispose)
+
+      if (ShouldDispose)
         await DisposeAsync().ConfigureAwait(false);
-        
+
       await base.OnInitializeAsync(cancellationToken);
     }
   }

--- a/Tests/ksqlDB.RestApi.Client.Tests/FluentAPI/FieldTypeBuilderTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/FluentAPI/FieldTypeBuilderTests.cs
@@ -5,7 +5,6 @@ using ksqlDB.RestApi.Client.KSql.Query;
 using ksqlDb.RestApi.Client.Metadata;
 using ksqlDb.RestApi.Client.Tests.Models;
 using NUnit.Framework;
-using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 namespace ksqlDb.RestApi.Client.Tests.FluentAPI
 {
@@ -128,7 +127,7 @@ namespace ksqlDb.RestApi.Client.Tests.FluentAPI
       builder = new(fieldMetadata);
 
       //Act
-      Assert.ThrowsException<InvalidOperationException>(() =>
+      Assert.Throws<InvalidOperationException>(() =>
       {
         //Act
         builder.AsPseudoColumn();

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/QbservableExtensionsExplainTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/QbservableExtensionsExplainTests.cs
@@ -28,6 +28,13 @@ public class QbservableExtensionsExplainTests : TestBase
     dbProvider = new TestableDbProviderForExplain(TestParameters.KsqlDbUrl, httpClientFactory);
   }
 
+  [TearDown]
+  public override void TestCleanup()
+  {
+    dbProvider.Dispose();
+    base.TestCleanup();
+  }
+
   private readonly string response =
     @"[{""@type"":""queryDescription"",""statementText"":""EXPLAIN SELECT * FROM Movies EMIT CHANGES;"",""queryDescription"":{""id"":""_confluent-ksql-ksql-connect-clustertransient_3226006621890769790_1631632793312"",""statementText"":""SELECT * FROM Movies EMIT CHANGES;"",""windowType"":null,""fields"":[{""name"":""TITLE"",""schema"":{""type"":""STRING"",""fields"":null,""memberSchema"":null},""type"":""KEY""},{""name"":""TITLE"",""schema"":{""type"":""STRING"",""fields"":null,""memberSchema"":null}},{""name"":""ID"",""schema"":{""type"":""INTEGER"",""fields"":null,""memberSchema"":null}},{""name"":""RELEASE_YEAR"",""schema"":{""type"":""INTEGER"",""fields"":null,""memberSchema"":null}}],""sources"":[""MOVIES""],""sinks"":[],""topology"":""Topologies:\n   Sub-topology: 0\n    Source: KSTREAM-SOURCE-0000000001 (topics: [movies])\n      --> KTABLE-SOURCE-0000000002\n    Processor: KTABLE-SOURCE-0000000002 (stores: [])\n      --> KTABLE-MAPVALUES-0000000003\n      <-- KSTREAM-SOURCE-0000000001\n    Processor: KTABLE-MAPVALUES-0000000003 (stores: [KsqlTopic-Reduce])\n      --> KTABLE-TRANSFORMVALUES-0000000004\n      <-- KTABLE-SOURCE-0000000002\n    Processor: KTABLE-TRANSFORMVALUES-0000000004 (stores: [])\n      --> Project\n      <-- KTABLE-MAPVALUES-0000000003\n    Processor: Project (stores: [])\n      --> KTABLE-TOSTREAM-0000000006\n      <-- KTABLE-TRANSFORMVALUES-0000000004\n    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])\n      --> KSTREAM-FOREACH-0000000007\n      <-- Project\n    Processor: KSTREAM-FOREACH-0000000007 (stores: [])\n      --> none\n      <-- KTABLE-TOSTREAM-0000000006\n\n"",""executionPlan"":"" > [ PROJECT ] | Schema: TITLE STRING KEY, TITLE STRING, ID INTEGER, RELEASE_YEAR INTEGER | Logger: 3226006621890769790.Project\n\t\t > [ SOURCE ] | Schema: TITLE STRING KEY, ID INTEGER, RELEASE_YEAR INTEGER, ROWTIME BIGINT, TITLE STRING | Logger: 3226006621890769790.KsqlTopic.Source\n"",""overriddenProperties"":{},""ksqlHostQueryStatus"":{},""queryType"":""PUSH"",""queryErrors"":[],""tasksMetadata"":[],""state"":null},""warnings"":[]}]";
 
@@ -76,7 +83,7 @@ WHERE c = 'ET' EMIT CHANGES;".ReplaceLineEndings());
   {
     private readonly IHttpClientFactory httpClientFactory;
 
-    public TestableDbProviderForExplain(string ksqlDbUrl, IHttpClientFactory httpClientFactory) 
+    public TestableDbProviderForExplain(string ksqlDbUrl, IHttpClientFactory httpClientFactory)
       : base(ksqlDbUrl)
     {
       this.httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/QbservableExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/QbservableExtensionsTests.cs
@@ -13,7 +13,6 @@ using Microsoft.Reactive.Testing;
 using Moq;
 using NUnit.Framework;
 using UnitTests;
-using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 using TestParameters = ksqlDb.RestApi.Client.Tests.Helpers.TestParameters;
 
 namespace ksqlDb.RestApi.Client.Tests.KSql.Linq;
@@ -129,7 +128,7 @@ public class QbservableExtensionsTests : TestBase
 WHERE ({columnName} = '1') OR (({columnName} != '2') AND ({columnName} = '3')) EMIT CHANGES;".ReplaceLineEndings();
 
     ksql.Should().BeEquivalentTo(expected);
-  }    
+  }
 
   [Test]
   public void OperatorPrecedenceInWhereClause_BuildKSql_PrintsParentheses()
@@ -304,7 +303,7 @@ WHERE (({columnName} = '1') OR ({columnName} != '2')) AND ({columnName} = '3') E
   {
     //Arrange
     var context = new TestableDbProvider(TestParameters.KsqlDbUrl);
-      
+
     var query = context.CreatePushQuery<string>();
 
     //Act
@@ -350,7 +349,7 @@ WHERE (({columnName} = '1') OR ({columnName} != '2')) AND ({columnName} = '3') E
   {
     //Arrange
     var query = CreateTestableKStreamSet();
-      
+
     var testScheduler = new TestScheduler();
 
     var results = new List<string>();
@@ -364,7 +363,7 @@ WHERE (({columnName} = '1') OR ({columnName} != '2')) AND ({columnName} = '3') E
     testScheduler.Start();
 
     //Assert
-    Assert.AreEqual(2, results.Count);
+    results.Count.Should().Be(2);
   }
 
   [Test]
@@ -372,7 +371,7 @@ WHERE (({columnName} = '1') OR ({columnName} != '2')) AND ({columnName} = '3') E
   {
     //Arrange
     var query = CreateTestableKStreamSet();
-      
+
     var testScheduler = new TestScheduler();
 
     var results = new List<string>();
@@ -386,7 +385,7 @@ WHERE (({columnName} = '1') OR ({columnName} != '2')) AND ({columnName} = '3') E
     testScheduler.Start();
 
     //Assert
-    Assert.AreEqual(2, results.Count);
+    results.Count.Should().Be(2);
     subscription.QueryId.Should().Be("xyz");
   }
 
@@ -408,7 +407,7 @@ WHERE (({columnName} = '1') OR ({columnName} != '2')) AND ({columnName} = '3') E
   {
     //Arrange
     var query = CreateTestableKStreamSet();
-      
+
     var testScheduler = new TestScheduler();
 
     //Act
@@ -423,7 +422,7 @@ WHERE (({columnName} = '1') OR ({columnName} != '2')) AND ({columnName} = '3') E
   {
     //Arrange
     var query = CreateTestableKStreamSet();
-      
+
     var testScheduler = new TestScheduler();
 
     //Act
@@ -436,7 +435,7 @@ WHERE (({columnName} = '1') OR ({columnName} != '2')) AND ({columnName} = '3') E
   private static IQbservable<Location> CreateStreamSource()
   {
     var context = new TestableDbProvider(TestParameters.KsqlDbUrl);
-      
+
     return context.CreatePushQuery<Location>();
   }
 
@@ -454,10 +453,10 @@ WHERE (({columnName} = '1') OR ({columnName} != '2')) AND ({columnName} = '3') E
 
     context.KSqlDbRestApiClientMock.Setup(c => c.ExecuteStatementAsync(It.IsAny<KSqlDbStatement>(), It.IsAny<CancellationToken>()))
       .ReturnsAsync(new HttpResponseMessage());
-      
+
     return context.CreatePushQuery<string>();
   }
-    
+
   [Test]
   public void SelectPredicate_BuildKSql_PrintsPredicate()
   {
@@ -471,7 +470,7 @@ WHERE (({columnName} = '1') OR ({columnName} != '2')) AND ({columnName} = '3') E
     //Assert
     ksql.Should().BeEquivalentTo($"SELECT LCASE({nameof(Location.Latitude)}) != LCASE('HI') FROM Locations EMIT CHANGES;");
   }
-    
+
   [Test]
   public void WhereIsNotNull_BuildKSql_PrintsQuery()
   {
@@ -541,7 +540,7 @@ WHERE Id = '{uniqueId}' EMIT CHANGES;".ReplaceLineEndings();
   {
     return context.CreatePushQuery<T>(tableName).Where(l => l.Id == uniqueId);
   }
-  
+
   [Test]
   public async Task InsertIntoAsync()
   {

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/QbservableExtensionsWindowsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/QbservableExtensionsWindowsTests.cs
@@ -7,7 +7,6 @@ using ksqlDb.RestApi.Client.Tests.KSql.Query.Context;
 using ksqlDb.RestApi.Client.Tests.Models;
 using NUnit.Framework;
 using UnitTests;
-using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 using TestParameters = ksqlDb.RestApi.Client.Tests.Helpers.TestParameters;
 
 namespace ksqlDb.RestApi.Client.Tests.KSql.Linq;
@@ -111,7 +110,7 @@ public class QbservableExtensionsWindowsTests : TestBase
     var context = new TransactionsDbProvider(TestParameters.KsqlDbUrl);
 
     //Assert
-    Assert.ThrowsException<InvalidOperationException>(() =>
+    Assert.Throws<InvalidOperationException>(() =>
     {
       //Act
       var grouping = context.CreatePushQuery<Transaction>()

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/Statements/CreateStatementExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Linq/Statements/CreateStatementExtensionsTests.cs
@@ -28,6 +28,13 @@ public class CreateStatementExtensionsTests : TestBase
     DbProvider = new TestableDbProvider(TestParameters.KsqlDbUrl, StatementResponse);
   }
 
+  [TearDown]
+  public override void TestCleanup()
+  {
+    DbProvider.Dispose();
+    base.TestCleanup();
+  }
+
   private const string StreamName = "TestStream";
 
   [Test]
@@ -54,7 +61,7 @@ AS SELECT * FROM {nameof(Location)}s EMIT CHANGES;".ReplaceLineEndings());
     //Arrange
     var creationMetadata = new CreationMetadata
     {
-      KafkaTopic = "moviesByTitle",		
+      KafkaTopic = "moviesByTitle",
       KeyFormat = SerializationFormats.Json,
       ValueFormat = SerializationFormats.Json,
       Replicas = 1,
@@ -153,7 +160,7 @@ AS SELECT * FROM Movies WINDOW TUMBLING (SIZE 2 MINUTES) GROUP BY Title EMIT CHA
   {
     //Arrange
     var query = DbProvider.CreateOrReplaceStreamStatement(StreamName)
-      .As<Movie>()        
+      .As<Movie>()
       .Join(
         Source.Of<Lead_Actor>("Actors"),
         movie => movie.Title,
@@ -180,7 +187,7 @@ EMIT CHANGES;".ReplaceLineEndings());
   {
     //Arrange
     var query = DbProvider.CreateOrReplaceStreamStatement(StreamName)
-      .As<Movie>()        
+      .As<Movie>()
       .FullOuterJoin(
         Source.Of<Lead_Actor>("Actors"),
         movie => movie.Title,
@@ -207,7 +214,7 @@ EMIT CHANGES;".ReplaceLineEndings());
   {
     //Arrange
     var query = DbProvider.CreateOrReplaceStreamStatement(StreamName)
-      .As<Movie>()        
+      .As<Movie>()
       .LeftJoin(
         Source.Of<Lead_Actor>("Actors"),
         movie => movie.Title,

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/KSqlDBContextOptionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/KSqlDBContextOptionsTests.cs
@@ -3,17 +3,15 @@ using ksqlDB.RestApi.Client.KSql.Config;
 using ksqlDB.RestApi.Client.KSql.Query.Context;
 using ksqlDB.RestApi.Client.KSql.Query.Options;
 using ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NUnit.Framework;
 using UnitTests;
-using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 using TestParameters = ksqlDb.RestApi.Client.Tests.Helpers.TestParameters;
 
 namespace ksqlDb.RestApi.Client.Tests.KSql.Query.Context;
 
 public class KSqlDBContextOptionsTests : TestBase<KSqlDBContextOptions>
 {
-  [TestInitialize]
+  [SetUp]
   public override void TestInitialize()
   {
     base.TestInitialize();
@@ -86,8 +84,9 @@ public class KSqlDBContextOptionsTests : TestBase<KSqlDBContextOptions>
     //Act
 
     //Assert
-    Assert.ThrowsException<KeyNotFoundException>(() =>
-      ClassUnderTest.QueryStreamParameters[parameterName].Should().BeEmpty());
+    Assert.Throws<KeyNotFoundException>(
+      () => ClassUnderTest.QueryStreamParameters[parameterName].Should().BeEmpty()
+    );
   }
 
   [Test]

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/Options/KSqlDbContextOptionsBuilderTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/Options/KSqlDbContextOptionsBuilderTests.cs
@@ -4,18 +4,16 @@ using ksqlDB.RestApi.Client.KSql.Query.Context.Options;
 using ksqlDB.RestApi.Client.KSql.Query.Options;
 using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
 using ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NUnit.Framework;
 using UnitTests;
 using static System.String;
-using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 using TestParameters = ksqlDb.RestApi.Client.Tests.Helpers.TestParameters;
 
 namespace ksqlDb.RestApi.Client.Tests.KSql.Query.Context.Options;
 
 public class KSqlDbContextOptionsBuilderTests : TestBase<KSqlDbContextOptionsBuilder>
 {
-  [TestInitialize]
+  [SetUp]
   public override void TestInitialize()
   {
     base.TestInitialize();
@@ -29,7 +27,7 @@ public class KSqlDbContextOptionsBuilderTests : TestBase<KSqlDbContextOptionsBui
     //Arrange
 
     //Assert
-    Assert.ThrowsException<ArgumentNullException>(() =>
+    Assert.Throws<ArgumentNullException>(() =>
     {
       //Act
       _ = ClassUnderTest.UseKSqlDb(Empty).Options;

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Functions/KSqlFunctionsExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Functions/KSqlFunctionsExtensionsTests.cs
@@ -1,84 +1,54 @@
 using ksqlDB.RestApi.Client.KSql.Query.Functions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 using UnitTests;
 
 namespace ksqlDb.RestApi.Client.Tests.KSql.Query.Functions;
 
-[TestClass]
+[TestFixture]
 public class KSqlFunctionsExtensionsTests : TestBase
 {
-  [TestMethod]
-  [ExpectedException(typeof(InvalidOperationException))]
+  [Test]
   public void Like_ThrowsInvalidOperationException()
   {
-    //Arrange
-
-    //Act
-    var kSqlFunctions = KSqlFunctions.Instance.Like("", "");
-
     //Assert
+    Assert.Throws<InvalidOperationException>(() => KSqlFunctions.Instance.Like("", ""));
   }
 
-  [TestMethod]
-  [ExpectedException(typeof(InvalidOperationException))]
+  [Test]
   public void Trim_ThrowsInvalidOperationException()
   {
-    //Arrange
-
-    //Act
-    string kSqlFunctions = KSqlFunctions.Instance.Trim("");
-
     //Assert
+    Assert.Throws<InvalidOperationException>(() => KSqlFunctions.Instance.Trim(""));
   }
 
-  [TestMethod]
-  [ExpectedException(typeof(InvalidOperationException))]
+  [Test]
   public void LPad_ThrowsInvalidOperationException()
   {
-    //Arrange
-
-    //Act
-    var kSqlFunctions = KSqlFunctions.Instance.LPad("", 2, "");
-
     //Assert
+    Assert.Throws<InvalidOperationException>(() => KSqlFunctions.Instance.LPad("", 2, ""));
   }
-    
-  [TestMethod]
-  [ExpectedException(typeof(InvalidOperationException))]
+
+  [Test]
   public void RPad_ThrowsInvalidOperationException()
   {
-    //Arrange
-
-    //Act
-    var kSqlFunctions = KSqlFunctions.Instance.RPad("", 2, "");
-
     //Assert
+    Assert.Throws<InvalidOperationException>(() => KSqlFunctions.Instance.RPad("", 2, ""));
   }
 
-  [TestMethod]
-  [ExpectedException(typeof(InvalidOperationException))]
+  [Test]
   public void Substring_ThrowsInvalidOperationException()
   {
-    //Arrange
-
-    //Act
-    var kSqlFunctions = KSqlFunctions.Instance.Substring("", 2, 2);
-
     //Assert
+    Assert.Throws<InvalidOperationException>(() => KSqlFunctions.Instance.Substring("", 2, 2));
   }
 
   #region Date and time
 
-  [TestMethod]
-  [ExpectedException(typeof(InvalidOperationException))]
+  [Test]
   public void DateToString_ThrowsInvalidOperationException()
   {
-    //Arrange
-
-    //Act
-    string kSqlFunctions = KSqlFunctions.Instance.DateToString(1, "");
-
     //Assert
+    Assert.Throws<InvalidOperationException>(() => KSqlFunctions.Instance.DateToString(1, ""));
   }
 
   #endregion

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Functions/KSqlInvocationFunctionsExtensionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Functions/KSqlInvocationFunctionsExtensionsTests.cs
@@ -1,81 +1,63 @@
 using ksqlDB.RestApi.Client.KSql.Query.Functions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 using UnitTests;
 
 namespace ksqlDb.RestApi.Client.Tests.KSql.Query.Functions;
 
-[TestClass]
+[TestFixture]
 public class KSqlInvocationFunctionsExtensionsTests : TestBase
 {
-  [TestMethod]
-  [ExpectedException(typeof(InvalidOperationException))]
+  [Test]
   public void Transform_ThrowsInvalidOperationException()
   {
-    //Arrange
-
-    //Act
-    var kSqlFunctions = K.Functions.Transform(Array.Empty<int>(), c => c);
-
     //Assert
+    Assert.Throws<InvalidOperationException>(
+      () => K.Functions.Transform(Array.Empty<int>(), c => c)
+    );
   }
 
-  [TestMethod]
-  [ExpectedException(typeof(InvalidOperationException))]
+  [Test]
   public void Filter_ThrowsInvalidOperationException()
   {
-    //Arrange
-
-    //Act
-    var kSqlFunctions = K.Functions.Filter(Array.Empty<int>(), c => true);
-
     //Assert
+    Assert.Throws<InvalidOperationException>(
+      () => K.Functions.Filter(Array.Empty<int>(), c => true)
+    );
   }
 
-  [TestMethod]
-  [ExpectedException(typeof(InvalidOperationException))]
+  [Test]
   public void Reduce_ThrowsInvalidOperationException()
   {
-    //Arrange
-
-    //Act
-    var kSqlFunctions = K.Functions.Reduce(Array.Empty<int>(), 0, (x, y) => x);
-
     //Assert
+    Assert.Throws<InvalidOperationException>(
+      () => K.Functions.Reduce(Array.Empty<int>(), 0, (x, y) => x)
+    );
   }
 
-  [TestMethod]
-  [ExpectedException(typeof(InvalidOperationException))]
+  [Test]
   public void TransformMap_ThrowsInvalidOperationException()
   {
-    //Arrange
-
-    //Act
-    var kSqlFunctions = K.Functions.Transform(new Dictionary<int, string>(), c => c);
-
     //Assert
+    Assert.Throws<InvalidOperationException>(
+      () => K.Functions.Transform(new Dictionary<int, string>(), c => c)
+    );
   }
 
-  [TestMethod]
-  [ExpectedException(typeof(InvalidOperationException))]
+  [Test]
   public void FilterMap_ThrowsInvalidOperationException()
   {
-    //Arrange
-
-    //Act
-    var kSqlFunctions = K.Functions.Filter(new Dictionary<int, string>(), c => true);
-
     //Assert
+    Assert.Throws<InvalidOperationException>(
+      () => K.Functions.Filter(new Dictionary<int, string>(), c => true)
+    );
   }
 
-  [TestMethod]
-  [ExpectedException(typeof(InvalidOperationException))]
+  [Test]
   public void ReduceMap_ThrowsInvalidOperationException()
   {
-    //Arrange
-
-    //Act
-    var kSqlFunctions = K.Functions.Reduce(new Dictionary<int, string>(), 0, (x, y) => x);
-
     //Assert
+    Assert.Throws<InvalidOperationException>(
+      () => K.Functions.Reduce(new Dictionary<int, string>(), 0, (x, y) => x)
+    );
   }
 }

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Functions/KSqlInvocationFunctionsTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Functions/KSqlInvocationFunctionsTests.cs
@@ -78,7 +78,7 @@ public class KSqlInvocationFunctionsTests : TestBase
   }
 
   [Test]
-  [NUnit.Framework.Ignore("TODO:")]
+  [Ignore("TODO:")]
   public void TransformExtensionMethod_Dictionary_ToUpper()
   {
     //Arrange

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/KSqlQueryGeneratorTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/KSqlQueryGeneratorTests.cs
@@ -122,11 +122,12 @@ WHERE {idColumnName} = '1' EMIT CHANGES;";
   {
     public int Id { get; set; }
   }
+
   private class Derived : Base
   {
     public string Description { get; set; }
   }
-  
+
   [Test]
   public void BuildKSql_ModelBuilder_HasColumnNameOverride_ForPropertyInBaseClass()
   {
@@ -140,7 +141,7 @@ WHERE {idColumnName} = '1' EMIT CHANGES;";
       .CreatePushQuery<Derived>()
       .Where(c => c.Id == 1)
       .Select(c => c.Id);
-    
+
     //Act
     var ksql = ClassUnderTest.BuildKSql(query.Expression, queryContext);
 
@@ -220,7 +221,7 @@ EMIT CHANGES;".ReplaceLineEndings();
   }
 
   [Test]
-  [NUnit.Framework.Ignore("TODO")]
+  [Ignore("TODO")]
   public void BuildKSql_SelectFrom3MultiJoinSameTypePropertyWithJsonPropertyNameAttribute()
   {
     //Arrange
@@ -646,7 +647,7 @@ WHERE Dt BETWEEN '0001-01-01' AND '9999-12-31' EMIT CHANGES;".ReplaceLineEndings
 
     ksql.Should().BeEquivalentTo(expectedKsql);
   }
-    
+
   #endregion
 
   #endregion

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/KSqlVisitorTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/KSqlVisitorTests.cs
@@ -919,7 +919,7 @@ public class KSqlVisitorTests : TestBase
   }
 
   [Test]
-  [NUnit.Framework.Ignore("TODO")]
+  [Ignore("TODO")]
   public void NegateBooleanConstant_BuildKSql_PrintsFalse()
   {
     //Arrange

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Visitors/JoinVisitorTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Visitors/JoinVisitorTests.cs
@@ -28,6 +28,13 @@ public class JoinVisitorTests : TestBase
     KSqlDbContext = new KSqlDBContext(contextOptions, new ModelBuilder());
   }
 
+  [TearDown]
+  public override void TestCleanup()
+  {
+    KSqlDbContext.Dispose();
+    base.TestCleanup();
+  }
+
   private static string MovieAlias => "movie";
   private static string ActorAlias => "actor";
 
@@ -39,17 +46,17 @@ public class JoinVisitorTests : TestBase
       @$"SELECT {MovieAlias}.Id Id, {MovieAlias}.Title Title, {MovieAlias}.Release_Year Release_Year, TRIM({ActorAlias}.Actor_Name) ActorName, UCASE({ActorAlias}.Actor_Name) UpperActorName, {ActorAlias}.Title AS ActorTitle FROM Movies {MovieAlias}
 INNER JOIN LeadActors {ActorAlias}
 ON {MovieAlias}.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords,
       @$"SELECT {MovieAlias}.Id Id, {MovieAlias}.Title Title, {MovieAlias}.Release_Year Release_Year, TRIM({ActorAlias}.Actor_Name) ActorName, UCASE({ActorAlias}.Actor_Name) UpperActorName, {ActorAlias}.Title AS ActorTitle FROM Movies {MovieAlias}
 INNER JOIN LeadActors {ActorAlias}
 ON {MovieAlias}.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always,
       @$"SELECT `{MovieAlias}`.`Id` `Id`, `{MovieAlias}`.`Title` `Title`, `{MovieAlias}`.`Release_Year` `Release_Year`, TRIM(`{ActorAlias}`.`Actor_Name`) `ActorName`, UCASE(`{ActorAlias}`.`Actor_Name`) `UpperActorName`, `{ActorAlias}`.`Title` AS `ActorTitle` FROM `Movies` `{MovieAlias}`
 INNER JOIN `LeadActors` `{ActorAlias}`
 ON `{MovieAlias}`.`Title` = `{ActorAlias}`.`Title`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(JoinTestCases))]
@@ -88,17 +95,17 @@ EMIT CHANGES;");
       @$"SELECT {MovieAlias}.Id Id, {MovieAlias}.Title Title, {MovieAlias}.Release_Year Release_Year, TRIM({ActorAlias}.Actor_Name) ActorName, UCASE({ActorAlias}.Actor_Name) UpperActorName, {ActorAlias}.Title AS ActorTitle FROM Movies {MovieAlias}
 INNER JOIN Lead_Actors {ActorAlias}
 ON {MovieAlias}.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords,
       @$"SELECT {MovieAlias}.Id Id, {MovieAlias}.Title Title, {MovieAlias}.Release_Year Release_Year, TRIM({ActorAlias}.Actor_Name) ActorName, UCASE({ActorAlias}.Actor_Name) UpperActorName, {ActorAlias}.Title AS ActorTitle FROM Movies {MovieAlias}
 INNER JOIN Lead_Actors {ActorAlias}
 ON {MovieAlias}.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always,
       @$"SELECT `{MovieAlias}`.`Id` `Id`, `{MovieAlias}`.`Title` `Title`, `{MovieAlias}`.`Release_Year` `Release_Year`, TRIM(`{ActorAlias}`.`Actor_Name`) `ActorName`, UCASE(`{ActorAlias}`.`Actor_Name`) `UpperActorName`, `{ActorAlias}`.`Title` AS `ActorTitle` FROM `Movies` `{MovieAlias}`
 INNER JOIN `Lead_Actors` `{ActorAlias}`
 ON `{MovieAlias}`.`Title` = `{ActorAlias}`.`Title`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(JoinPluralizedJointItemTestCases))]
@@ -137,17 +144,17 @@ EMIT CHANGES;");
       @$"SELECT myMovie.Title Title, LEN({ActorAlias}.Actor_Name) Length FROM Movies myMovie
 INNER JOIN Lead_Actors {ActorAlias}
 ON myMovie.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords,
       @$"SELECT myMovie.Title Title, LEN({ActorAlias}.Actor_Name) Length FROM Movies myMovie
 INNER JOIN Lead_Actors {ActorAlias}
 ON myMovie.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always,
       @$"SELECT `myMovie`.`Title` `Title`, LEN(`{ActorAlias}`.`Actor_Name`) `Length` FROM `Movies` `myMovie`
 INNER JOIN `Lead_Actors` `{ActorAlias}`
 ON `myMovie`.`Title` = `{ActorAlias}`.`Title`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(JoinAndSelectWithAliasesPrintsInnerJoinTestCases))]
@@ -185,15 +192,15 @@ EMIT CHANGES;");
     yield return (Never, @$"SELECT {MovieAlias}.Title Title FROM Movies {MovieAlias}
 INNER JOIN MovieExts ext
 ON {MovieAlias}.Title = ext.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords, @$"SELECT {MovieAlias}.Title Title FROM Movies {MovieAlias}
 INNER JOIN MovieExts ext
 ON {MovieAlias}.Title = ext.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always, @$"SELECT `{MovieAlias}`.`Title` `Title` FROM `Movies` `{MovieAlias}`
 INNER JOIN `MovieExts` `ext`
 ON `{MovieAlias}`.`Title` = `ext`.`Title`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(SameStreamNameDifferentAliasesTestCases))]
@@ -226,15 +233,15 @@ EMIT CHANGES;");
     yield return (Never, @$"SELECT {MovieAlias}.Title Title FROM Movies {MovieAlias}
 INNER JOIN Actors {ActorAlias}
 ON {MovieAlias}.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords, @$"SELECT {MovieAlias}.Title Title FROM Movies {MovieAlias}
 INNER JOIN Actors {ActorAlias}
 ON {MovieAlias}.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always, @$"SELECT `{MovieAlias}`.`Title` `Title` FROM `Movies` `{MovieAlias}`
 INNER JOIN `Actors` `{ActorAlias}`
 ON `{MovieAlias}`.`Title` = `{ActorAlias}`.`Title`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(InnerJoinOverrideStatementNoProjectionFromJoinTableTestCases))]
@@ -268,17 +275,17 @@ EMIT CHANGES;");
       @$"SELECT {MovieAlias}.Title Title, {ActorAlias}.Actor_Name AS ActorName FROM Movies {MovieAlias}
 INNER JOIN Actors {ActorAlias}
 ON {MovieAlias}.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords,
       @$"SELECT {MovieAlias}.Title Title, {ActorAlias}.Actor_Name AS ActorName FROM Movies {MovieAlias}
 INNER JOIN Actors {ActorAlias}
 ON {MovieAlias}.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always,
       @$"SELECT `{MovieAlias}`.`Title` `Title`, `{ActorAlias}`.`Actor_Name` AS `ActorName` FROM `Movies` `{MovieAlias}`
 INNER JOIN `Actors` `{ActorAlias}`
 ON `{MovieAlias}`.`Title` = `{ActorAlias}`.`Title`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(InnerJoinOverrideStatementTestCases))]
@@ -312,15 +319,15 @@ EMIT CHANGES;");
     yield return (Never, @$"SELECT {MovieAlias}.Title Title, {ActorAlias}.Actor_Name AS ActorName FROM Movies {MovieAlias}
 INNER JOIN Actors {ActorAlias}
 ON {MovieAlias}.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords, @$"SELECT {MovieAlias}.Title Title, {ActorAlias}.Actor_Name AS ActorName FROM Movies {MovieAlias}
 INNER JOIN Actors {ActorAlias}
 ON {MovieAlias}.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always, @$"SELECT `{MovieAlias}`.`Title` `Title`, `{ActorAlias}`.`Actor_Name` AS `ActorName` FROM `Movies` `{MovieAlias}`
 INNER JOIN `Actors` `{ActorAlias}`
 ON `{MovieAlias}`.`Title` = `{ActorAlias}`.`Title`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(InnerJoinQuerySyntaxTestCases))]
@@ -349,10 +356,12 @@ EMIT CHANGES;");
   {
     public int Id { get; set; }
   }
+
   private record Shipment
   {
     public int Id { get; set; }
   }
+
   struct Foo
   {
     public int Prop { get; set; }
@@ -366,21 +375,21 @@ INNER JOIN Shipments S1
 ON O.OrderId = S1.Id
 INNER JOIN Payments P1
 ON O.OrderId = P1.Id
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords,
       @"SELECT STRUCT(Prop := 42) value, O.OrderId AS orderId, S1.Id AS shipmentId, P1.Id AS paymentId FROM Orders O
 INNER JOIN Shipments S1
 ON O.OrderId = S1.Id
 INNER JOIN Payments P1
 ON O.OrderId = P1.Id
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always,
       @"SELECT STRUCT(`Prop` := 42) `value`, `O`.`OrderId` AS `orderId`, `S1`.`Id` AS `shipmentId`, `P1`.`Id` AS `paymentId` FROM `Orders` `O`
 INNER JOIN `Shipments` `S1`
 ON `O`.`OrderId` = `S1`.`Id`
 INNER JOIN `Payments` `P1`
 ON `O`.`OrderId` = `P1`.`Id`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(MultipleInnerJoinsQuerySyntaxTestCases))]
@@ -415,6 +424,7 @@ EMIT CHANGES;");
     public IDictionary<string, City> Dictionary { get; set; } = null!;
     public Nested Nested { get; set; } = null!;
   }
+
   private class City
   {
     public int[] Values { get; set; } = null!;
@@ -433,21 +443,21 @@ INNER JOIN Shipments s1
 ON O.OrderId = s1.Id
 INNER JOIN LambdaMaps lm
 ON O.OrderId = lm.Id
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords,
       @$"SELECT TRANSFORM(lm.{nameof(LambdaMap.Dictionary)}, (k, v) => CONCAT(k, '_new'), (k, v) => TRANSFORM(v->`Values`, (x) => x * x)) A, O.OrderId AS orderId, s1.Id AS shipmentId FROM Orders O
 INNER JOIN Shipments s1
 ON O.OrderId = s1.Id
 INNER JOIN LambdaMaps lm
 ON O.OrderId = lm.Id
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always,
       @$"SELECT TRANSFORM(`lm`.`{nameof(LambdaMap.Dictionary)}`, (k, v) => CONCAT(k, '_new'), (k, v) => TRANSFORM(v->`Values`, (x) => x * x)) `A`, `O`.`OrderId` AS `orderId`, `s1`.`Id` AS `shipmentId` FROM `Orders` `O`
 INNER JOIN `Shipments` `s1`
 ON `O`.`OrderId` = `s1`.`Id`
 INNER JOIN `LambdaMaps` `lm`
 ON `O`.`OrderId` = `lm`.`Id`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(TestCasesJoinWithInvocation))]
@@ -475,7 +485,7 @@ EMIT CHANGES;");
   }
 
   [Test]
-  [NUnit.Framework.Ignore("TODO:")]
+  [Ignore("TODO:")]
   public void JoinWithSeveralOnConditions_BuildKSql_Prints()
   {
     //Arrange
@@ -499,15 +509,15 @@ EMIT CHANGES;");
     yield return (Never, @$"SELECT lm.Nested->Prop Prop, O.OrderId AS orderId FROM Orders O
 INNER JOIN LambdaMaps lm
 ON O.OrderId = lm.Id
-WHERE lm.Nested->Prop = 'Nested' EMIT CHANGES;");
+WHERE lm.Nested->Prop = 'Nested' EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords, @$"SELECT lm.Nested->Prop Prop, O.OrderId AS orderId FROM Orders O
 INNER JOIN LambdaMaps lm
 ON O.OrderId = lm.Id
-WHERE lm.Nested->Prop = 'Nested' EMIT CHANGES;");
+WHERE lm.Nested->Prop = 'Nested' EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always, @$"SELECT `lm`.`Nested`->`Prop` `Prop`, `O`.`OrderId` AS `orderId` FROM `Orders` `O`
 INNER JOIN `LambdaMaps` `lm`
 ON `O`.`OrderId` = `lm`.`Id`
-WHERE `lm`.`Nested`->`Prop` = 'Nested' EMIT CHANGES;");
+WHERE `lm`.`Nested`->`Prop` = 'Nested' EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(JoinWithNestedTypeTestCases))]
@@ -539,17 +549,17 @@ WHERE `lm`.`Nested`->`Prop` = 'Nested' EMIT CHANGES;");
       @$"SELECT CONCAT(lm.Nested->Prop, '_new') Concat, o.OrderId AS orderId FROM Orders o
 INNER JOIN LambdaMaps lm
 ON o.OrderId = lm.Id
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords,
       @$"SELECT CONCAT(lm.Nested->Prop, '_new') Concat, o.OrderId AS orderId FROM Orders o
 INNER JOIN LambdaMaps lm
 ON o.OrderId = lm.Id
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always,
       @$"SELECT CONCAT(`lm`.`Nested`->`Prop`, '_new') `Concat`, `o`.`OrderId` AS `orderId` FROM `Orders` `o`
 INNER JOIN `LambdaMaps` `lm`
 ON `o`.`OrderId` = `lm`.`Id`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(JoinWithFunctionAndNestedTypeTestCases))]
@@ -582,21 +592,21 @@ INNER JOIN Shipments S1
 ON O.OrderId = S1.Id
 INNER JOIN Payments P1
 ON O.OrderId = P1.Id
-EMIT CHANGES LIMIT 2;");
+EMIT CHANGES LIMIT 2;".ReplaceLineEndings());
     yield return (Keywords,
       @"SELECT O.OrderId AS orderId, S1.Id AS shipmentId, P1.Id AS paymentId FROM Orders O
 INNER JOIN Shipments S1
 ON O.OrderId = S1.Id
 INNER JOIN Payments P1
 ON O.OrderId = P1.Id
-EMIT CHANGES LIMIT 2;");
+EMIT CHANGES LIMIT 2;".ReplaceLineEndings());
     yield return (Always,
       @"SELECT `O`.`OrderId` AS `orderId`, `S1`.`Id` AS `shipmentId`, `P1`.`Id` AS `paymentId` FROM `Orders` `O`
 INNER JOIN `Shipments` `S1`
 ON `O`.`OrderId` = `S1`.`Id`
 INNER JOIN `Payments` `P1`
 ON `O`.`OrderId` = `P1`.`Id`
-EMIT CHANGES LIMIT 2;");
+EMIT CHANGES LIMIT 2;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(MultipleInnerJoinsQuerySyntaxWithTakeTestCase))]
@@ -632,19 +642,19 @@ LEFT JOIN Shipments sa
 ON o.OrderId = sa.Id
 INNER JOIN Payments p1
 ON o.OrderId = p1.Id
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords, @$"SELECT o.OrderId AS orderId, sa.Id AS shipmentId, p1.Id AS paymentId FROM Orders o
 LEFT JOIN Shipments sa
 ON o.OrderId = sa.Id
 INNER JOIN Payments p1
 ON o.OrderId = p1.Id
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always, @$"SELECT `o`.`OrderId` AS `orderId`, `sa`.`Id` AS `shipmentId`, `p1`.`Id` AS `paymentId` FROM `Orders` `o`
 LEFT JOIN `Shipments` `sa`
 ON `o`.`OrderId` = `sa`.`Id`
 INNER JOIN `Payments` `p1`
 ON `o`.`OrderId` = `p1`.`Id`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(JoinAndLeftJoinWithTakeTestCases))]
@@ -680,21 +690,21 @@ INNER JOIN Shipments s
 WITHIN 5 DAYS ON o.OrderId = s.Id
 INNER JOIN Payments p
 WITHIN 1 HOURS ON o.OrderId = p.Id
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords,
       @$"SELECT o.OrderId AS orderId, s.Id AS shipmentId, p.Id AS paymentId FROM Orders o
 INNER JOIN Shipments s
 WITHIN 5 DAYS ON o.OrderId = s.Id
 INNER JOIN Payments p
 WITHIN 1 HOURS ON o.OrderId = p.Id
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always,
       @$"SELECT `o`.`OrderId` AS `orderId`, `s`.`Id` AS `shipmentId`, `p`.`Id` AS `paymentId` FROM `Orders` `o`
 INNER JOIN `Shipments` `s`
 WITHIN 5 DAYS ON `o`.`OrderId` = `s`.`Id`
 INNER JOIN `Payments` `p`
 WITHIN 1 HOURS ON `o`.`OrderId` = `p`.`Id`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(JoinWithinTimeUnitTestCases))]
@@ -726,15 +736,15 @@ EMIT CHANGES;");
     yield return (Never, @$"SELECT o.OrderId AS orderId, p.Id AS paymentId FROM Orders o
 INNER JOIN Payments p
 WITHIN (1 HOURS, 5 DAYS) ON o.OrderId = p.Id
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords, @$"SELECT o.OrderId AS orderId, p.Id AS paymentId FROM Orders o
 INNER JOIN Payments p
 WITHIN (1 HOURS, 5 DAYS) ON o.OrderId = p.Id
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always, @$"SELECT `o`.`OrderId` AS `orderId`, `p`.`Id` AS `paymentId` FROM `Orders` `o`
 INNER JOIN `Payments` `p`
 WITHIN (1 HOURS, 5 DAYS) ON `o`.`OrderId` = `p`.`Id`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(JoinWithTimeUnitBeforeAfterTestCases))]
@@ -764,15 +774,15 @@ EMIT CHANGES;");
     yield return (Never, @"SELECT actor.Title AS EnduserId, actor.Actor_Name AS Name, movie.Title AS Raw FROM movies movie
 INNER JOIN actors actor
 WITHIN 1 DAYS ON EXTRACTJSONFIELD(movie.Title, '$.movie_title') = EXTRACTJSONFIELD(actor.Actor_Name, '$.actor_name')
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords, @"SELECT actor.Title AS EnduserId, actor.Actor_Name AS Name, movie.Title AS Raw FROM movies movie
 INNER JOIN actors actor
 WITHIN 1 DAYS ON EXTRACTJSONFIELD(movie.Title, '$.movie_title') = EXTRACTJSONFIELD(actor.Actor_Name, '$.actor_name')
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always, @"SELECT `actor`.`Title` AS `EnduserId`, `actor`.`Actor_Name` AS `Name`, `movie`.`Title` AS `Raw` FROM `movies` `movie`
 INNER JOIN `actors` `actor`
 WITHIN 1 DAYS ON EXTRACTJSONFIELD(`movie`.`Title`, '$.movie_title') = EXTRACTJSONFIELD(`actor`.`Actor_Name`, '$.actor_name')
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(JoinKSqlFunctionKeySelectorTestCases))]
@@ -805,17 +815,17 @@ EMIT CHANGES;");
       @$"SELECT movie.Id Id, {MovieAlias}.Title Title, {MovieAlias}.Release_Year Release_Year, TRIM({ActorAlias}.Actor_Name) ActorName, UCASE({ActorAlias}.Actor_Name) UpperActorName, {ActorAlias}.Title AS ActorTitle FROM Movies {MovieAlias}
 LEFT JOIN Lead_Actors {ActorAlias}
 ON movie.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords,
       @$"SELECT movie.Id Id, {MovieAlias}.Title Title, {MovieAlias}.Release_Year Release_Year, TRIM({ActorAlias}.Actor_Name) ActorName, UCASE({ActorAlias}.Actor_Name) UpperActorName, {ActorAlias}.Title AS ActorTitle FROM Movies {MovieAlias}
 LEFT JOIN Lead_Actors {ActorAlias}
 ON movie.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always,
       @$"SELECT `movie`.`Id` `Id`, `{MovieAlias}`.`Title` `Title`, `{MovieAlias}`.`Release_Year` `Release_Year`, TRIM(`{ActorAlias}`.`Actor_Name`) `ActorName`, UCASE(`{ActorAlias}`.`Actor_Name`) `UpperActorName`, `{ActorAlias}`.`Title` AS `ActorTitle` FROM `Movies` `{MovieAlias}`
 LEFT JOIN `Lead_Actors` `{ActorAlias}`
 ON `movie`.`Title` = `{ActorAlias}`.`Title`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(LeftJoinTestCases))]
@@ -854,17 +864,17 @@ EMIT CHANGES;");
       @$"SELECT {MovieAlias}.Id Id, UCASE(a.Actor_Name) UpperActorName, a.Title AS ActorTitle FROM Movies {MovieAlias}
 LEFT JOIN Actors a
 ON {MovieAlias}.Title = a.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords,
       @$"SELECT {MovieAlias}.Id Id, UCASE(a.Actor_Name) UpperActorName, a.Title AS ActorTitle FROM Movies {MovieAlias}
 LEFT JOIN Actors a
 ON {MovieAlias}.Title = a.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always,
       @$"SELECT `{MovieAlias}`.`Id` `Id`, UCASE(`a`.`Actor_Name`) `UpperActorName`, `a`.`Title` AS `ActorTitle` FROM `Movies` `{MovieAlias}`
 LEFT JOIN `Actors` `a`
 ON `{MovieAlias}`.`Title` = `a`.`Title`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(LeftJoinQuerySyntaxTestCases))]
@@ -899,17 +909,17 @@ EMIT CHANGES;");
       @$"SELECT {MovieAlias}.Id Id, UCASE(a.Actor_Name) UpperActorName, a.Title AS ActorTitle FROM Movies {MovieAlias}
 LEFT JOIN Actors a
 ON {MovieAlias}.Title = a.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords,
       @$"SELECT {MovieAlias}.Id Id, UCASE(a.Actor_Name) UpperActorName, a.Title AS ActorTitle FROM Movies {MovieAlias}
 LEFT JOIN Actors a
 ON {MovieAlias}.Title = a.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always,
       @$"SELECT `{MovieAlias}`.`Id` `Id`, UCASE(`a`.`Actor_Name`) `UpperActorName`, `a`.`Title` AS `ActorTitle` FROM `Movies` `{MovieAlias}`
 LEFT JOIN `Actors` `a`
 ON `{MovieAlias}`.`Title` = `a`.`Title`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(TestCasesGroupJoinSelectMany))]
@@ -944,10 +954,12 @@ EMIT CHANGES;");
     public int CustomerId { get; set; }
     public int ItemId { get; set; }
   }
+
   private sealed class Customer
   {
     public int CustomerId { get; set; }
   }
+
   private sealed class Item
   {
     public int ItemId { get; set; }
@@ -962,21 +974,21 @@ LEFT JOIN Items items
 ON orders.ItemId = items.ItemId
 LEFT JOIN Customers customers
 ON orders.CustomerId = customers.CustomerId
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords,
       @"SELECT customers.CustomerId AS customerid, orders.OrderId OrderId, items.ItemId ItemId, items.ItemName ItemName FROM Orders orders
 LEFT JOIN Items items
 ON orders.ItemId = items.ItemId
 LEFT JOIN Customers customers
 ON orders.CustomerId = customers.CustomerId
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always,
       @"SELECT `customers`.`CustomerId` AS `customerid`, `orders`.`OrderId` `OrderId`, `items`.`ItemId` `ItemId`, `items`.`ItemName` `ItemName` FROM `Orders` `orders`
 LEFT JOIN `Items` `items`
 ON `orders`.`ItemId` = `items`.`ItemId`
 LEFT JOIN `Customers` `customers`
 ON `orders`.`CustomerId` = `customers`.`CustomerId`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(MultipleLeftJoinsQuerySyntax))]
@@ -1015,17 +1027,17 @@ EMIT CHANGES;");
       @$"SELECT {ActorAlias}.RowTime RowTime, {MovieAlias}.Title Title FROM Movies {MovieAlias}
 LEFT JOIN Actors {ActorAlias}
 ON {MovieAlias}.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords,
       @$"SELECT {ActorAlias}.RowTime `RowTime`, {MovieAlias}.Title Title FROM Movies {MovieAlias}
 LEFT JOIN Actors {ActorAlias}
 ON {MovieAlias}.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always,
       @$"SELECT `{ActorAlias}`.RowTime `RowTime`, `{MovieAlias}`.`Title` `Title` FROM `Movies` `{MovieAlias}`
 LEFT JOIN `Actors` `{ActorAlias}`
 ON `{MovieAlias}`.`Title` = `{ActorAlias}`.`Title`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(LeftJoinOverrideStreamNameTestCases))]
@@ -1064,17 +1076,17 @@ EMIT CHANGES;");
       @$"SELECT {MovieAlias}.Title Title, {ActorAlias}.Actor_Name AS ActorName FROM Movies {MovieAlias}
 FULL OUTER JOIN Actors {ActorAlias}
 ON {MovieAlias}.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords,
       @$"SELECT {MovieAlias}.Title Title, {ActorAlias}.Actor_Name AS ActorName FROM Movies {MovieAlias}
 FULL OUTER JOIN Actors {ActorAlias}
 ON {MovieAlias}.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always,
       @$"SELECT `{MovieAlias}`.`Title` `Title`, `{ActorAlias}`.`Actor_Name` AS `ActorName` FROM `Movies` `{MovieAlias}`
 FULL OUTER JOIN `Actors` `{ActorAlias}`
 ON `{MovieAlias}`.`Title` = `{ActorAlias}`.`Title`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(FullOuterJoinOverrideStatementTestCases))]
@@ -1113,17 +1125,17 @@ EMIT CHANGES;");
       @$"SELECT {MovieAlias}.Title Title, {ActorAlias}.Actor_Name AS ActorName FROM Movies {MovieAlias}
 RIGHT JOIN Actors {ActorAlias}
 ON {MovieAlias}.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Keywords,
       @$"SELECT {MovieAlias}.Title Title, {ActorAlias}.Actor_Name AS ActorName FROM Movies {MovieAlias}
 RIGHT JOIN Actors {ActorAlias}
 ON {MovieAlias}.Title = {ActorAlias}.Title
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
     yield return (Always,
       @$"SELECT `{MovieAlias}`.`Title` `Title`, `{ActorAlias}`.`Actor_Name` AS `ActorName` FROM `Movies` `{MovieAlias}`
 RIGHT JOIN `Actors` `{ActorAlias}`
 ON `{MovieAlias}`.`Title` = `{ActorAlias}`.`Title`
-EMIT CHANGES;");
+EMIT CHANGES;".ReplaceLineEndings());
   }
 
   [TestCaseSource(nameof(RightJoinOverrideStreamNameTestCases))]

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/KSqlDbRestApiClientTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/KSqlDbRestApiClientTests.cs
@@ -95,7 +95,7 @@ public class KSqlDbRestApiClientTests : KSqlDbRestApiClientTestsBase
     httpRequestMessage.RequestUri.Should().Be("/ksql");
     httpRequestMessage.Content!.Headers!.ContentType!.MediaType.Should().Be(KSqlDbRestApiClient.MediaType);
   }
-    
+
   [Test]
   public async Task CreateHttpRequestMessage_HttpRequestMessage_ContentWasSet()
   {
@@ -227,7 +227,7 @@ public class KSqlDbRestApiClientTests : KSqlDbRestApiClientTestsBase
 
     //Assert
     var expectedContent = GetExpectedContent(StatementTemplates.ShowQueries);
-      
+
     VerifySendAsync(expectedContent);
 
     queriesResponses[0].StatementText.Should().Be(StatementTemplates.ShowQueries);
@@ -251,7 +251,7 @@ public class KSqlDbRestApiClientTests : KSqlDbRestApiClientTestsBase
 
     //Assert
     var expectedContent = GetExpectedContent(StatementTemplates.ShowTopics);
-      
+
     VerifySendAsync(expectedContent);
 
     topicsResponses[0].StatementText.Should().Be(StatementTemplates.ShowTopics);
@@ -271,7 +271,7 @@ public class KSqlDbRestApiClientTests : KSqlDbRestApiClientTestsBase
 
     //Assert
     var expectedContent = GetExpectedContent(StatementTemplates.ShowAllTopics);
-      
+
     VerifySendAsync(expectedContent);
 
     topicsResponses[0].StatementText.Should().Be(StatementTemplates.ShowAllTopics);
@@ -291,7 +291,7 @@ public class KSqlDbRestApiClientTests : KSqlDbRestApiClientTestsBase
     //Assert
     responses.Should().NotBeNull();
     var expectedContent = GetExpectedContent(StatementTemplates.ShowTopicsExtended);
-      
+
     VerifySendAsync(expectedContent);
   }
 
@@ -329,7 +329,7 @@ public class KSqlDbRestApiClientTests : KSqlDbRestApiClientTestsBase
     string terminateStatement = StatementTemplates.TerminatePersistentQuery(queryId);
 
     var expectedContent = GetExpectedContent(terminateStatement);
-      
+
     VerifySendAsync(expectedContent);
 
     string expectedStatement = StatementTemplates.TerminatePersistentQuery(queryId);
@@ -389,7 +389,7 @@ public class KSqlDbRestApiClientTests : KSqlDbRestApiClientTestsBase
 
     //Assert
     var expectedContent = GetExpectedContent(StatementTemplates.ShowStreams);
-      
+
     VerifySendAsync(expectedContent);
 
     streamsResponses[0].StatementText.Should().Be(StatementTemplates.ShowStreams);
@@ -410,7 +410,7 @@ public class KSqlDbRestApiClientTests : KSqlDbRestApiClientTestsBase
 
     //Assert
     var expectedContent = GetExpectedContent(StatementTemplates.ShowTables);
-      
+
     VerifySendAsync(expectedContent);
 
     tablesResponses[0].StatementText.Should().Be(StatementTemplates.ShowTables);
@@ -432,7 +432,7 @@ public class KSqlDbRestApiClientTests : KSqlDbRestApiClientTestsBase
     //Assert
     response.Should().NotBeNull();
     var expectedContent = GetExpectedContent(StatementTemplates.DropStream(streamName));
-      
+
     VerifySendAsync(expectedContent);
   }
 
@@ -472,7 +472,7 @@ public class KSqlDbRestApiClientTests : KSqlDbRestApiClientTestsBase
     string streamName = nameof(TestStream);
     bool useIfExistsClause = true;
     bool deleteTopic = true;
-      
+
     //Act
     var response = await ClassUnderTest.DropStreamAsync(streamName, useIfExistsClause, deleteTopic);
 
@@ -497,7 +497,7 @@ public class KSqlDbRestApiClientTests : KSqlDbRestApiClientTestsBase
     //Assert
     response.Should().NotBeNull();
     var expectedContent = GetExpectedContent(StatementTemplates.DropTable(tableName));
-      
+
     VerifySendAsync(expectedContent);
   }
 
@@ -597,6 +597,7 @@ public class KSqlDbRestApiClientTests : KSqlDbRestApiClientTestsBase
     [IgnoreByInserts]
     public long RowTime { get; set; }
     public string Title { get; set; }
+
     [Key]
     public int Id { get; set; }
     public string Release_Date { get; set; }
@@ -638,7 +639,7 @@ public class KSqlDbRestApiClientTests : KSqlDbRestApiClientTestsBase
     response[0].TopicName.Should().Be(topicName);
     response[0].Exists.Should().BeTrue();
   }
-  
+
   [Test]
   public async Task AssertTopicExistsAsync_ReturnsFalse()
   {

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/KSqlDbRestApiClientTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/KSqlDbRestApiClientTests.cs
@@ -721,8 +721,9 @@ public class KSqlDbRestApiClientTests : KSqlDbRestApiClientTestsBase
     var response = await ClassUnderTest.CreateSourceTableAsync<Movie>(creationMetadata);
 
     //Assert
-    var expectedContent = GetExpectedContent(@"CREATE SOURCE TABLE Movies (\r\n\tTitle VARCHAR,\r\n\tId INT PRIMARY KEY,\r\n\tRelease_Year INT\r\n) WITH ( KAFKA_TOPIC=\u0027moviesByTitle\u0027, VALUE_FORMAT=\u0027Json\u0027, PARTITIONS=\u00271\u0027, REPLICAS=\u00271\u0027 );".ReplaceLineEndings());
-
+    var expectedContent = GetExpectedContent(
+      @"CREATE SOURCE TABLE Movies (Title VARCHAR,Id INT PRIMARY KEY,Release_Year INT) WITH ( KAFKA_TOPIC=\u0027moviesByTitle\u0027, VALUE_FORMAT=\u0027Json\u0027, PARTITIONS=\u00271\u0027, REPLICAS=\u00271\u0027 );".ReplaceLineEndings()
+    );
     VerifySendAsync(expectedContent);
 
     response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -745,7 +746,9 @@ public class KSqlDbRestApiClientTests : KSqlDbRestApiClientTestsBase
     var response = await ClassUnderTest.CreateSourceStreamAsync<Movie>(creationMetadata);
 
     //Assert
-    var expectedContent = GetExpectedContent(@"CREATE SOURCE STREAM Movies (\r\n\tTitle VARCHAR,\r\n\tId INT KEY,\r\n\tRelease_Year INT\r\n) WITH ( KAFKA_TOPIC=\u0027moviesByTitle\u0027, VALUE_FORMAT=\u0027Json\u0027, PARTITIONS=\u00271\u0027, REPLICAS=\u00271\u0027 );".ReplaceLineEndings());
+    var expectedContent = GetExpectedContent(
+      @"CREATE SOURCE STREAM Movies (Title VARCHAR,Id INT KEY,Release_Year INT) WITH ( KAFKA_TOPIC=\u0027moviesByTitle\u0027, VALUE_FORMAT=\u0027Json\u0027, PARTITIONS=\u00271\u0027, REPLICAS=\u00271\u0027 );".ReplaceLineEndings()
+    );
 
     VerifySendAsync(expectedContent);
 

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/KSqlDbRestApiClientTestsBase.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/KSqlDbRestApiClientTestsBase.cs
@@ -1,6 +1,6 @@
 using ksqlDb.RestApi.Client.Tests.Fakes.Http;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using NUnit.Framework;
 using UnitTests;
 using IHttpClientFactory = ksqlDB.RestApi.Client.KSql.RestApi.Http.IHttpClientFactory;
 
@@ -12,12 +12,19 @@ public abstract class KSqlDbRestApiClientTestsBase : TestBase
   protected HttpClient HttpClient = null!;
   protected Mock<HttpMessageHandler> HttpMessageHandlerMock = null!;
 
-  [TestInitialize]
+  [SetUp]
   public override void TestInitialize()
   {
     base.TestInitialize();
 
     HttpClientFactory = Mock.Of<IHttpClientFactory>();
+  }
+
+  [TearDown]
+  public override void TestCleanup()
+  {
+    HttpClient?.Dispose();
+    base.TestCleanup();
   }
 
   protected void CreateHttpMocks(string responseContents)

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/RowValueJsonSerializerTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/RowValueJsonSerializerTests.cs
@@ -1,16 +1,15 @@
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using FluentAssertions;
+using ksqlDb.RestApi.Client.FluentAPI.Builders;
 using ksqlDB.RestApi.Client.KSql.Query;
 using ksqlDb.RestApi.Client.KSql.Query.Context.Options;
 using ksqlDB.RestApi.Client.KSql.RestApi;
 using ksqlDB.RestApi.Client.KSql.RestApi.Responses;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements;
+using ksqlDb.RestApi.Client.Tests.KSql.RestApi.Generators;
 using NUnit.Framework;
 using UnitTests;
-using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
-using ksqlDb.RestApi.Client.Tests.KSql.RestApi.Generators;
-using System.Text.Json.Serialization.Metadata;
-using ksqlDb.RestApi.Client.FluentAPI.Builders;
 
 namespace ksqlDb.RestApi.Client.Tests.KSql.RestApi;
 
@@ -218,6 +217,7 @@ public class RowValueJsonSerializerTests : TestBase
   {
     public string Title { get; set; } = null!;
     public int Id { get; set; }
+
     [JsonPropertyName("RELEASE_YEAR")]
     public int ReleaseYear { get; set; }
   }
@@ -421,7 +421,7 @@ public class RowValueJsonSerializerTests : TestBase
     };
 
     //Assert
-    Assert.ThrowsException<InvalidOperationException>(() =>
+    Assert.Throws<InvalidOperationException>(() =>
     {
       //Act
       ClassUnderTest = new RowValueJsonSerializer(queryStreamHeader);

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/CreateInsertTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/CreateInsertTests.cs
@@ -26,8 +26,10 @@ public class CreateInsertTests
   private class Movie
   {
     public string Title { get; set; } = null!;
+
     [Key]
     public int Id { get; set; }
+
     [JsonPropertyName("ReleaseYear")]
     public int ReleaseYear { get; set; }
 

--- a/Tests/ksqlDB.RestApi.Client.Tests/ksqlDb.RestApi.Client.Tests.csproj
+++ b/Tests/ksqlDB.RestApi.Client.Tests/ksqlDb.RestApi.Client.Tests.csproj
@@ -14,7 +14,6 @@
 		<PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="Microsoft.Reactive.Testing" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="Moq" />
 		<PackageReference Include="NUnit" />
 		<PackageReference Include="NUnit3TestAdapter" />

--- a/Tests/ksqlDB.RestApi.Client.Tests/ksqlDb.RestApi.Client.Tests.csproj
+++ b/Tests/ksqlDB.RestApi.Client.Tests/ksqlDb.RestApi.Client.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSTest.Sdk/3.6.2">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<ImplicitUsings>enable</ImplicitUsings>
@@ -12,7 +12,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="Microsoft.Reactive.Testing" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="Moq" />
 		<PackageReference Include="NUnit" />
 		<PackageReference Include="NUnit3TestAdapter" />

--- a/Tests/ksqlDb.RestApi.Client.ProtoBuf.Tests/KSql/RestApi/KSqlDbQueryProviderTests.cs
+++ b/Tests/ksqlDb.RestApi.Client.ProtoBuf.Tests/KSql/RestApi/KSqlDbQueryProviderTests.cs
@@ -1,7 +1,6 @@
 using FluentAssertions;
-using ksqlDb.RestApi.Client.ProtoBuf.Tests.Models;
 using ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ksqlDb.RestApi.Client.ProtoBuf.Tests.Models;
 using Ninject;
 using NUnit.Framework;
 using UnitTests;
@@ -9,10 +8,10 @@ using UnitTests;
 namespace ksqlDb.RestApi.Client.ProtoBuf.Tests.KSql.RestApi;
 
 public class KSqlDbQueryProviderTests : TestBase
-{  
+{
   private TestableKSqlDbQueryProvider ClassUnderTest { get; set; } = null!;
 
-  [TestInitialize]
+  [SetUp]
   public override void TestInitialize()
   {
     base.TestInitialize();

--- a/Tests/ksqlDb.RestApi.Client.ProtoBuf.Tests/ksqlDb.RestApi.Client.ProtoBuf.Tests.csproj
+++ b/Tests/ksqlDb.RestApi.Client.ProtoBuf.Tests/ksqlDb.RestApi.Client.ProtoBuf.Tests.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="MSTest.Sdk/3.6.2">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
+<PropertyGroup>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>12.0</LangVersion>
 		<IsPackable>false</IsPackable>
@@ -13,6 +13,7 @@
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" />
 		<PackageReference Include="Microsoft.Reactive.Testing" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="Moq" />
 		<PackageReference Include="NUnit" />
 		<PackageReference Include="NUnit3TestAdapter" />

--- a/ksqlDb.RestApi.Client.ProtoBuf/ksqlDb.RestApi.Client.ProtoBuf.csproj
+++ b/ksqlDb.RestApi.Client.ProtoBuf/ksqlDb.RestApi.Client.ProtoBuf.csproj
@@ -24,7 +24,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="ksqlDb.RestApi.Client" Version="7.0.0" />
+        <PackageReference Include="ksqlDb.RestApi.Client" Version="7.1.0" />
         <!-- <ProjectReference Include="..\ksqlDb.RestApi.Client\ksqlDb.RestApi.Client.csproj" /> -->
         <PackageReference Include="protobuf-net" Version="3.2.0" />
     </ItemGroup>

--- a/ksqlDb.RestApi.Client/KSql/Linq/QbservableExtensions.cs
+++ b/ksqlDb.RestApi.Client/KSql/Linq/QbservableExtensions.cs
@@ -165,7 +165,7 @@ public static class QbservableExtensions
 
     var kStreamSet = (KStreamSet<TSource>)source;
 
-    var explainStatement = CreateExplainStatement(kStreamSet);
+    var explainStatement = CreateExplainStatement(kStreamSet).Replace("\r", " ").Replace("\n", " ");
 
     var httpClientFactory = kStreamSet.GetHttpClientFactory();
 
@@ -205,7 +205,7 @@ public static class QbservableExtensions
   #endregion
 
   #region ExplainAsync
-    
+
   /// <summary>
   /// Show the execution plan for a SQL expression, show the execution plan plus additional runtime information and metrics.
   /// </summary>
@@ -446,7 +446,7 @@ public static class QbservableExtensions
         source.Expression, Expression.Quote(keySelector))
     );
   }
-    
+
   private static MethodInfo? groupByTSourceTKeyTElement3;
 
   private static MethodInfo GroupBy_TSource_TKey_TElement_3(Type source, Type key, Type element) =>
@@ -497,19 +497,19 @@ public static class QbservableExtensions
   {
     if (outer == null)
       throw new ArgumentNullException(nameof(outer));
-      
+
     if (inner == null)
       throw new ArgumentNullException(nameof(inner));
-      
+
     if (outerKeySelector == null)
       throw new ArgumentNullException(nameof(outerKeySelector));
-      
+
     if (innerKeySelector == null)
       throw new ArgumentNullException(nameof(innerKeySelector));
-      
+
     if (resultSelector == null)
       throw new ArgumentNullException(nameof(resultSelector));
-      
+
     return outer.Provider.CreateQuery<TResult>(
       Expression.Call(
         null,
@@ -574,7 +574,7 @@ public static class QbservableExtensions
       throw new ArgumentNullException(nameof(collectionSelector));
     if (resultSelector == null)
       throw new ArgumentNullException(nameof(resultSelector));
-      
+
     return source.Provider.CreateQuery<TResult>(
       Expression.Call(
         null,

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Extensions/MemberInfoExtensions.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Extensions/MemberInfoExtensions.cs
@@ -14,6 +14,6 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi.Extensions
     /// <param name="escaping"></param>
     /// <param name="metadataProvider"></param>
     /// <returns>the <c>memberInfo.Name</c> modified based on the provided <c>format</c></returns>
-    public static string Format(this MemberInfo memberInfo, IdentifierEscaping escaping, IMetadataProvider metadataProvider) => IdentifierUtil.Format(memberInfo, escaping, metadataProvider);
+    public static string Format(this MemberInfo memberInfo, IdentifierEscaping escaping, IMetadataProvider? metadataProvider) => IdentifierUtil.Format(memberInfo, escaping, metadataProvider);
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Generators/TypeGenerator.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Generators/TypeGenerator.cs
@@ -11,8 +11,15 @@ using System.Reflection;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Generators;
 
-internal sealed class TypeGenerator(IMetadataProvider metadataProvider) : EntityInfo(metadataProvider)
+internal sealed class TypeGenerator : EntityInfo
 {
+  private readonly IMetadataProvider metadataProvider;
+
+  public TypeGenerator(IMetadataProvider metadataProvider) : base(metadataProvider)
+  {
+    this.metadataProvider = metadataProvider;
+  }
+
   internal string Print<T>(TypeProperties properties)
   {
     StringBuilder stringBuilder = new();
@@ -45,7 +52,7 @@ internal sealed class TypeGenerator(IMetadataProvider metadataProvider) : Entity
 
     stringBuilder.Append(string.Join(", ", ksqlProperties));
   }
-  
+
   private static string EscapeName(string name, IdentifierEscaping escaping) =>
     (escaping, IdentifierUtil.IsValid(name)) switch
     {

--- a/ksqlDb.RestApi.Client/KSql/RestApi/KSqlDbRestApiClient.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/KSqlDbRestApiClient.cs
@@ -122,7 +122,13 @@ public class KSqlDbRestApiClient : IKSqlDbRestApiClient
   {
     logger?.LogInformation("Executing command: {SQL}", ksqlDbStatement.Sql);
 
-    return ExecuteStatementAsync(ksqlDbStatement, ksqlDbStatement.EndpointType, ksqlDbStatement.ContentEncoding, cancellationToken);
+    ksqlDbStatement.Sql = ksqlDbStatement.CompactSql();
+    return ExecuteStatementAsync(
+      ksqlDbStatement,
+      ksqlDbStatement.EndpointType,
+      ksqlDbStatement.ContentEncoding,
+      cancellationToken
+    );
   }
 
   private async Task<HttpResponseMessage> ExecuteStatementAsync(object content, EndpointType endPointType, Encoding encoding, CancellationToken cancellationToken = default)

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntity.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntity.cs
@@ -10,9 +10,15 @@ using ksqlDb.RestApi.Client.Metadata;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 
-internal sealed class CreateEntity(IMetadataProvider metadataProvider) : EntityInfo(metadataProvider)
+internal sealed class CreateEntity : EntityInfo
 {
   private readonly StringBuilder stringBuilder = new();
+  private readonly IMetadataProvider metadataProvider;
+
+  public CreateEntity(IMetadataProvider metadataProvider) : base(metadataProvider)
+  {
+    this.metadataProvider = metadataProvider;
+  }
 
   internal string Print<T>(StatementContext statementContext, EntityCreationMetadata metadata, bool? ifNotExists)
   {

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/KSqlDbStatement.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/KSqlDbStatement.cs
@@ -9,6 +9,7 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 /// </summary>
 public sealed class KSqlDbStatement : QueryParameters
 {
+
   public KSqlDbStatement(string statement)
   {
     if (string.IsNullOrEmpty(statement))
@@ -18,6 +19,11 @@ public sealed class KSqlDbStatement : QueryParameters
 
     EndpointType = EndpointType.KSql;
   }
+
+  /// <summary>
+  /// Returns the sql statement as a compact one line string without formatting characters.
+  /// </summary>
+  public string CompactSql() => Sql.Replace("\n", string.Empty).Replace("\r", string.Empty).Replace("\t", string.Empty).Trim();
 
   /// <summary>
   /// Dictionary (map) of string variable names and values of any type as initial variable substitution values.

--- a/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
+++ b/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
@@ -22,8 +22,9 @@
         <PackageReleaseNotes>https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/ksqlDb.RestApi.Client/ChangeLog.md</PackageReleaseNotes>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
+
     </PropertyGroup>
-    
+
     <ItemGroup>
         <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
         <PackageReference Include="Antlr4BuildTasks" Version="12.8.0" />


### PR DESCRIPTION
I have updated the test project to be able to run the tests via

```sh
dotnet test Tests/ksqlDB.RestApi.Client.Tests/ksqlDb.RestApi.Client.Tests.csproj
```

or neotest.

But these two tests fail:

- `CreateSourceTableAsync`
- `CreateSourceStreamAsync`

with a mock exception. The response code is 200 though.



```
Moq.MockException : 
Expected invocation on the mock once, but was 0 times: mock => mock.SendAsync(It.Is<HttpRequestMessage>(c => (c.Method == HttpMethod.Post && c.RequestUri.PathAndQuery == requestUri) && c.Content.ReadAsStringAsync().Result == content), It.IsAny<CancellationToken>())

Performed invocations:

   Mock<HttpMessageHandler:24> (mock):

      HttpMessageHandler.SendAsync(Method: POST, RequestUri: 'http://localhost:8088/ksql', Version: 1.1, Content: System.Net.Http.StringContent, Headers:
{
  Accept: application/vnd.ksql.v1+json
  Content-Type: application/vnd.ksql.v1+json; charset=utf-8
  Content-Length: 248
}, CancellationToken)

   at Moq.Mock.Verify(Mock mock, LambdaExpression expression, Times times, String failMessage) in /_/src/Moq/Mock.cs:line 332
   at Moq.Protected.ProtectedMock`1.InternalVerify(String methodName, Type[] genericTypeArguments, Times times, Boolean exactParameterMatch, Object[] args) in /_/src/Moq/Protected/ProtectedMock.cs:line 234
   at Moq.Protected.ProtectedMock`1.Verify(String methodName, Times times, Boolean exactParameterMatch, Object[] args) in /_/src/Moq/Protected/ProtectedMock.cs:line 217
   at ksqlDb.RestApi.Client.Tests.KSql.RestApi.KSqlDbRestApiClientTests.VerifySendAsync(String content, String requestUri) in /home/martin/repos/ksqlDB.RestApi.Client-DotNet/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/KSqlDbRestApiClientTests.cs:line 375
   at ksqlDb.RestApi.Client.Tests.KSql.RestApi.KSqlDbRestApiClientTests.CreateSourceStreamAsync() in /home/martin/repos/ksqlDB.RestApi.Client-DotNet/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/KSqlDbRestApiClientTests.cs:line 750
```

@tomasfabian Do you have an idea of fixing those?

UPDATE: I have fixed them by stripping the special formatting characters from the ksql statement before sending the request.