### PR TITLE
fix: entity info member check is not isolated

### DIFF
--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/KSqlTypeTranslatorTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Statements/KSqlTypeTranslatorTests.cs
@@ -426,6 +426,7 @@ namespace ksqlDb.RestApi.Client.Tests.KSql.RestApi.Statements
     public void Translate_UseModelBuilderConfiguration_Ignore()
     {
       //Arrange
+      var kSqlTypeTranslator = new KSqlTypeTranslator<PocoEx>(modelBuilder);
       var type = typeof(PocoEx);
       modelBuilder.Entity<PocoEx>()
         .Property(c => c.Description)
@@ -442,6 +443,7 @@ namespace ksqlDb.RestApi.Client.Tests.KSql.RestApi.Statements
     public void Translate_UseModelBuilderConfiguration_IgnorePropertyFromBaseType()
     {
       //Arrange
+      var kSqlTypeTranslator  = new KSqlTypeTranslator<PocoEx>(modelBuilder);
       var type = typeof(PocoEx);
       modelBuilder.Entity<PocoEx>()
         .Property(c => c.Amount)

--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -1,5 +1,10 @@
 # ksqlDB.RestApi.Client
 
+# 7.1.2
+
+## 🐛 Bug Fixes
+- fixed `EntityInfo.Members` to isolate fieldmetadata lookup between entities that share fields with same types.
+
 # 7.1.1
 
 ## 🐛 Bug Fixes

--- a/ksqlDb.RestApi.Client/Infrastructure/Extensions/TypeExtensions.cs
+++ b/ksqlDb.RestApi.Client/Infrastructure/Extensions/TypeExtensions.cs
@@ -33,8 +33,8 @@ internal static class TypeExtensions
 
     return null;
   }
-    
-  internal static bool IsStruct(this Type source) 
+
+  internal static bool IsStruct(this Type source)
   {
     return source.IsValueType && !source.IsEnum && !source.IsPrimitive;
   }
@@ -84,7 +84,7 @@ internal static class TypeExtensions
   {
     return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IKSqlGrouping<,>);
   }
-    
+
   internal static string ExtractTypeName(this Type type)
   {
     var name = type.Name;
@@ -94,7 +94,7 @@ internal static class TypeExtensions
 
     return name;
   }
-    
+
   internal static TAttribute? TryGetAttribute<TAttribute>(this MemberInfo memberInfo)
     where TAttribute : Attribute
   {

--- a/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlVisitor.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Visitors/KSqlVisitor.cs
@@ -439,7 +439,7 @@ internal class KSqlVisitor : ExpressionVisitor
 
       return memberExpression;
     }
-    
+
     var memberName2 = memberExpression.GetMemberName(QueryMetadata.ModelBuilder);
 
     switch (memberExpression.Expression.NodeType)

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Generators/TypeGenerator.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Generators/TypeGenerator.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text;
 using ksqlDb.RestApi.Client.FluentAPI.Builders;
 using ksqlDB.RestApi.Client.Infrastructure.Extensions;
@@ -5,9 +6,8 @@ using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
 using ksqlDb.RestApi.Client.KSql.RestApi.Parsers;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
-using static ksqlDB.RestApi.Client.KSql.RestApi.Enums.IdentifierEscaping;
 using ksqlDb.RestApi.Client.Metadata;
-using System.Reflection;
+using static ksqlDB.RestApi.Client.KSql.RestApi.Enums.IdentifierEscaping;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Generators;
 
@@ -63,12 +63,12 @@ internal sealed class TypeGenerator : EntityInfo
       _ => throw new ArgumentOutOfRangeException(nameof(escaping), escaping, "Non-exhaustive match")
     };
 
-  protected override bool IncludeMemberInfo(Type type, EntityMetadata? entityMetadata, MemberInfo memberInfo, bool? includeReadOnly = null)
+  protected override bool IncludeMemberInfo<TEntity>(Type type, EntityMetadata? entityMetadata, MemberInfo memberInfo, bool? includeReadOnly = null)
   {
     var fieldMetadata = entityMetadata?.GetFieldMetadataBy(memberInfo);
     if (fieldMetadata is { IgnoreInDDL: true })
       return false;
 
-    return base.IncludeMemberInfo(type, entityMetadata, memberInfo, includeReadOnly) && !memberInfo.GetCustomAttributes().OfType<IgnoreInDDLAttribute>().Any();
+    return base.IncludeMemberInfo<TEntity>(type, entityMetadata, memberInfo, includeReadOnly) && !memberInfo.GetCustomAttributes().OfType<IgnoreInDDLAttribute>().Any();
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntity.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateEntity.cs
@@ -5,8 +5,8 @@ using ksqlDB.RestApi.Client.Infrastructure.Extensions;
 using ksqlDB.RestApi.Client.KSql.Query.Context;
 using ksqlDB.RestApi.Client.KSql.RestApi.Enums;
 using ksqlDb.RestApi.Client.KSql.RestApi.Parsers;
-using static System.String;
 using ksqlDb.RestApi.Client.Metadata;
+using static System.String;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
 
@@ -108,12 +108,12 @@ internal sealed class CreateEntity : EntityInfo
     return $" {key}";
   }
 
