### PR TITLE
fix!: preserve JSON types in query properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ var contextOptions = new KSqlDbContextOptionsBuilder()
   .SetIdentifierEscaping(IdentifierEscaping.Keywords)
   .SetupPushQuery(options =>
   {
-    options.Properties["ksql.query.push.v2.enabled"] = "true";
+    options.Properties["ksql.query.push.v2.enabled"] = true;
   })
   .Options;
 ```

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/Options/KSqlDbContextOptionsBuilderTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/Query/Context/Options/KSqlDbContextOptionsBuilderTests.cs
@@ -276,5 +276,21 @@ public class KSqlDbContextOptionsBuilderTests : TestBase<KSqlDbContextOptionsBui
     //Assert
     options.PullQueryParameters.Properties[KSqlDbConfigs.KsqlQueryPullTableScanEnabled].Should().BeEquivalentTo("true");
   }
+
+  [Test]
+  public void SetupPullQuery_BooleanPropertyWasSet()
+  {
+    //Arrange
+    var setupParameters = ClassUnderTest.UseKSqlDb(TestParameters.KsqlDbUrl);
+
+    //Act
+    var options = setupParameters.SetupPullQuery(opt =>
+    {
+      opt.Properties[KSqlDbConfigs.KsqlQueryPullTableScanEnabled] = true;
+    }).Options;
+
+    //Assert
+    options.PullQueryParameters.Properties[KSqlDbConfigs.KsqlQueryPullTableScanEnabled].Should().Be(true);
+  }
   #endregion
 }

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Parameters/QueryEndpointParametersTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Parameters/QueryEndpointParametersTests.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+using FluentAssertions;
+using ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
+using NUnit.Framework;
+
+namespace ksqlDb.RestApi.Client.Tests.KSql.RestApi.Parameters
+{
+  public class QueryEndpointParametersTests
+  {
+    private const string BooleanPropertyName = "ksql.query.pull.table.scan.enabled";
+
+    [Test]
+    public void BooleanProperty_IsSerializedAsJsonBoolean()
+    {
+      //Arrange
+      var parameters = new PullQueryParameters
+      {
+        Sql = "Select",
+        Properties = { [BooleanPropertyName] = true }
+      };
+
+      //Act
+      var json = JsonSerializer.Serialize(parameters);
+
+      //Assert
+      using var document = JsonDocument.Parse(json);
+      document.RootElement.GetProperty("streamsProperties").GetProperty(BooleanPropertyName)
+        .ValueKind.Should().Be(JsonValueKind.True);
+    }
+
+    [Test]
+    public void Clone_PreservesBooleanProperty()
+    {
+      //Arrange
+      var source = new PullQueryParameters
+      {
+        Sql = "Select",
+        Properties = { [BooleanPropertyName] = true }
+      };
+
+      //Act
+      var clone = source.Clone();
+
+      //Assert
+      clone.Properties[BooleanPropertyName].Should().Be(true);
+    }
+  }
+}

--- a/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Parameters/QueryStreamEndpointParametersTests.cs
+++ b/Tests/ksqlDB.RestApi.Client.Tests/KSql/RestApi/Parameters/QueryStreamEndpointParametersTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FluentAssertions;
 using ksqlDB.RestApi.Client.KSql.Query.Options;
 using ksqlDB.RestApi.Client.KSql.RestApi.Parameters;
@@ -7,6 +8,8 @@ namespace ksqlDb.RestApi.Client.Tests.KSql.RestApi.Parameters
 {
   public class QueryStreamEndpointParametersTests
   {
+    private const string BooleanPropertyName = "ksql.query.pull.table.scan.enabled";
+
     [Test]
     public void Clone()
     {
@@ -55,6 +58,42 @@ namespace ksqlDb.RestApi.Client.Tests.KSql.RestApi.Parameters
 
       //Assert
       clone.Properties[QueryParameters.AutoOffsetResetPropertyName].Should().Be(nameof(AutoOffsetReset.Latest).ToLower());
+    }
+
+    [Test]
+    public void BooleanProperty_IsSerializedAsJsonBoolean()
+    {
+      //Arrange
+      var parameters = new PullQueryStreamParameters
+      {
+        Sql = "Select",
+        Properties = { [BooleanPropertyName] = true }
+      };
+
+      //Act
+      var json = JsonSerializer.Serialize(parameters);
+
+      //Assert
+      using var document = JsonDocument.Parse(json);
+      document.RootElement.GetProperty("properties").GetProperty(BooleanPropertyName)
+        .ValueKind.Should().Be(JsonValueKind.True);
+    }
+
+    [Test]
+    public void Clone_PreservesBooleanProperty()
+    {
+      //Arrange
+      var source = new PullQueryStreamParameters
+      {
+        Sql = "Select",
+        Properties = { [BooleanPropertyName] = true }
+      };
+
+      //Act
+      var clone = source.Clone();
+
+      //Assert
+      clone.Properties[BooleanPropertyName].Should().Be(true);
     }
   }
 }

--- a/docs/breaking_changes.md
+++ b/docs/breaking_changes.md
@@ -1,5 +1,8 @@
 # Breaking changes
 
+# Upcoming
+- `IQueryOptions.Properties` changed from `Dictionary<string, string>` to `Dictionary<string, object>`. Direct reads now require a cast or the existing string indexer; string assignments still work.
+
 # v6.0.0
 - `QueryType` enum was renamed to `EndpointType`
 - removed `CreateQuery` from `IKSqlDBContext` interface, it was merged with `CreateQueryStream`.  Subsequently `CreateQueryStream` was renamed to `CreatePushQuery` to align with the nomenclature of `CreatePullQuery`.

--- a/docs/ksqldbcontext.md
+++ b/docs/ksqldbcontext.md
@@ -421,7 +421,7 @@ public static KSqlDBContextOptions CreatePushQueryOptions(string ksqlDbUrl)
 contextOptions
   .SetupPullQuery(options =>
   {
-    options[KSqlDbConfigs.KsqlQueryPullTableScanEnabled] = "true";
+    options.Properties[KSqlDbConfigs.KsqlQueryPullTableScanEnabled] = true;
   })
 ```
 

