### PR TITLE
fix: concurrent first callers race lazy init on service-provider

### DIFF
--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/KSqlDBContextTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/KSqlDBContextTests.cs
@@ -390,4 +390,18 @@ public class KSqlDBContextTests : TestBase
     pushQueryParameters.Should().BeOfType<QueryStreamParameters>();
     pullQueryParameters.Should().BeOfType<PullQueryStreamParameters>();
   }
+
+  [Test]
+  public async Task CreatePullQuery_CalledConcurrentlyOnFreshContext_DoesNotThrow()
+  {
+    //Arrange
+    var context = new KSqlDBContext(TestParameters.KsqlDbUrl);
+
+    //Act
+    var tasks = Enumerable.Range(0, 50).Select(_ => Task.Run(() => context.CreatePullQuery<int>("tableName")));
+
+    //Assert
+    var act = async () => await Task.WhenAll(tasks);
+    await act.Should().NotThrowAsync();
+  }
 }

--- a/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContextDependenciesProvider.cs
+++ b/ksqlDb.RestApi.Client/KSql/Query/Context/KSqlDBContextDependenciesProvider.cs
@@ -34,17 +34,24 @@ public abstract class KSqlDBContextDependenciesProvider : AsyncDisposableObject,
   protected ServiceProvider? ServiceProvider { get; private set; }
 
   private IServiceScopeFactory? serviceScopeFactory;
+  private readonly object serviceScopeFactoryLock = new();
 
   internal IServiceScopeFactory ServiceScopeFactory()
   {
     if (serviceScopeFactory != null)
       return serviceScopeFactory;
 
-    RegisterDependencies(kSqlDbContextOptions);
+    lock (serviceScopeFactoryLock)
+    {
+      if (serviceScopeFactory != null)
+        return serviceScopeFactory;
 
-    ServiceProvider = ServiceCollection.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+      RegisterDependencies(kSqlDbContextOptions);
 
-    serviceScopeFactory = ServiceProvider.GetRequiredService<IServiceScopeFactory>();
+      ServiceProvider = ServiceCollection.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+
+      serviceScopeFactory = ServiceProvider.GetRequiredService<IServiceScopeFactory>();
+    }
 
     return serviceScopeFactory;
   }


### PR DESCRIPTION
Many concurrent first-callers race on the lazy initialized ServiceProvider and register their dependencies multiple times. Later this throws "Sequence contains more than one matching element" during DI resolution.

fix #120