-  protected override bool IncludeMemberInfo(Type type, EntityMetadata? entityMetadata, MemberInfo memberInfo, bool? includeReadOnly = null)
+  protected override bool IncludeMemberInfo<TEntity>(Type type, EntityMetadata? entityMetadata, MemberInfo memberInfo, bool? includeReadOnly = null)
   {
     var fieldMetadata = entityMetadata?.GetFieldMetadataBy(memberInfo);
     if (fieldMetadata is { IgnoreInDDL: true })
       return false;
 
-    return base.IncludeMemberInfo(type, entityMetadata, memberInfo, includeReadOnly) && !memberInfo.GetCustomAttributes().OfType<IgnoreInDDLAttribute>().Any();
+    return base.IncludeMemberInfo<TEntity>(type, entityMetadata, memberInfo, includeReadOnly) && !memberInfo.GetCustomAttributes().OfType<IgnoreInDDLAttribute>().Any();
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateInsert.cs
@@ -1,11 +1,11 @@
 using System.Reflection;
 using System.Text;
+using ksqlDb.RestApi.Client.FluentAPI.Builders;
 using ksqlDB.RestApi.Client.KSql.RestApi.Extensions;
 using ksqlDb.RestApi.Client.KSql.RestApi.Parsers;
+using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Annotations;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Inserts;
 using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Properties;
-using ksqlDb.RestApi.Client.FluentAPI.Builders;
-using ksqlDB.RestApi.Client.KSql.RestApi.Statements.Annotations;
 using ksqlDb.RestApi.Client.Metadata;
 
 namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements;
@@ -40,7 +40,7 @@ internal sealed class CreateInsert : EntityInfo
 
     bool isFirst = true;
 
-    foreach (var memberInfo in Members(entityType, insertProperties.IncludeReadOnlyProperties))
+    foreach (var memberInfo in Members<T>(entityType, insertProperties.IncludeReadOnlyProperties))
     {
       if (isFirst)
       {
@@ -82,12 +82,12 @@ internal sealed class CreateInsert : EntityInfo
     return value;
   }
 
-  protected override bool IncludeMemberInfo(Type type, EntityMetadata? entityMetadata, MemberInfo memberInfo, bool? includeReadOnly = null)
+  protected override bool IncludeMemberInfo<TEntity>(Type type, EntityMetadata? entityMetadata, MemberInfo memberInfo, bool? includeReadOnly = null)
   {
     var fieldMetadata = entityMetadata?.GetFieldMetadataBy(memberInfo);
-    if (fieldMetadata is {IgnoreInDML: true})
+    if (fieldMetadata is { IgnoreInDML: true })
       return false;
 
-    return base.IncludeMemberInfo(type, entityMetadata, memberInfo, includeReadOnly) && !memberInfo.GetCustomAttributes().OfType<IgnoreByInsertsAttribute>().Any();
+    return base.IncludeMemberInfo<TEntity>(type, entityMetadata, memberInfo, includeReadOnly) && !memberInfo.GetCustomAttributes().OfType<IgnoreByInsertsAttribute>().Any();
   }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateKSqlValue.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/CreateKSqlValue.cs
@@ -85,7 +85,7 @@ internal sealed class CreateKSqlValue(IMetadataProvider metadataProvider) : Enti
     }
     else if (!type.IsGenericType && (type.IsClass || type.IsStruct()))
     {
-      GenerateStruct(valueFormatters, type, formatter, ref value);
+      GenerateStruct<T>(valueFormatters, type, formatter, ref value);
     }
     else
     {
@@ -130,7 +130,7 @@ internal sealed class CreateKSqlValue(IMetadataProvider metadataProvider) : Enti
     value = sb.ToString();
   }
 
-  private void GenerateStruct(IValueFormatters valueFormatters, Type type, Func<MemberInfo, string> formatter,
+  private void GenerateStruct<T>(IValueFormatters valueFormatters, Type type, Func<MemberInfo, string> formatter,
     ref object value)
   {
     var sb = new StringBuilder();
@@ -139,7 +139,7 @@ internal sealed class CreateKSqlValue(IMetadataProvider metadataProvider) : Enti
 
     bool isFirst = true;
 
-    foreach (var memberInfo2 in Members(type))
+    foreach (var memberInfo2 in Members<T>(type))
     {
       if (isFirst)
         isFirst = false;

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/KSqlTypeTranslator.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/KSqlTypeTranslator.cs
@@ -117,7 +117,7 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements
     {
       var ksqlProperties = new List<string>();
 
-      foreach (var memberInfo in Members(type, false))
+      foreach (var memberInfo in Members<TEntity>(type, false))
       {
         var memberType = GetMemberType(memberInfo);
 

--- a/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
+++ b/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
@@ -15,8 +15,8 @@
             Documentation for the library can be found at https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/README.md.
         </Description>
         <PackageTags>ksql ksqlDB LINQ .NET csharp push query</PackageTags>
-        <Version>7.1.1</Version>
-        <AssemblyVersion>7.1.1.0</AssemblyVersion>
+        <Version>7.1.2</Version>
+        <AssemblyVersion>7.1.2.0</AssemblyVersion>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <PackageReleaseNotes>https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/ksqlDb.RestApi.Client/ChangeLog.md</PackageReleaseNotes>


### PR DESCRIPTION
The member check did not fall back to check an entity for fieldmetadata but instead checks all fieldmetadata from all entities, breaking isolated configuration per entity. It also did not consider array element types.

The KSqlTypeTranslator is parameterized by the entity type, this type parameter is used to retrieve entity metadata, to find any field type related configuration for the entity which the translators `Translate` method will translate.

This allows to configure one entity which has a property of some type A with field configuration and also to configure an entity of type A with another set of field configurations. The configurations will not interfere with each other.