### PR TITLE
Mark Antlr4BuildTasks as PrivateAssets="all" to prevent transitive dependency issues for consumers.

### DIFF
--- a/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
+++ b/ksqlDb.RestApi.Client/ksqlDb.RestApi.Client.csproj
@@ -26,8 +26,7 @@
 
     <ItemGroup>
         <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
-        <PackageReference Include="Antlr4BuildTasks" Version="12.11.0" />
-        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.0.2" />
+        <PackageReference Include="Antlr4BuildTasks" Version="12.11.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />


### PR DESCRIPTION
Antlr4BuildTasks is a build-time code generation tool used by this project to generate C# parser/lexer source files from SqlBase.g4. 

Since its output is compiled directly into the assembly, consumers of the ksqlDB.RestApi.Client NuGet package have no need for this package at build or runtime.

Previously, Antlr4BuildTasks was flowing transitively to consumers as a dependency, unnecessarily polluting their NuGet dependency graph. In the case of our consuming application, it also caused assembly conflicts. This change is intended to fix that.

Also removed the direct reference to `Microsoft.Build.Utilities.Core` since this is not used directly and already shipped with Antlr4BuildTasks package. Its assets should also be private.