### PR TITLE
fix: casting nulls while generating insert statement

### DIFF
--- a/ksqlDb.RestApi.Client/ChangeLog.md
+++ b/ksqlDb.RestApi.Client/ChangeLog.md
@@ -1,5 +1,10 @@
 # ksqlDB.RestApi.Client
 
+# 7.1.5
+
+## 🐛 Bug Fixes
+- casting nulls while generating insert statement. #115 (contributed by @vidyaranya92)
+
 # 7.1.4
 
 ## 🐛 Bug Fixes
@@ -80,7 +85,7 @@ This enables updating the credentials at runtime by setting them on the `KSqlDbC
 ## 🚀 New Features
 1. **KSqlDbRestApiClient Constructor Update**:
     - The `KSqlDbRestApiClient` class constructor now includes a parameter for `KSqlDBRestApiClientOptions`.
-    
+
 2. **EntityCreationMetadata Update**:
     - The `EntityCreationMetadata.ShouldPluralizeEntityName` property was modified to be a nullable boolean (`bool?`), and the default value of `true` was removed.
 
@@ -91,7 +96,7 @@ This enables updating the credentials at runtime by setting them on the `KSqlDbC
         - `InsertProperties`
         - `DropFromItemProperties`
     - If `ShouldPluralizeEntityName` is null, the methods will set it using the value from the `KSqlDBRestApiClientOptions`.
-    
+
 ## 🐛 Bug Fix
 - `KSqlDBContext` removed `!NETSTANDARD` pragma from `OnDisposeAsync`
 
@@ -124,7 +129,7 @@ This enables updating the credentials at runtime by setting them on the `KSqlDbC
 - see also [breakingchanges.md](https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/docs/breaking_changes.md#v600)
 
 ## 🐛 Bug Fix
-- CreateQueryStream doesn't always use configured parameters. The PullQuery functionality was overriding the options configured for the PushQuery. #75 reported by @jbkuczma 
+- CreateQueryStream doesn't always use configured parameters. The PullQuery functionality was overriding the options configured for the PushQuery. #75 reported by @jbkuczma
 
 # 5.1.0
 - added `InsertIntoAsync` Qbservable extension for executing `INSERT INTO <stream-name> SELECT` statements.

--- a/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
+++ b/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
@@ -15,8 +15,8 @@
             Documentation for the library can be found at https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/README.md.
         </Description>
         <PackageTags>ksql ksqlDB LINQ .NET csharp push query</PackageTags>
-        <Version>7.1.4</Version>
-        <AssemblyVersion>7.1.4.0</AssemblyVersion>
+        <Version>7.1.5</Version>
+        <AssemblyVersion>7.1.5.0</AssemblyVersion>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <PackageReleaseNotes>https://github.com/tomasfabian/ksqlDB.RestApi.Client-DotNet/blob/main/ksqlDb.RestApi.Client/ChangeLog.md</PackageReleaseNotes>


### PR DESCRIPTION
This PR introduces enhancements to null handling, struct type detection. The changes include adding support for casting nulls in SQL generation, extending metadata checks for struct types, and updating tests to reflect the new functionality.

### Enhancements to null handling:
* Added a `castNulls` parameter to the `ExtractValue` method in `CreateKSqlValue` to allow casting null values to specific SQL types when generating statements. This includes updates to handle non-array types with proper casting 
* Modified the `GenerateStruct` method to pass the `castNulls` parameter, ensuring nested struct fields handle nulls appropriately 

### Test updates:
* Added a new `POC5` class and updated test cases to include scenarios for handling `POC5` with null and non-null values in SQL generation.
* Updated the `ToInsertStatement_WithNullHandling` test to configure `POC5` as a struct field and validate its SQL representation.