--- a/docs/pull_queries.md
+++ b/docs/pull_queries.md
@@ -180,7 +180,7 @@ public static async Task<List<OrderData>> GetOrdersAsync()
 {
   var ksqlDbUrl = @"http://localhost:8088";
   var options = new KSqlDBContextOptions(ksqlDbUrl) { ShouldPluralizeFromItemName = false };
-  options.QueryParameters.Properties["ksql.query.pull.table.scan.enabled"] = "true";
+  options.PullQueryParameters.Properties["ksql.query.pull.table.scan.enabled"] = true;
 
   await using var context = new KSqlDBContext(options);
   var tableName = "queryable_order";

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/IQueryOptions.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/IQueryOptions.cs
@@ -2,5 +2,8 @@
 
 public interface IQueryOptions
 {
-  Dictionary<string, string> Properties { get; }
+  /// <summary>
+  /// Property overrides serialized using each value's JSON type.
+  /// </summary>
+  Dictionary<string, object> Properties { get; }
 }

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryEndpointParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryEndpointParameters.cs
@@ -20,7 +20,7 @@ public class QueryEndpointParameters<T> : IKSqlDbParameters
   /// Property overrides to run the statements with.
   /// </summary>
   [JsonPropertyName("streamsProperties")]
-  public Dictionary<string, string> Properties { get; } = new();
+  public Dictionary<string, object> Properties { get; } = new();
 
   /// <summary>
   /// Indexer to access properties by key.
@@ -29,7 +29,7 @@ public class QueryEndpointParameters<T> : IKSqlDbParameters
   /// <returns>The value of the property.</returns>
   public string this[string key]
   {
-    get => Properties[key];
+    get => Properties[key].ToString()!;
     set => Properties[key] = value;
   }
 

--- a/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryStreamEndpointParameters.cs
+++ b/ksqlDb.RestApi.Client/KSql/RestApi/Parameters/QueryStreamEndpointParameters.cs
@@ -19,7 +19,7 @@ public class QueryStreamEndpointParameters<T> : IKSqlDbParameters
   /// Property overrides to run the statements with.
   /// </summary>
   [JsonPropertyName("properties")]
-  public Dictionary<string, string> Properties { get; } = new();
+  public Dictionary<string, object> Properties { get; } = new();
 
   /// <summary>
   /// Indexer to access properties by key.
@@ -28,7 +28,7 @@ public class QueryStreamEndpointParameters<T> : IKSqlDbParameters
   /// <returns>The value of the property.</returns>
   public string this[string key]
   {
-    get => Properties[key];
+    get => Properties[key].ToString()!;
     set => Properties[key] = value;
   }
 


### PR DESCRIPTION
Query properties currently only accept strings, so Boolean ksqlDB settings
are serialized as JSON strings. The `/query-stream` endpoint does not coerce
them and fails with `class java.lang.String cannot be cast to class
java.lang.Boolean`.

Change `IQueryOptions.Properties` to `Dictionary<string, object>` while
keeping the string indexer for existing string-based callers.

BREAKING CHANGE: Consumers reading values directly from `Properties` must
cast them or use the string indexer.

This addresses the same typed-property limitation as #100, but keeps the
existing string indexer and enum handling, limiting the change to the property
value type, serialization tests, and documentation.

fix #122
