### PR TITLE
fix: empty array constructors are not valid

### DIFF
--- a/ksqlDb.RestApi.Client/KSql/RestApi/Statements/KSqlTypes.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Statements/KSqlTypes.cs
@@ -15,5 +15,6 @@ namespace ksqlDB.RestApi.Client.KSql.RestApi.Statements
     internal const string Array = "ARRAY";
     internal const string Struct = "STRUCT";
     internal const string Map = "MAP";
+    internal const string Null = "NULL";
   }
 }


### PR DESCRIPTION
Null or empty arrays must be either set to `NULL` or when on a struct field be set using `ARRAY_REMOVE(ARRAY[0], 0)`.

Trying to insert an empty array will result in an error like this:

> Invalid insert value: Cannot construct an array with all NULL elements (see https://github.com/confluentinc/ksql/issues/4239). As a workaround, you may cast a NULL value to the desired type..